### PR TITLE
DROOLS-733 - improved UserTaskServiceIntegrationTest.testSkipUserTask test

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/UserTaskServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/UserTaskServiceIntegrationTest.java
@@ -269,6 +269,7 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
             assertEquals(1, taskList.size());
             TaskSummary taskSummary = taskList.get(0);
             assertEquals("First task", taskSummary.getName());
+            assertTrue(taskSummary.getSkipable().booleanValue());
 
             client.skipTask("definition-project", taskSummary.getId(), "yoda");
 


### PR DESCRIPTION
Test improvement showing possible bug.
taskSummary.getSkipable() returns false although task has defined Skippable data input which is set to true and is possible to skip task by calling client.skipTask(...).

Please try to run this test.