### PR TITLE
Ordered Builders: 1195772 - Remote Java API builders provide too much options

### DIFF
--- a/kie-remote/kie-remote-client/src/main/java/org/kie/remote/client/api/RemoteRuntimeEngineFactory.java
+++ b/kie-remote/kie-remote-client/src/main/java/org/kie/remote/client/api/RemoteRuntimeEngineFactory.java
@@ -9,6 +9,8 @@ import javax.naming.NamingException;
 
 import org.kie.api.runtime.manager.RuntimeEngine;
 import org.kie.remote.client.api.exception.RemoteCommunicationException;
+import org.kie.remote.client.api.order.OrderedRemoteJmsRuntimeEngineBuilder;
+import org.kie.remote.client.api.order.OrderedRemoteRestRuntimeEngineBuilder;
 import org.kie.remote.services.ws.command.generated.CommandWebService;
 
 /**
@@ -30,7 +32,7 @@ public abstract class RemoteRuntimeEngineFactory {
     public static RemoteJmsRuntimeEngineBuilder newJmsBuilder() { 
        return org.kie.services.client.api.RemoteRuntimeEngineFactory.newJmsBuilder();
     }
-    
+   
     /**
      * Create a new {@link RemoteRestRuntimeEngineBuilder} instance 
      * to configure and buid a remote API client {@link RuntimeEngine} instance.
@@ -46,6 +48,33 @@ public abstract class RemoteRuntimeEngineFactory {
      * @return A {@link RemoteWebserviceClientBuilder} instance
      */
     public static RemoteWebserviceClientBuilder<RemoteWebserviceClientBuilder, CommandWebService> newCommandWebServiceClientBuilder() { 
+       return org.kie.services.client.api.RemoteRuntimeEngineFactory.newCommandWebServiceClientBuilder();
+    }
+   
+    /**
+     * Create a new {@link RemoteJmsRuntimeEngineBuilder} instance 
+     * to configure and buid a remote API client {@link RuntimeEngine} instance.
+     * @return A {@link RemoteJmsRuntimeEngineBuilder} instance
+     */
+    public static OrderedRemoteJmsRuntimeEngineBuilder newOrderedJmsBuilder() { 
+       return org.kie.services.client.api.RemoteRuntimeEngineFactory.newOrderedJmsBuilder();
+    }
+    
+    /**
+     * Create a new {@link RemoteRestRuntimeEngineBuilder} instance 
+     * to configure and buid a remote API client {@link RuntimeEngine} instance.
+     * @return A {@link RemoteRestRuntimeEngineBuilder} instance
+     */
+    public static OrderedRemoteRestRuntimeEngineBuilder newOrderedRestBuilder() { 
+       return org.kie.services.client.api.RemoteRuntimeEngineFactory.newOrderedRestBuilder();
+    }
+    
+    /**
+     * Create a new {@link RemoteWebserviceClientBuilder} instance 
+     * to configure and buid a remote client for the {@link CommandWebService}.
+     * @return A {@link RemoteWebserviceClientBuilder} instance
+     */
+    public static RemoteWebserviceClientBuilder<RemoteWebserviceClientBuilder, CommandWebService> newOrderedCommandWebServiceClientBuilder() { 
        return org.kie.services.client.api.RemoteRuntimeEngineFactory.newCommandWebServiceClientBuilder();
     }
     

--- a/kie-remote/kie-remote-client/src/main/java/org/kie/remote/client/api/order/OrderedRemoteJmsRuntimeEngineBuilder.java
+++ b/kie-remote/kie-remote-client/src/main/java/org/kie/remote/client/api/order/OrderedRemoteJmsRuntimeEngineBuilder.java
@@ -1,0 +1,258 @@
+package org.kie.remote.client.api.order;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.Queue;
+import javax.naming.InitialContext;
+
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.manager.RuntimeEngine;
+import org.kie.api.task.TaskService;
+import org.kie.internal.runtime.conf.RuntimeStrategy;
+import org.kie.remote.client.api.RemoteJmsRuntimeEngineBuilder;
+import org.kie.remote.client.api.order.OrderedRemoteRestRuntimeEngineBuilder.RemoteRestRuntimeEngineBuilder1;
+
+/**
+ * username -> password -> hostname -> connector port
+ *   -> useSsl
+ *   -> disableTaskSecurity
+ *   -> connection factory -> session queue -> task queue -> response queue 
+ *   -> initial context 
+ */
+public interface OrderedRemoteJmsRuntimeEngineBuilder {
+
+    /**
+     * Adds the user name used. If no other user name is specified, the user id
+     * specified is used for all purposes.
+     * 
+     * @param userName The user name
+     * @return The builder instance
+     */
+    RemoteJmsRuntimeEngineBuilder1 addUserName(String userName);
+
+    public static interface RemoteJmsRuntimeEngineBuilder1 {
+
+        /**
+         * Adds the password used. If no other password is specified, the password 
+         * specified is used for all purposes.
+         * 
+         * @param userName The password
+         * @return The builder instance
+         */
+        RemoteJmsRuntimeEngineBuilder2 addPassword(String password);
+    } 
+    
+    public static interface RemoteJmsRuntimeEngineBuilder2 {
+
+        /**
+         * Add the host name of the server on which Console or BPMS is running. 
+         * @param string The host name (or ip-address)
+         * @return The current instance of this builder
+         */
+        RemoteJmsRuntimeEngineBuilder3 addHostName(String string);
+    }
+
+    public static interface RemoteJmsRuntimeEngineBuilder3 {
+
+        /**
+         * Add the JMS connector port being used on the server on which Console or BPMS is running.
+         * @param port The port
+         * @return The current instance of this builder
+         */
+         RemoteJmsRuntimeEngineBuilder4 addJmsConnectorPort(int port);
+    }
+    
+    public static interface RemoteJmsRuntimeEngineBuilder4 {
+       
+        RemoteJmsRuntimeEngineBuilderSsl1 useSsl();
+        
+        RemoteJmsRuntimeEngineBuilder5 disableTaskSecurity();
+    }
+   
+    public static interface RemoteJmsRuntimeEngineBuilder5 {
+        
+        /**
+         * Add a {@link ConnectionFactory} instance that can be used to create (JMS) {@link Connection}s with the remote Console or 
+         * BPMS instance. 
+         * 
+         * @param connectionFactory a {@link ConnectionFactory} instance
+         * @return The current instance of this builder
+         */
+        RemoteJmsRuntimeEngineBuilderJms1 addConnectionFactory(ConnectionFactory connectionFactory);
+       
+        /**
+         * Add a remote {@link InitialContext} instance to the configuration. This
+         * {@link InitialContext} instance is then used to retrieve the
+         * JMS {@link Queue} instances 
+         * so that the 
+         * @param remoteInitialContext
+         * @return
+         */
+        RemoteJmsRuntimeEngineBuilderOpt addRemoteInitialContext(InitialContext remoteInitialContext); 
+
+        /**
+         * Use the given hostname to look up and retrieve a Remote {@link InitialContext} instance. The
+         * information in the remote {@link InitialContext} instance will be used to retrieve
+         * the {@link Queue} and {@link ConnectionFactory} instances. 
+         * @param hostanem The hostname (or ip-address) of the Jboss Server instance on which Console or BPMS is running.
+         * @return The current instance of this builder
+         */
+        RemoteJmsRuntimeEngineBuilderOpt addJbossServerHostName(String hostname);
+    }
+
+    public static interface RemoteJmsRuntimeEngineBuilderJms1 {
+
+        /**
+         * Add a {@link Queue} instance that can be used to communicate with the remote Console or BPMS instance. The {@link Queue}
+         * instance given should allow the client to send {@link KieSession} related command requests. 
+         * 
+         * @param ksessionQueue a {@link Queue} instance
+         * @return The current instance of this builder
+         */
+        RemoteJmsRuntimeEngineBuilder2 addKieSessionQueue(Queue ksessionQueue);
+    }
+
+    public static interface RemoteJmsRuntimeEngineBuilderJms2 {
+        /**
+         * Add a {@link Queue} instance that can be used to communicate with the remote Console or BPMS instance. The {@link Queue}
+         * instance given should allow the client to send {@link TaskService} related command requests. 
+         * 
+         * @param ksessionQueue a {@link Queue} instance
+         * @return The current instance of this builder
+         */
+        RemoteJmsRuntimeEngineBuilderJms3 addTaskServiceQueue(Queue taskServiceQueue);
+    }
+
+    public static interface RemoteJmsRuntimeEngineBuilderJms3 {
+        /**
+         * Add a {@link Queue} instance that can be used to communicate with the remote Console or BPMS instance. The {@link Queue}
+         * instance given should allow the client to send {@link TaskService} related command requests. 
+         * 
+         * @param ksessionQueue a {@link Queue} instance
+         * @return The current instance of this builder
+         */
+        RemoteJmsRuntimeEngineBuilderOpt addResponseQueue(Queue responseQueue);
+    } 
+
+    public static interface RemoteJmsRuntimeEngineBuilderSsl1  {
+       
+        /**
+         * Add the keystore password: the keystore is a storage facility for cryptographic keys and certificates. These keys
+         * and certificates are used when communicating over a SSL-encrypted connection. The client-side keystore stores the
+         * credentials of the client needed to identify the client to the server. 
+         * @param string The password associated with the keystore
+         * @return The current instance of this builder
+         */
+        RemoteJmsRuntimeEngineBuilderSsl2 addKeystorePassword(String string);
+    }
+    
+    public static interface RemoteJmsRuntimeEngineBuilderSsl2 {
+        
+        /**
+         * Add the keystore file location: the keystore is a storage facility for cryptographic keys and certificates. These keys
+         * and certificates are used when communicating over a SSL-encrypted connection. The client-side keystore stores the
+         * credentials of the client needed to identify the client to the server. 
+         * @param string The path of the keystore file, relative or absolute
+         * @return The current instance of this builder
+         */
+        RemoteJmsRuntimeEngineBuilderSsl3 addKeystoreLocation(String string);
+    }
+    
+    public static interface RemoteJmsRuntimeEngineBuilderSsl3 {
+        
+        /**
+         * Add the truststore password: the trustore is a storage facility for cryptographic keys and certificates. These keys
+         * and certificates are used when communicating over a SSL-encrypted connection. The client-side truststore stores the
+         * credentials of the server needed to verify the server's identity.
+         * @param string The password associated with the truststore
+         * @return The current instance of this builder
+         */
+        RemoteJmsRuntimeEngineBuilderSsl4 addTruststorePassword(String string);
+        
+        /**
+         * Use this option if the keystore and truststore are both located in the same file. In this case, only add the keystore
+         * location (and password) and then use this option to configure the client to use the file being used for the keystore 
+         * also as the truststore. 
+         * @return The current instance of this builder
+         */
+        RemoteJmsRuntimeEngineBuilderOpt useKeystoreAsTruststore();      
+    }
+   
+    public static interface RemoteJmsRuntimeEngineBuilderSsl4 {
+        
+        /**
+         * Add the truststore file location: the trustore is a storage facility for cryptographic keys and certificates. These keys
+         * and certificates are used when communicating over a SSL-encrypted connection. The client-side truststore stores the
+         * credentials of the server needed to verify the server's identity.
+         * @param string The path of the truststore file, relative or absolute
+         * @return The current instance of this builder
+         */
+        RemoteJmsRuntimeEngineBuilderOpt addTruststoreLocation(String string);
+    }
+    
+    public static interface RemoteJmsRuntimeEngineBuilderOpt {
+
+        RemoteJmsRuntimeEngineBuilderOpt setConnectionFactoryJNDIName(String connFactoryName);
+        
+        RemoteJmsRuntimeEngineBuilderOpt setSessionQueueJNDIName(String sessionQueueName);
+        
+        RemoteJmsRuntimeEngineBuilderOpt setTaskQueueJNDIName(String taskQueueName);
+        
+        RemoteJmsRuntimeEngineBuilderOpt setResponseQueueJNDIName(String responseQueueName);
+        
+        /**
+         * The quality-of-service threshold when sending JMS msgs.
+         * @param timeoutInSeconds The timeout in seconds
+         * @return The builder instance
+         */
+        RemoteJmsRuntimeEngineBuilderOpt addTimeout(int timeoutInSeconds);
+
+        /**
+         * Adds the deployment id to the configuration.
+         * @param deploymentId The deployment id
+         * @return The builder instance
+         */
+        RemoteJmsRuntimeEngineBuilderOpt addDeploymentId(String deploymentId);
+
+        /**
+         * Adds the process instance id, which may be necessary when interacting
+         * with deployments that employ the {@link RuntimeStrategy#PER_PROCESS_INSTANCE}.
+         * @param processInstanceId The process instance id
+         * @return The builder instance
+         */
+        RemoteJmsRuntimeEngineBuilderOpt addProcessInstanceId(long processInstanceId);
+
+        /**
+         * When sending non-primitive class instances, it's necessary to add the class instances
+         * beforehand to the configuration so that the class instances can be serialized correctly
+         * in requests
+         * @param classes One or more class instances
+         * @return The builder instance
+         */
+        RemoteJmsRuntimeEngineBuilderOpt addExtraJaxbClasses(Class... classes); 
+        
+        /**
+         * Creates a {@link RuntimeEngine} instance, using the 
+         * configuration built up to this point. 
+         * </p>
+         * 
+         * @return The {@link RuntimeEngine} instance
+         * @throws @{link InsufficientInfoToBuildException} when insufficient information 
+         * is provided to build the {@link RuntimeEngine}
+         */
+        RuntimeEngine build();
+    }
+
+    public static interface OrderedRemoteJmsRuntimeEngineBuilderAll 
+        extends OrderedRemoteJmsRuntimeEngineBuilder,
+        RemoteJmsRuntimeEngineBuilder1, RemoteJmsRuntimeEngineBuilder2, 
+        RemoteJmsRuntimeEngineBuilder3, RemoteJmsRuntimeEngineBuilder4, 
+        RemoteJmsRuntimeEngineBuilder5, 
+        RemoteJmsRuntimeEngineBuilderJms1, RemoteJmsRuntimeEngineBuilderJms2, 
+        RemoteJmsRuntimeEngineBuilderJms3, 
+        RemoteJmsRuntimeEngineBuilderSsl1, RemoteJmsRuntimeEngineBuilderSsl2, 
+        RemoteJmsRuntimeEngineBuilderSsl3, RemoteJmsRuntimeEngineBuilderSsl4,
+        RemoteJmsRuntimeEngineBuilderOpt {
+        
+    }
+}

--- a/kie-remote/kie-remote-client/src/main/java/org/kie/remote/client/api/order/OrderedRemoteRestRuntimeEngineBuilder.java
+++ b/kie-remote/kie-remote-client/src/main/java/org/kie/remote/client/api/order/OrderedRemoteRestRuntimeEngineBuilder.java
@@ -1,0 +1,123 @@
+package org.kie.remote.client.api.order;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.kie.api.runtime.manager.RuntimeEngine;
+import org.kie.internal.runtime.conf.RuntimeStrategy;
+
+public interface OrderedRemoteRestRuntimeEngineBuilder {
+
+    /**
+     * Adds the user name used. If no other user name is specified, the user id
+     * specified is used for all purposes.
+     * 
+     * @param userName The user name
+     * @return The builder instance
+     */
+    RemoteRestRuntimeEngineBuilder1 addUserName(String userName);
+
+    public static interface RemoteRestRuntimeEngineBuilder1 {
+
+        /**
+         * Adds the password used. If no other password is specified, the password 
+         * specified is used for all purposes.
+         * 
+         * @param userName The password
+         * @return The builder instance
+         */
+        RemoteRestRuntimeEngineBuilder2 addPassword(String password);
+    } 
+
+    public static interface RemoteRestRuntimeEngineBuilder2 {
+
+        /**
+         * The URL used here should be in the following form:
+         * <code>http://HOST:PORT/INSTANCE/</code>
+         * The different parts of the URL are:<ul>
+         *   <li><code>HOST</code>: the hostname or ip address</li>
+         *   <li><code>PORT</code>: the port number that the application is available on (often 8080)</li>
+         *   <li><code>INSTANCE</code>: the name of the application, often one of the following:<ul>
+         *     <li>business-central</li>
+         *     <li>kie-wb</li>
+         *     <li>jbpm-console</li></ul></li>
+         * </ul>
+         * 
+         * @param instanceUrl The URL of the application
+         * @return The builder instance
+         */
+        RemoteRestRuntimeEngineBuilderOpt addUrl(URL instanceUrl);
+
+        /**
+         * The URL used here should be in the following form:
+         * <code>http://HOST:PORT/INSTANCE/</code>
+         * The different parts of the URL are:<ul>
+         *   <li><code>HOST</code>: the hostname or ip address</li>
+         *   <li><code>PORT</code>: the port number that the application is available on (often 8080)</li>
+         *   <li><code>INSTANCE</code>: the name of the application, often one of the following:<ul>
+         *     <li>business-central</li>
+         *     <li>kie-wb</li>
+         *     <li>jbpm-console</li></ul></li>
+         * </ul>
+         * 
+         * @param instanceUrl The URL of the application
+         * @return The builder instance
+         * @throws MalformedURLException if the string is not a proper URL
+         */
+        RemoteRestRuntimeEngineBuilderOpt addUrl(String instanceUrlString) throws MalformedURLException;
+    }
+
+    public static interface RemoteRestRuntimeEngineBuilderOpt {
+
+        /**
+         * The timeout (or otherwise the quality-of-service threshold when sending JMS msgs).
+         * For HTTP related services (REST or webservices), this timeout is used for both 
+         * the time it takes to connect as well as the time it takes to receive the request.
+         * @param timeoutInSeconds The timeout in seconds
+         * @return The builder instance
+         */
+        RemoteRestRuntimeEngineBuilderOpt addTimeout(int timeoutInSeconds);
+
+        /**
+         * Adds the deployment id to the configuration.
+         * @param deploymentId The deployment id
+         * @return The builder instance
+         */
+        RemoteRestRuntimeEngineBuilderOpt addDeploymentId(String deploymentId);
+
+        /**
+         * Adds the process instance id, which may be necessary when interacting
+         * with deployments that employ the {@link RuntimeStrategy#PER_PROCESS_INSTANCE}.
+         * @param processInstanceId The process instance id
+         * @return The builder instance
+         */
+        RemoteRestRuntimeEngineBuilderOpt addProcessInstanceId(long processInstanceId);
+
+        /**
+         * When sending non-primitive class instances, it's necessary to add the class instances
+         * beforehand to the configuration so that the class instances can be serialized correctly
+         * in requests
+         * @param classes One or more class instances
+         * @return The builder instance
+         */
+        RemoteRestRuntimeEngineBuilderOpt addExtraJaxbClasses(Class... classes); 
+
+        /**
+         * Creates a {@link RuntimeEngine} instance, using the 
+         * configuration built up to this point. 
+         * </p>
+         * 
+         * @return The {@link RuntimeEngine} instance
+         * @throws @{link InsufficientInfoToBuildException} when insufficient information 
+         * is provided to build the {@link RuntimeEngine}
+         */
+        RuntimeEngine build();
+    }
+
+    public static interface OrderedRemoteRestRuntimeEngineBuilderAll 
+        extends OrderedRemoteRestRuntimeEngineBuilder,
+        RemoteRestRuntimeEngineBuilder1, RemoteRestRuntimeEngineBuilder2,
+        RemoteRestRuntimeEngineBuilderOpt {
+        
+    }
+}

--- a/kie-remote/kie-remote-client/src/main/java/org/kie/remote/client/builder/RemoteRuntimeEngineBuilder.java
+++ b/kie-remote/kie-remote-client/src/main/java/org/kie/remote/client/builder/RemoteRuntimeEngineBuilder.java
@@ -1,0 +1,5 @@
+package org.kie.remote.client.builder;
+
+public class RemoteRuntimeEngineBuilder {
+
+}

--- a/kie-remote/kie-remote-client/src/main/java/org/kie/services/client/api/RemoteJmsRuntimeEngineBuilderImpl.java
+++ b/kie-remote/kie-remote-client/src/main/java/org/kie/services/client/api/RemoteJmsRuntimeEngineBuilderImpl.java
@@ -11,6 +11,7 @@ import javax.naming.InitialContext;
 
 import org.kie.remote.client.api.RemoteJmsRuntimeEngineFactory;
 import org.kie.remote.client.api.exception.InsufficientInfoToBuildException;
+import org.kie.remote.client.api.order.OrderedRemoteJmsRuntimeEngineBuilder;
 import org.kie.services.client.api.command.RemoteConfiguration;
 import org.kie.services.client.api.command.RemoteConfiguration.Type;
 import org.kie.services.client.api.command.RemoteRuntimeEngine;
@@ -21,7 +22,7 @@ import org.kie.services.client.api.command.RemoteRuntimeEngine;
  * It takes care of implementing the methods specified as well as managing the 
  * state of the internal {@link RemoteConfiguration} instance.
  */
-class RemoteJmsRuntimeEngineBuilderImpl implements org.kie.remote.client.api.RemoteJmsRuntimeEngineBuilder {
+class RemoteJmsRuntimeEngineBuilderImpl implements org.kie.remote.client.api.RemoteJmsRuntimeEngineBuilder, OrderedRemoteJmsRuntimeEngineBuilder.OrderedRemoteJmsRuntimeEngineBuilderAll {
 
     private RemoteConfiguration config;
     
@@ -167,6 +168,13 @@ class RemoteJmsRuntimeEngineBuilderImpl implements org.kie.remote.client.api.Rem
     }
 
     @Override
+    public RemoteJmsRuntimeEngineBuilderImpl useSsl() {
+        this.createOwnFactory = true;
+        this.config.setUseSsl(true);
+        return this;
+    }
+
+    @Override
     public RemoteJmsRuntimeEngineBuilderImpl addKeystorePassword(String keystorePassword) {
         this.keystorePassword = keystorePassword;
         this.useSsl(true);
@@ -202,10 +210,35 @@ class RemoteJmsRuntimeEngineBuilderImpl implements org.kie.remote.client.api.Rem
   
     @Override
     public RemoteJmsRuntimeEngineBuilderImpl disableTaskSecurity() {
+        this.createOwnFactory = false;
         config.setDisableTaskSecurity(true);
         return this;
     }
 
+    @Override
+    public RemoteJmsRuntimeEngineBuilderImpl setConnectionFactoryJNDIName( String connectionFactoryJNDIName ) {
+        config.setConnectionFactoryJndiName(connectionFactoryJNDIName); 
+        return this;
+    }
+
+    @Override
+    public RemoteJmsRuntimeEngineBuilderImpl setSessionQueueJNDIName( String sessionQueueJNDIName ) {
+        config.setSessionQueueJndiName(sessionQueueJNDIName);
+        return this;
+    }
+
+    @Override
+    public RemoteJmsRuntimeEngineBuilderImpl setTaskQueueJNDIName( String taskQueueJNDIName ) {
+        config.setTaskQueueJndiName(taskQueueJNDIName);
+        return this;
+    }
+
+    @Override
+    public RemoteJmsRuntimeEngineBuilderImpl setResponseQueueJNDIName( String responseQueueJNDIName ) {
+        config.setResponseQueueJndiName(responseQueueJNDIName);
+        return this;
+    }
+    
     private void checkAndFinalizeConfig() {
         RemoteRuntimeEngineFactory.checkAndFinalizeConfig(config, this);
     }
@@ -272,5 +305,7 @@ class RemoteJmsRuntimeEngineBuilderImpl implements org.kie.remote.client.api.Rem
     public static RemoteJmsRuntimeEngineBuilderImpl newBuilder() { 
         return new RemoteJmsRuntimeEngineBuilderImpl();
     }
+
+
 
 }

--- a/kie-remote/kie-remote-client/src/main/java/org/kie/services/client/api/RemoteRestRuntimeEngineBuilderImpl.java
+++ b/kie-remote/kie-remote-client/src/main/java/org/kie/services/client/api/RemoteRestRuntimeEngineBuilderImpl.java
@@ -1,11 +1,13 @@
 package org.kie.services.client.api;
 
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashSet;
 import java.util.Set;
 
 import org.kie.remote.client.api.RemoteRestRuntimeEngineFactory;
 import org.kie.remote.client.api.exception.InsufficientInfoToBuildException;
+import org.kie.remote.client.api.order.OrderedRemoteRestRuntimeEngineBuilder;
 import org.kie.services.client.api.command.RemoteConfiguration;
 import org.kie.services.client.api.command.RemoteConfiguration.Type;
 import org.kie.services.client.api.command.RemoteRuntimeEngine;
@@ -16,7 +18,7 @@ import org.kie.services.client.api.command.RemoteRuntimeEngine;
  * It takes care of implementing the methods specified as well as managing the 
  * state of the internal {@link RemoteConfiguration} instance.
  */
-class RemoteRestRuntimeEngineBuilderImpl implements  org.kie.remote.client.api.RemoteRestRuntimeEngineBuilder {
+class RemoteRestRuntimeEngineBuilderImpl implements org.kie.remote.client.api.RemoteRestRuntimeEngineBuilder, OrderedRemoteRestRuntimeEngineBuilder.OrderedRemoteRestRuntimeEngineBuilderAll {
 
     private RemoteConfiguration config;
     
@@ -56,6 +58,13 @@ class RemoteRestRuntimeEngineBuilderImpl implements  org.kie.remote.client.api.R
         return this;
     }
 
+    @Override
+    public RemoteRestRuntimeEngineBuilderImpl addUrl(String urlString) throws MalformedURLException {
+        URL realUrl = new URL(urlString);
+        config.setServerBaseRestUrl(realUrl);
+        return this;
+    }
+    
     @Override
     public RemoteRestRuntimeEngineBuilderImpl addTimeout(int timeoutInSeconds) {
         config.setTimeout(timeoutInSeconds);

--- a/kie-remote/kie-remote-client/src/main/java/org/kie/services/client/api/RemoteRuntimeEngineFactory.java
+++ b/kie-remote/kie-remote-client/src/main/java/org/kie/services/client/api/RemoteRuntimeEngineFactory.java
@@ -15,6 +15,8 @@ import org.kie.remote.client.api.RemoteJmsRuntimeEngineBuilder;
 import org.kie.remote.client.api.RemoteRestRuntimeEngineBuilder;
 import org.kie.remote.client.api.RemoteWebserviceClientBuilder;
 import org.kie.remote.client.api.exception.InsufficientInfoToBuildException;
+import org.kie.remote.client.api.order.OrderedRemoteJmsRuntimeEngineBuilder;
+import org.kie.remote.client.api.order.OrderedRemoteRestRuntimeEngineBuilder;
 import org.kie.remote.services.ws.command.generated.CommandWebService;
 import org.kie.services.client.api.command.RemoteConfiguration;
 
@@ -60,6 +62,33 @@ public abstract class RemoteRuntimeEngineFactory extends org.kie.remote.client.a
      * @return A {@link RemoteRestRuntimeEngineBuilder} instance
      */
     public static RemoteWebserviceClientBuilder<RemoteWebserviceClientBuilder, CommandWebService> newCommandWebServiceClientBuilder() { 
+       return new RemoteCommandWebserviceClientBuilderImpl();
+    }
+   
+    /**
+     * Create a new {@link RemoteJmsRuntimeEngineBuilder} instance 
+     * to configure and buid a remote API client {@link RuntimeEngine} instance.
+     * @return A {@link RemoteJmsRuntimeEngineBuilder} instance
+     */
+    public static OrderedRemoteJmsRuntimeEngineBuilder newOrderedJmsBuilder() { 
+       return new org.kie.services.client.api.RemoteJmsRuntimeEngineBuilderImpl(); 
+    }
+    
+    /**
+     * Create a new {@link RemoteRestRuntimeEngineBuilder} instance 
+     * to configure and buid a remote API client {@link RuntimeEngine} instance.
+     * @return A {@link RemoteRestRuntimeEngineBuilder} instance
+     */
+    public static OrderedRemoteRestRuntimeEngineBuilder newOrderedRestBuilder() { 
+       return new org.kie.services.client.api.RemoteRestRuntimeEngineBuilderImpl(); 
+    }
+
+    /**
+     * Create a new {@link RemoteRestRuntimeEngineBuilder} instance 
+     * to configure and buid a remote API client {@link RuntimeEngine} instance.
+     * @return A {@link RemoteRestRuntimeEngineBuilder} instance
+     */
+    public static RemoteWebserviceClientBuilder<RemoteWebserviceClientBuilder, CommandWebService> newOrderedCommandWebServiceClientBuilder() { 
        return new RemoteCommandWebserviceClientBuilderImpl();
     }
     

--- a/kie-remote/kie-remote-client/src/main/java/org/kie/services/client/api/command/RemoteConfiguration.java
+++ b/kie-remote/kie-remote-client/src/main/java/org/kie/services/client/api/command/RemoteConfiguration.java
@@ -54,6 +54,11 @@ public final class RemoteConfiguration {
     private Queue responseQueue;
     private int jmsSerializationType = JaxbSerializationProvider.JMS_SERIALIZATION_TYPE;
 
+    private String connectionFactoryJndiName = CONNECTION_FACTORY_NAME;
+    private String sessionQueueJndiName = SESSION_QUEUE_NAME;
+    private String taskQueueJndiName = TASK_QUEUE_NAME;
+    private String responseQueueJndiName = RESPONSE_QUEUE_NAME;
+            
     /**
      * Public constructors and setters
      */
@@ -216,7 +221,7 @@ public final class RemoteConfiguration {
     }
     
     public void setRemoteInitialContext(InitialContext context) { 
-        String prop = CONNECTION_FACTORY_NAME;
+        String prop = this.connectionFactoryJndiName;
         try {
             if( this.connectionFactory == null ) { 
                 this.connectionFactory = (ConnectionFactory) context.lookup(prop);
@@ -400,6 +405,22 @@ public final class RemoteConfiguration {
         this.disableTaskSecurity = disableTaskSecurity;
     }
    
+    public void setConnectionFactoryJndiName( String connectionFactoryJndiName ) {
+        this.connectionFactoryJndiName = connectionFactoryJndiName;
+    }
+
+    public void setSessionQueueJndiName( String sessionQueueJndiName ) {
+        this.sessionQueueJndiName = sessionQueueJndiName;
+    }
+
+    public void setTaskQueueJndiName( String taskQueueJndiName ) {
+        this.taskQueueJndiName = taskQueueJndiName;
+    }
+
+    public void setResponseQueueJndiName( String responseQueueJndiName ) {
+        this.responseQueueJndiName = responseQueueJndiName;
+    }
+
     // Clone --- 
    
     private RemoteConfiguration(RemoteConfiguration config) { 

--- a/kie-remote/kie-remote-client/src/test/java/org/kie/services/client/builder/RemoteRestClientBuilderTest.java
+++ b/kie-remote/kie-remote-client/src/test/java/org/kie/services/client/builder/RemoteRestClientBuilderTest.java
@@ -1,0 +1,172 @@
+package org.kie.services.client.builder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import static org.powermock.api.mockito.PowerMockito.mock;
+
+import java.lang.reflect.Field;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.security.NoSuchAlgorithmException;
+import java.util.HashSet;
+
+import javax.jms.ConnectionFactory;
+import javax.jms.Queue;
+import javax.naming.InitialContext;
+import javax.naming.spi.NamingManager;
+
+import org.jbpm.bpmn2.objects.Person;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.kie.api.runtime.manager.RuntimeEngine;
+import org.kie.remote.client.api.RemoteRuntimeEngineFactory;
+import org.kie.remote.client.api.exception.InsufficientInfoToBuildException;
+import org.kie.services.client.api.RemoteRestRuntimeEngineFactory;
+import org.kie.services.client.api.command.RemoteConfiguration;
+import org.kie.services.client.api.command.exception.MissingRequiredInfoException;
+import org.kie.services.client.api.command.exception.RemoteCommunicationException;
+import org.kie.services.client.builder.objects.MyType;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({InitialContext.class, NamingManager.class})
+public class RemoteRestClientBuilderTest extends org.kie.services.client.api.RemoteJmsRuntimeEngineFactory {
+
+    protected static Logger logger = LoggerFactory.getLogger(RemoteRestClientBuilderTest.class);
+    
+    private InitialContext remoteInitialContext = null;
+    
+    private ConnectionFactory connectionFactory = null;
+    private Queue ksessionQueue = null;
+    private Queue taskQueue = null;
+    private Queue responseQueue = null;
+  
+    public RemoteRestClientBuilderTest() { 
+        super();
+    }
+    
+    @Rule
+    public TestName testName = new TestName();
+
+    @Before
+    public void before() throws Exception {  // Create initial context
+        System.out.println( ">>> " + testName.getMethodName());
+    }
+    
+    @Test
+    public void restRuntimeFactoryBuilderTest() throws MalformedURLException, InsufficientInfoToBuildException { 
+       org.kie.remote.client.api.RemoteRestRuntimeEngineFactory restRuntimeFactory = 
+               RemoteRestRuntimeEngineFactory.newBuilder()
+               .addDeploymentId("deployment")
+               .addProcessInstanceId(23l)
+               .addUserName("S")
+               .addPassword("koek")
+               .addUrl(new URL("http://localhost:8080/kie-wb"))
+               .addTimeout(3)
+               .addExtraJaxbClasses(MyType.class, Person.class)
+               .buildFactory();
+       assertNotNull( restRuntimeFactory );
+       
+       try { 
+           RemoteRestRuntimeEngineFactory.newBuilder()
+               .addDeploymentId("deployment")
+               .addPassword("poffertje")
+               .addUrl(new URL("http://localhost:8080/kie-wb"))
+               .addTimeout(3)
+               .buildFactory();
+           fail( "A user name should always be required!");
+       } catch(InsufficientInfoToBuildException e) { 
+          // expected
+       }
+       
+       try { 
+           RemoteRestRuntimeEngineFactory.newBuilder()
+               .addDeploymentId("deployment")
+               .addUserName("A")
+               .addUrl(new URL("http://localhost:8080/kie-wb"))
+               .addTimeout(3)
+               .buildFactory();
+           fail( "A password should always be required!");
+       } catch(InsufficientInfoToBuildException e) { 
+          // expected 
+       }
+       
+       try { 
+           RemoteRestRuntimeEngineFactory.newBuilder()
+               .addDeploymentId("deployment")
+               .addUserName("E")
+               .addPassword("suiker")
+               .addTimeout(3)
+               .buildFactory();
+           fail( "A URL should always be required!");
+       } catch(InsufficientInfoToBuildException e) { 
+          // expected 
+       }
+      
+       // minimum
+       RemoteRestRuntimeEngineFactory.newBuilder()
+               .addUserName("joke")
+               .addPassword("stroop")
+               .addUrl(new URL("http://localhost:8080/kie-wb"))
+               .buildFactory();
+    }
+
+    private RemoteConfiguration getConfig(org.kie.services.client.api.RemoteJmsRuntimeEngineFactory factory) throws Exception { 
+        Field configField = org.kie.services.client.api.RemoteJmsRuntimeEngineFactory.class.getDeclaredField("config");
+        configField.setAccessible(true);
+        Object configObj = configField.get(factory);
+        assertNotNull("No config found.", configObj);
+        return (RemoteConfiguration) configObj;
+    }
+    
+    @Test
+    public void missingDeploymentIdTest() throws Exception { 
+        RuntimeEngine runtimeEngine = 
+                RemoteRestRuntimeEngineFactory.newBuilder()
+                .addUserName("user")
+                .addPassword("pass")
+                .addUrl(new URL("http://localhost:8080/business-central"))
+                .build();
+        
+        try { 
+            runtimeEngine.getTaskService().claim(23l, "user");
+            fail( "This should have failed because there's no server running... ");
+        } catch( RemoteCommunicationException rce ) { 
+            // expected
+        }
+        
+        try { 
+            runtimeEngine.getAuditService().clear();
+            fail( "This should have failed because there's no server running... ");
+        } catch( RemoteCommunicationException rce ) { 
+            // expected
+        }
+        
+        // This will throw a MissingRequiredInfoException because the deployment id is required here
+        try { 
+            runtimeEngine.getKieSession().startProcess("org.test.process"); 
+            fail( "This should have failed because no deployment id has been provided. ");
+        } catch( MissingRequiredInfoException mrie ) { 
+            // expected
+        }
+   
+    }
+    
+    @Test
+    public void orderedRestBuilderTest() throws Exception {
+        RemoteRuntimeEngineFactory.newOrderedRestBuilder()
+        .addUserName("user")
+        .addPassword("pass")
+        .addUrl("http://localhost:8080/kie-wb/")
+        .build();
+    }
+    
+    
+}

--- a/kie-remote/kie-remote-client/src/test/java/org/kie/services/client/builder/RemoteWebservicesClientBuilderTest.java
+++ b/kie-remote/kie-remote-client/src/test/java/org/kie/services/client/builder/RemoteWebservicesClientBuilderTest.java
@@ -1,0 +1,58 @@
+package org.kie.services.client.builder;
+
+import java.net.URL;
+
+import javax.naming.InitialContext;
+import javax.naming.spi.NamingManager;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.kie.remote.client.api.RemoteRuntimeEngineFactory;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({InitialContext.class, NamingManager.class})
+public class RemoteWebservicesClientBuilderTest extends org.kie.services.client.api.RemoteJmsRuntimeEngineFactory {
+
+    protected static Logger logger = LoggerFactory.getLogger(RemoteWebservicesClientBuilderTest.class);
+    
+    public RemoteWebservicesClientBuilderTest() { 
+        super();
+    }
+    
+    @Rule
+    public TestName testName = new TestName();
+
+    @Before
+    public void before() throws Exception {  // Create initial context
+        System.out.println( ">>> " + testName.getMethodName());
+    }
+    
+    @Test
+    public void commandWebServiceClientInterfaceInheritanceTest() { 
+        try { 
+        RemoteRuntimeEngineFactory.newCommandWebServiceClientBuilder()
+            .addPassword("test")
+            .addUserName("tester")
+            .addServerUrl("http://test.server.com/test-app/")
+            .addServerUrl(new URL("http://test.server.com/test-app/"))
+            .addPassword("test")
+            .addUserName("tester")
+            .addServerUrl("http://test.server.com/test-app/")
+            .addServerUrl(new URL("http://test.server.com/test-app/"))
+            .addPassword("test")
+            .addUserName("tester")
+            .addServerUrl("http://test.server.com/test-app/")
+            .addServerUrl(new URL("http://test.server.com/test-app/"))
+            .buildBasicAuthClient();
+        } catch( Exception e ) { 
+            // the above just needs to compile..
+        }
+    }
+}


### PR DESCRIPTION
@ibek and @rsynek: could you look at this and let me know what you think? 

In general, I don't like adding constructors because they're not "forward-compatibile": each constructor is unique. 

I've taken the fluent API and imposed a second set of interfaces on top of it: with the "ordered" builders, you can only call ".build()" when all of the correct information has been added, regardless of which path/configuration you choose for. 