### PR TITLE
DROOLS-733 - splitted and refactored work item operations test

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/JbpmKieServerBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/JbpmKieServerBaseIntegrationTest.java
@@ -6,6 +6,7 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.rules.ExternalResource;
 import org.kie.api.runtime.KieContainer;
+import org.kie.server.integrationtests.config.TestConfig;
 import org.kie.server.integrationtests.shared.RestJmsSharedBaseIntegrationTest;
 
 public abstract class JbpmKieServerBaseIntegrationTest extends RestJmsSharedBaseIntegrationTest {
@@ -41,5 +42,18 @@ public abstract class JbpmKieServerBaseIntegrationTest extends RestJmsSharedBase
         } catch (Exception e) {
             return null;
         }
+    }
+
+    /**
+     * Change user used by client.
+     *
+     * @param username Name of user, default user taken from TestConfig in case of null parameter.
+     */
+    protected void changeUser(String username) {
+        if(username == null) {
+            username = TestConfig.getUsername();
+        }
+        configuration.setUserName(username);
+        client = createDefaultClient();
     }
 }

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -77,7 +77,7 @@
               <properties>
                 <cargo.servlet.port>${container.port}</cargo.servlet.port>
                 <!-- kie-server role for REST tests; guest for JMS tests -->
-                <cargo.servlet.users>yoda:usetheforce123@:kie-server,guest|Administrator:usetheforce123@:kie-server,guest,Administrators</cargo.servlet.users>
+                <cargo.servlet.users>yoda:usetheforce123@:kie-server,guest|Administrator:usetheforce123@:kie-server,guest,Administrators|john:usetheforce123@:kie-server,guest</cargo.servlet.users>
               </properties>
             </configuration>
           </configuration>


### PR DESCRIPTION
Splitted testWorkItemOperations. 
User task shouldn't be handled as work item because in such case it doesn't behave consistently: in database there was left task in ready status even when process instance was completed. That caused issues in other tests.
In this PR user task is completed using startTask/completeTask and work item operation tests are done on second task - Email work item.
Test was splitted to cover both abortWorkItem and completeWorkItem.