### PR TITLE
kie-server: 'admin's should be able to use the remote api

### DIFF
--- a/kie-server/kie-server-distribution-wars/src/main/servlet-container/WEB-INF/web.xml
+++ b/kie-server/kie-server-distribution-wars/src/main/servlet-container/WEB-INF/web.xml
@@ -30,6 +30,7 @@
       <url-pattern>/*</url-pattern>
     </web-resource-collection>
     <auth-constraint>
+      <role-name>admin</role-name>
       <role-name>kie-server</role-name>
     </auth-constraint>
   </security-constraint>
@@ -37,6 +38,9 @@
     <auth-method>BASIC</auth-method>
     <realm-name>KIE Server</realm-name>
   </login-config>
+  <security-role>
+    <role-name>admin</role-name>
+  </security-role>
   <security-role>
     <role-name>kie-server</role-name>
   </security-role>

--- a/kie-server/kie-server-distribution-wars/src/main/shared-resources/WEB-INF/web.xml
+++ b/kie-server/kie-server-distribution-wars/src/main/shared-resources/WEB-INF/web.xml
@@ -19,6 +19,7 @@
       <url-pattern>/*</url-pattern>
     </web-resource-collection>
     <auth-constraint>
+      <role-name>admin</role-name>
       <role-name>kie-server</role-name>
     </auth-constraint>
   </security-constraint>
@@ -27,6 +28,10 @@
     <realm-name>KIE Server</realm-name>
   </login-config>
   <security-role>
+      <role-name>admin</role-name>
+    </security-role>
+  <security-role>
+    <role-name>admin</role-name>
     <role-name>kie-server</role-name>
   </security-role>
 


### PR DESCRIPTION
@etirelli please take a look at this. I think the KIE Server remote API should be accessible also for users with role 'admin', to be consistent with KIE Workbench. 