### PR TITLE
JBPM-4537 - Error when getting a primitive type process instance variable when using the REST API

### DIFF
--- a/kie-remote/kie-services-remote/src/main/java/org/kie/remote/services/rest/RuntimeResource.java
+++ b/kie-remote/kie-services-remote/src/main/java/org/kie/remote/services/rest/RuntimeResource.java
@@ -156,7 +156,12 @@ public class RuntimeResource extends ResourceBase {
     public Response process_instance_procInstId_variable_varName(@PathParam("procInstId") Long procInstId,
             @PathParam("varName") String varName) {
         Object procVar =  processRequestBean.getVariableObjectInstanceFromRuntime(deploymentId, procInstId, varName);
-     
+        
+        // If this is a primitive type, there's no need to serialize
+        if(procVar instanceof String || procVar instanceof Boolean || procVar instanceof Float || procVar instanceof Integer) {
+        	return createCorrectVariant(procVar, headers);
+        }
+        
         // serialize
         QName rootElementName = getRootElementName(procVar); 
         @SuppressWarnings("rawtypes") // unknown at compile time, dynamic from deployment


### PR DESCRIPTION
JBPM-4537 - Error when getting a primitive type process instance variable when using the REST API

The fix will simply check if use is requesting the value of a primitive type and return build the response without trying to parse it.

Another more complex solution would be create a wrapper object for primitive types.