### PR TITLE
Additional setters in FactoryBeans to fix IDE (Eclipse/Spring) errors

### DIFF
--- a/kie-spring/src/main/java/org/kie/spring/factorybeans/KBaseFactoryBean.java
+++ b/kie-spring/src/main/java/org/kie/spring/factorybeans/KBaseFactoryBean.java
@@ -59,6 +59,15 @@ public class KBaseFactoryBean
     public void setKBaseName(String name) {
         this.kBaseName = name;
     }
+    
+    /**
+     * Additional Setter to satisfy Spring Eclipse support (avoiding "No setter found" errors).
+     * @param name
+     *            The name.
+     */
+    public void setkBaseName(String name) {
+        this.kBaseName = name;
+    }    
 
     public String getId() {
         return id;

--- a/kie-spring/src/main/java/org/kie/spring/factorybeans/KSessionFactoryBean.java
+++ b/kie-spring/src/main/java/org/kie/spring/factorybeans/KSessionFactoryBean.java
@@ -97,6 +97,15 @@ public class KSessionFactoryBean
     public void setKBaseName(String kBaseName) {
         this.kBaseName = kBaseName;
     }
+    
+    /**
+     * Additional Setter to satisfy Spring Eclipse support (avoiding "No setter found" errors).
+     * @param kBaseName
+     *            The kBaseName.
+     */
+    public void setkBaseName(String kBaseName) {
+        this.kBaseName = kBaseName;
+    }    
 
     public List<Command<?>> getBatch() {
         return batch;
@@ -129,6 +138,15 @@ public class KSessionFactoryBean
     public void setKBase(KieBase kBase) {
         this.kBase = kBase;
     }
+    
+    /**
+     * Additional Setter to satisfy Spring Eclipse support (avoiding "No setter found" errors).
+     * @param kBase
+     *            The kBase.
+     */
+    public void setkBase(KieBase kBase) {
+        this.kBase = kBase;
+    }    
 
     public String getType() {
         return type;


### PR DESCRIPTION
If you use Eclipse with m2e and Spring support, and are adding the kie-spring dependency to your project, you are experiencing errors in the Spring Bean definitions of the knowledge bases, as you can read here:
https://lists.jboss.org/pipermail/rules-users/2014-April/035762.html
http://drools-moved.46999.n3.nabble.com/Kie-namespace-td4030236.html

If you add additional setters with a slighty modified syntax, the IDE errors are gone.
