### PR TITLE
BZ1193122: Various fixes to allow running execution server on Weblogic

### DIFF
--- a/kie-server/kie-server-distribution-wars/src/main/shared-resources/WEB-INF/web.xml
+++ b/kie-server/kie-server-distribution-wars/src/main/shared-resources/WEB-INF/web.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <web-app xmlns="http://java.sun.com/xml/ns/javaee" 
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         version="2.5"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+         version="3.0"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
 
   <servlet>
     <servlet-name>org.kie.server.services.KieServerApplication</servlet-name>

--- a/kie-server/kie-server-distribution-wars/src/main/shared-resources/WEB-INF/weblogic.xml
+++ b/kie-server/kie-server-distribution-wars/src/main/shared-resources/WEB-INF/weblogic.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+
+<weblogic-web-app xmlns="http://www.bea.com/ns/weblogic/90" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <security-role-assignment>
+    <role-name>kie-server</role-name>
+    <principal-name>kie-server</principal-name>
+  </security-role-assignment>
+</weblogic-web-app>

--- a/kie-server/kie-server-jms/src/main/java/org/kie/server/jms/KieServerMDB.java
+++ b/kie-server/kie-server-jms/src/main/java/org/kie/server/jms/KieServerMDB.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import static org.kie.server.api.jms.JMSConstants.*;
 
 @MessageDriven(name = "KieServerMDB", activationConfig = {
+        @ActivationConfigProperty(propertyName = "destinationJndiName", propertyValue = "queue/KIE.SERVER.REQUEST"),
         @ActivationConfigProperty(propertyName = "destination", propertyValue = "queue/KIE.SERVER.REQUEST"),
         @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue"),
         @ActivationConfigProperty(propertyName = "acknowledgeMode", propertyValue = "Auto-acknowledge")})

--- a/kie-server/kie-server-services/src/main/java/org/kie/server/services/KieServerApplication.java
+++ b/kie-server/kie-server-services/src/main/java/org/kie/server/services/KieServerApplication.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
+import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
 import org.codehaus.jackson.jaxrs.JacksonJaxbJsonProvider;
@@ -14,6 +15,7 @@ import org.codehaus.jackson.map.introspect.JacksonAnnotationIntrospector;
 import org.codehaus.jackson.xc.JaxbAnnotationIntrospector;
 import org.kie.server.services.rest.KieServerRestImpl;
 
+@ApplicationPath("/")
 public class KieServerApplication extends Application {
 
     private final Set<Object> instances = new CopyOnWriteArraySet<Object>() {

--- a/kie-server/kie-server-services/src/main/java/org/kie/server/services/api/KieServer.java
+++ b/kie-server/kie-server-services/src/main/java/org/kie/server/services/api/KieServer.java
@@ -18,7 +18,6 @@ import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.KieScannerResource;
 import org.kie.server.api.model.ReleaseId;
 
-@Path("/server")
 public interface KieServer {
     
     @GET


### PR DESCRIPTION
Small changes which allows deployment of execution server on Weblogic.

- raised version of web.xml (caused problem to weblogic) so content become valid
- added weblogic.xml to map security role from web.xml to role group defined in Weblogic
- added destinationJndiName property for JMS - Weblogic use this one for finding out queue JNDI name
- added @ApplicationPath with default value, is overwritten in web.xml - was needed by Weblogic
- removed @Path annotation from REST interface, this annotation in interface caused problems to Weblogic, is duplicated in implementation class anyway

