### PR TITLE
KIE Performance Kit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,15 @@
 
 # Eclipse, Netbeans and IntelliJ files
 /.*
-!.gitignore
+.gitignore
 /nbproject
 /*.ipr
 /*.iws
 /*.iml
+.classpath
+.project
+.settings
+target
 
 # Repository wide ignore mac DS_Store files
 .DS_Store

--- a/kie-performance-kit/pom.xml
+++ b/kie-performance-kit/pom.xml
@@ -1,0 +1,81 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.drools</groupId>
+        <artifactId>droolsjbpm-integration</artifactId>
+        <version>6.3.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.kie</groupId>
+    <artifactId>kie-performance-kit</artifactId>
+
+    <name>BPMS Performance Kit</name>
+
+    <properties>
+        <logback.version>1.1.2</logback.version>
+        <metrics.version>3.1.0</metrics.version>
+        <slf4j.version>1.7.7</slf4j.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-core</artifactId>
+                <version>${metrics.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-jvm</artifactId>
+                <version>${metrics.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${logback.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.reflections</groupId>
+                <artifactId>reflections</artifactId>
+                <version>0.9.10</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-jvm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+        </dependency>
+    </dependencies>
+
+    <developers>
+        <developer>
+            <name>Ivo Bek</name>
+            <email>bekivo@gmail.com</email>
+        </developer>
+    </developers>
+
+</project>

--- a/kie-performance-kit/src/main/java/org/kie/perf/Executor.java
+++ b/kie-performance-kit/src/main/java/org/kie/perf/Executor.java
@@ -1,0 +1,172 @@
+package org.kie.perf;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
+import java.lang.reflect.Method;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.kie.perf.TestConfig.Measure;
+import org.kie.perf.TestConfig.ReporterType;
+import org.kie.perf.metrics.CsvSingleReporter;
+import org.kie.perf.metrics.MemoryUsageGaugeSet;
+import org.kie.perf.metrics.ThreadStatesGaugeSet;
+import org.kie.perf.scenario.IPerfTest;
+import org.kie.perf.suite.ITestSuite;
+import org.reflections.Reflections;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.codahale.metrics.ConsoleReporter;
+import com.codahale.metrics.CsvReporter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.ScheduledReporter;
+import com.codahale.metrics.jvm.FileDescriptorRatioGauge;
+
+public class Executor {
+    
+    protected static final Logger log = LoggerFactory.getLogger(Executor.class);
+
+    private ScheduledReporter reporter;
+
+    public Executor() {
+
+    }
+
+    public ITestSuite findTestSuite() throws Exception {
+        Class<?> csuite = Class.forName("org.kie.perf.suite." + TestConfig.getInstance().getSuite());
+        return (ITestSuite) csuite.newInstance();
+    }
+
+    public void initMetrics(IPerfTest scenario) {
+        // including reporter
+        MetricRegistry metrics = SharedMetricRegistry.getInstance();
+
+        TestConfig tc = TestConfig.getInstance();
+        ReporterType reporterType = tc.getReporterType();
+        if (reporterType == ReporterType.CONSOLE) {
+            reporter = ConsoleReporter.forRegistry(metrics).convertRatesTo(TimeUnit.SECONDS).convertDurationsTo(TimeUnit.MILLISECONDS).build();
+        } else if (reporterType == ReporterType.CSV) {
+            reporter = CsvReporter.forRegistry(metrics).formatFor(Locale.US).convertRatesTo(TimeUnit.SECONDS)
+                    .convertDurationsTo(TimeUnit.MILLISECONDS).build(new File(tc.getReportDataLocation()));
+            reporter.start(tc.getPeriodicity(), TimeUnit.SECONDS);
+        } else if (reporterType == ReporterType.CSVSINGLE) {
+            reporter = CsvSingleReporter.forRegistry(metrics).formatFor(Locale.US).convertRatesTo(TimeUnit.SECONDS)
+                    .convertDurationsTo(TimeUnit.MILLISECONDS).build(new File(tc.getReportDataLocation()));
+        }
+        
+        for (Measure m : tc.getMeasure()) {
+            if (m == Measure.MEMORYUSAGE) {
+                metrics.registerAll(new MemoryUsageGaugeSet(scenario.getClass()));
+            } else if (m == Measure.FILEDESCRIPTORS) {
+                metrics.register(MetricRegistry.name(scenario.getClass(), "file.descriptors.usage"), new FileDescriptorRatioGauge());
+                metrics.register(MetricRegistry.name(scenario.getClass(), "file.descriptors.used"), new Gauge<Long>() {
+                    @Override
+                    public Long getValue() {
+                        try {
+                            OperatingSystemMXBean os = ManagementFactory.getOperatingSystemMXBean();
+                            Method method = os.getClass().getDeclaredMethod("getOpenFileDescriptorCount");
+                            method.setAccessible(true);
+                            return (Long) method.invoke(os);
+                        } catch (Exception e) {
+                            
+                        }
+                        return -1L;
+                    }
+                });
+            } else if (m == Measure.THREADSTATES) {
+                metrics.registerAll(new ThreadStatesGaugeSet(scenario.getClass()));
+            }
+        }
+    }
+
+    public IPerfTest selectNextTestFromSuite(ITestSuite testSuite) throws Exception {
+        TestConfig tc = TestConfig.getInstance();
+        String testPackage = testSuite.getTestPackage();
+        Class<? extends IPerfTest> selectedScenario = null;
+        if (tc.getScenario() != null) {
+            selectedScenario = (Class<? extends IPerfTest>) Class.forName(testPackage + "." + tc.getScenario());
+        }
+
+        Reflections reflections = new Reflections(testPackage);
+        Set<Class<? extends IPerfTest>> scenarios = reflections.getSubTypesOf(IPerfTest.class);
+        IPerfTest instance = null;
+
+        if (selectedScenario == null) {
+            // parent process going through all scenarios to start new child
+            // processes for each scenario
+            for (Class<? extends IPerfTest> c : scenarios) {
+                if (selectedScenario == null) {
+                    ProcessBuilder processBuilder = new ProcessBuilder(tc.getStartScriptLocation(), c.getSimpleName());
+                    try {
+                        Process process = processBuilder.start();
+                        InputStreamReader isr = new InputStreamReader(process.getInputStream());
+                        BufferedReader br = new BufferedReader(isr);
+                        String line = null;
+                        while ((line = br.readLine()) != null) {
+                            System.out.println(line);
+                        }
+                        process.waitFor();
+                    } catch (Exception ex) {
+                        ex.printStackTrace();
+                    }
+                }
+            }
+        } else {
+            try {
+                instance = selectedScenario.newInstance();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+
+        return instance;
+    }
+
+    public void report() {
+        reporter.report();
+    }
+
+    public static void main(String[] args) {
+        Executor exec = new Executor();
+        try {
+            TestConfig tc = TestConfig.getInstance();
+            ITestSuite testSuite = exec.findTestSuite();
+            IPerfTest scenario = exec.selectNextTestFromSuite(testSuite);
+
+            String msg = "======== SUITE: " + tc.getSuite();
+            String scenarioName = tc.getScenario();
+            if (scenarioName != null) {
+                msg += " / " + "SCENARIO: " + scenarioName;
+            }
+            msg += " ========";
+            log.info(msg);
+            
+            if (scenario != null) {
+                // this is a child process for this scenario with own JVM
+                exec.initMetrics(scenario);
+                testSuite.initScenario(scenario);
+                if (tc.isWarmUp()) {
+                    SharedMetricRegistry.setWarmUp(true);
+                    scenario.initMetrics();
+                    for (int i=0; i<tc.getWarmUpCount(); ++i) {
+                        scenario.execute();
+                    }
+                    SharedMetricRegistry.setWarmUp(false);
+                }
+                scenario.initMetrics();
+                testSuite.startScenario(scenario);
+                exec.report();
+            }
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+        System.exit(0);
+    }
+
+}

--- a/kie-performance-kit/src/main/java/org/kie/perf/SharedMetricRegistry.java
+++ b/kie-performance-kit/src/main/java/org/kie/perf/SharedMetricRegistry.java
@@ -1,0 +1,32 @@
+package org.kie.perf;
+
+import com.codahale.metrics.MetricRegistry;
+
+public class SharedMetricRegistry {
+
+    private static MetricRegistry instance;
+    private static boolean isWarmUp = false;
+    private static MetricRegistry warmUpInstance;
+    
+    private SharedMetricRegistry() {
+        
+    }
+    
+    public static void setWarmUp(boolean isWarmUp) {
+        SharedMetricRegistry.isWarmUp = isWarmUp;
+    }
+
+    public static MetricRegistry getInstance() {
+        if (isWarmUp) {
+            if (warmUpInstance == null) {
+                warmUpInstance = new MetricRegistry();
+            }
+            return warmUpInstance;
+        }
+        if (instance == null) {
+            instance = new MetricRegistry();
+        }
+        return instance;
+    }
+
+}

--- a/kie-performance-kit/src/main/java/org/kie/perf/TestConfig.java
+++ b/kie-performance-kit/src/main/java/org/kie/perf/TestConfig.java
@@ -1,0 +1,182 @@
+package org.kie.perf;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import org.kie.perf.run.Duration;
+import org.kie.perf.run.IRunType;
+import org.kie.perf.run.Iteration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestConfig {
+
+    protected final Logger log = LoggerFactory.getLogger(getClass());
+
+    protected static TestConfig tc;
+
+    protected String suite;
+    protected String scenario;
+    protected String startScriptLocation;
+
+    protected RunType runType;
+    protected int duration;
+    protected int iterations;
+
+    protected ReporterType reporterType;
+    protected int periodicity;
+    protected String reportDataLocation;
+
+    protected int threads;
+    
+    protected boolean warmUp;
+    protected int warmUpCount;
+    
+    protected List<Measure> measure;
+
+    protected TestConfig() {
+
+    }
+
+    public Properties loadProperties() throws Exception {
+        Properties props = new Properties();
+        props.load(TestConfig.class.getClassLoader().getResourceAsStream("performance.properties"));
+
+        suite = props.getProperty("suite");
+        if (suite == null) {
+            suite = System.getProperty("suite");
+        }
+        scenario = props.getProperty("scenario");
+        if (scenario == null) {
+            scenario = System.getProperty("scenario");
+            if (scenario.isEmpty() || scenario.equals("${scenario}")) {
+                scenario = null;
+            }
+        }
+
+        startScriptLocation = props.getProperty("startScriptLocation");
+        if (startScriptLocation == null) {
+            startScriptLocation = "./run.sh";
+        }
+
+        runType = RunType.valueOf(props.getProperty("runType").toUpperCase());
+        duration = Integer.valueOf(props.getProperty("duration"));
+        iterations = Integer.valueOf(props.getProperty("iterations"));
+
+        reporterType = ReporterType.valueOf(props.getProperty("reporterType").toUpperCase());
+        periodicity = Integer.valueOf(props.getProperty("periodicity"));
+        reportDataLocation = props.getProperty("reportDataLocation");
+
+        threads = Integer.valueOf(props.getProperty("threads"));
+        
+        warmUp = Boolean.valueOf(props.getProperty("warmUp"));
+        warmUpCount = Integer.valueOf(props.getProperty("warmUpCount"));
+        
+        measure = new ArrayList<TestConfig.Measure>();
+        String mprop = props.getProperty("measure");
+        String[] mlist = (mprop != null)?mprop.toUpperCase().split(","):new String[0];
+        for (String m : mlist) {
+            try {
+                measure.add(Measure.valueOf(m));
+            } catch (Exception ex) {
+                
+            }
+        }
+
+        return props;
+    }
+
+    public static TestConfig getInstance() {
+        if (tc == null) {
+            tc = new TestConfig();
+            try {
+                tc.loadProperties();
+            } catch (Exception ex) {
+                ex.printStackTrace();
+            }
+        }
+        return tc;
+    }
+
+    public String getSuite() {
+        return suite;
+    }
+
+    public String getScenario() {
+        return scenario;
+    }
+
+    public String getStartScriptLocation() {
+        return startScriptLocation;
+    }
+
+    public RunType getRunType() {
+        return runType;
+    }
+
+    public int getDuration() {
+        return duration;
+    }
+
+    public int getIterations() {
+        return iterations;
+    }
+
+    public ReporterType getReporterType() {
+        return reporterType;
+    }
+
+    public int getPeriodicity() {
+        return periodicity;
+    }
+
+    public String getReportDataLocation() {
+        return reportDataLocation;
+    }
+
+    public int getThreads() {
+        return threads;
+    }
+    
+    public boolean isWarmUp() {
+        return warmUp;
+    }
+    
+    public int getWarmUpCount() {
+        return warmUpCount;
+    }
+    
+    public List<Measure> getMeasure() {
+        return measure;
+    }
+
+    public static enum ReporterType {
+        CONSOLE, CSV, CSVSINGLE
+    }
+    
+    public static enum Measure {
+        MEMORYUSAGE, FILEDESCRIPTORS, THREADSTATES
+    }
+
+    public static enum RunType {
+        DURATION(Duration.class), ITERATION(Iteration.class);
+
+        private Class<? extends IRunType> klass;
+
+        private RunType(Class<? extends IRunType> klass) {
+            this.klass = klass;
+        }
+
+        public IRunType newInstance() {
+            IRunType instance = null;
+            try {
+                instance = klass.newInstance();
+            } catch (Exception e) {
+
+            }
+            return instance;
+        }
+    }
+
+}

--- a/kie-performance-kit/src/main/java/org/kie/perf/annotation/KPKLimit.java
+++ b/kie-performance-kit/src/main/java/org/kie/perf/annotation/KPKLimit.java
@@ -1,0 +1,14 @@
+package org.kie.perf.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(value = { ElementType.TYPE })
+@Retention(value = RetentionPolicy.RUNTIME)
+public @interface KPKLimit {
+
+    int value();
+    
+}

--- a/kie-performance-kit/src/main/java/org/kie/perf/metrics/CsvSingleReporter.java
+++ b/kie-performance-kit/src/main/java/org/kie/perf/metrics/CsvSingleReporter.java
@@ -1,0 +1,237 @@
+package org.kie.perf.metrics;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.nio.charset.Charset;
+import java.util.Locale;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.codahale.metrics.Clock;
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.CsvReporter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.ScheduledReporter;
+import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.Timer;
+
+public class CsvSingleReporter extends ScheduledReporter {
+    /**
+     * Returns a new {@link Builder} for {@link CsvReporter}.
+     * 
+     * @param registry
+     *            the registry to report
+     * @return a {@link Builder} instance for a {@link CsvReporter}
+     */
+    public static Builder forRegistry(MetricRegistry registry) {
+        return new Builder(registry);
+    }
+
+    /**
+     * A builder for {@link CsvReporter} instances. Defaults to using the
+     * default locale, converting rates to events/second, converting durations
+     * to milliseconds, and not filtering metrics.
+     */
+    public static class Builder {
+        private final MetricRegistry registry;
+        private Locale locale;
+        private TimeUnit rateUnit;
+        private TimeUnit durationUnit;
+        private Clock clock;
+        private MetricFilter filter;
+
+        private Builder(MetricRegistry registry) {
+            this.registry = registry;
+            this.locale = Locale.getDefault();
+            this.rateUnit = TimeUnit.SECONDS;
+            this.durationUnit = TimeUnit.MILLISECONDS;
+            this.clock = Clock.defaultClock();
+            this.filter = MetricFilter.ALL;
+        }
+
+        /**
+         * Format numbers for the given {@link Locale}.
+         * 
+         * @param locale
+         *            a {@link Locale}
+         * @return {@code this}
+         */
+        public Builder formatFor(Locale locale) {
+            this.locale = locale;
+            return this;
+        }
+
+        /**
+         * Convert rates to the given time unit.
+         * 
+         * @param rateUnit
+         *            a unit of time
+         * @return {@code this}
+         */
+        public Builder convertRatesTo(TimeUnit rateUnit) {
+            this.rateUnit = rateUnit;
+            return this;
+        }
+
+        /**
+         * Convert durations to the given time unit.
+         * 
+         * @param durationUnit
+         *            a unit of time
+         * @return {@code this}
+         */
+        public Builder convertDurationsTo(TimeUnit durationUnit) {
+            this.durationUnit = durationUnit;
+            return this;
+        }
+
+        /**
+         * Use the given {@link Clock} instance for the time.
+         * 
+         * @param clock
+         *            a {@link Clock} instance
+         * @return {@code this}
+         */
+        public Builder withClock(Clock clock) {
+            this.clock = clock;
+            return this;
+        }
+
+        /**
+         * Only report metrics which match the given filter.
+         * 
+         * @param filter
+         *            a {@link MetricFilter}
+         * @return {@code this}
+         */
+        public Builder filter(MetricFilter filter) {
+            this.filter = filter;
+            return this;
+        }
+
+        /**
+         * Builds a {@link CsvReporter} with the given properties, writing
+         * {@code .csv} files to the given directory.
+         * 
+         * @param directory
+         *            the directory in which the {@code .csv} files will be
+         *            created
+         * @return a {@link CsvReporter}
+         */
+        public CsvSingleReporter build(File directory) {
+            return new CsvSingleReporter(registry, directory, locale, rateUnit, durationUnit, clock, filter);
+        }
+    }
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CsvReporter.class);
+    private static final Charset UTF_8 = Charset.forName("UTF-8");
+
+    private final File directory;
+    private final Locale locale;
+    private final Clock clock;
+
+    private CsvSingleReporter(MetricRegistry registry, File directory, Locale locale, TimeUnit rateUnit, TimeUnit durationUnit, Clock clock,
+            MetricFilter filter) {
+        super(registry, "csv-reporter", filter, rateUnit, durationUnit);
+        this.directory = directory;
+        this.locale = locale;
+        this.clock = clock;
+    }
+
+    @Override
+    public void report(SortedMap<String, Gauge> gauges, SortedMap<String, Counter> counters, SortedMap<String, Histogram> histograms,
+            SortedMap<String, Meter> meters, SortedMap<String, Timer> timers) {
+
+        for (Map.Entry<String, Gauge> entry : gauges.entrySet()) {
+            reportGauge(entry.getKey(), entry.getValue());
+        }
+
+        for (Map.Entry<String, Counter> entry : counters.entrySet()) {
+            reportCounter(entry.getKey(), entry.getValue());
+        }
+
+        for (Map.Entry<String, Histogram> entry : histograms.entrySet()) {
+            reportHistogram(entry.getKey(), entry.getValue());
+        }
+
+        for (Map.Entry<String, Meter> entry : meters.entrySet()) {
+            reportMeter(entry.getKey(), entry.getValue());
+        }
+
+        for (Map.Entry<String, Timer> entry : timers.entrySet()) {
+            reportTimer(entry.getKey(), entry.getValue());
+        }
+    }
+
+    private void reportTimer(String name, Timer timer) {
+        final Snapshot snapshot = timer.getSnapshot();
+
+        report(name, getMeterName(name), timer.getCount(), convertRate(timer.getMeanRate()), convertDuration(snapshot.getMin()),
+                convertDuration(snapshot.getMean()), convertDuration(snapshot.getMax()), convertDuration(snapshot.getStdDev()),
+                convertDuration(snapshot.getMedian()), convertDuration(snapshot.get75thPercentile()), convertDuration(snapshot.get95thPercentile()),
+                convertDuration(snapshot.get98thPercentile()), convertDuration(snapshot.get99thPercentile()),
+                convertDuration(snapshot.get999thPercentile()));
+    }
+
+    private void reportMeter(String name, Meter meter) {
+        report(name, getMeterName(name), meter.getCount(), 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    }
+
+    private void reportHistogram(String name, Histogram histogram) {
+        final Snapshot snapshot = histogram.getSnapshot();
+
+        report(name, getMeterName(name), histogram.getCount(), 0.0f, snapshot.getMin(), snapshot.getMean(), snapshot.getMax(), snapshot.getStdDev(),
+                snapshot.getMedian(), snapshot.get75thPercentile(), snapshot.get95thPercentile(), snapshot.get98thPercentile(),
+                snapshot.get99thPercentile(), snapshot.get999thPercentile());
+    }
+
+    private void reportCounter(String name, Counter counter) {
+        report(name, getMeterName(name), counter.getCount(), 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    }
+
+    private void reportGauge(String name, Gauge gauge) {
+        report(name, getMeterName(name), gauge.getValue(), 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    }
+
+    private void report(String name, Object... values) {
+        try {
+            final File file = new File(directory, getFileName(name) + ".csv");
+            final boolean fileAlreadyExists = file.exists();
+            if (fileAlreadyExists || file.createNewFile()) {
+                final PrintWriter out = new PrintWriter(new OutputStreamWriter(new FileOutputStream(file, true), UTF_8));
+                try {
+                    if (!fileAlreadyExists) {
+                        out.println("Metric,Count/Value,Mean Rate [events/" + getRateUnit() + "],Min [" + getDurationUnit() + "],Mean [" + getDurationUnit()
+                                + "],Max [" + getDurationUnit() + "],Standard Deviation,Median,p75,p95,p98,p99,p99.9");
+                    }
+                    out.printf(locale, String.format(locale, "%s%n", "%s,%s,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f"), values);
+                } finally {
+                    out.close();
+                }
+            }
+        } catch (IOException e) {
+            LOGGER.warn("Error writing to {}", name, e);
+        }
+    }
+
+    protected String getFileName(String name) {
+        String a = name.substring(name.indexOf(".", "org.kie.perf.scenario".length() + 1) + 1);
+        return a.substring(0, a.indexOf("."));
+    }
+
+    protected String getMeterName(String name) {
+        String a = name.substring(name.indexOf(".", "org.kie.perf.scenario".length() + 1) + 1);
+        return a.substring(a.indexOf(".") + 1);
+    }
+}

--- a/kie-performance-kit/src/main/java/org/kie/perf/metrics/MemoryUsageGaugeSet.java
+++ b/kie-performance-kit/src/main/java/org/kie/perf/metrics/MemoryUsageGaugeSet.java
@@ -1,0 +1,106 @@
+package org.kie.perf.metrics;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryUsage;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.MetricSet;
+
+public class MemoryUsageGaugeSet implements MetricSet {
+
+    private Class<?> scenario;
+
+    private final MemoryMXBean mxBean;
+    private final List<MemoryPoolMXBean> memoryPools;
+
+    public MemoryUsageGaugeSet(Class<?> scenario) {
+        this.scenario = scenario;
+        this.mxBean = ManagementFactory.getMemoryMXBean();
+        this.memoryPools = new ArrayList<MemoryPoolMXBean>(ManagementFactory.getMemoryPoolMXBeans());
+    }
+
+    @Override
+    public Map<String, Metric> getMetrics() {
+        final Map<String, Metric> gauges = new HashMap<String, Metric>();
+
+        gauges.put(MetricRegistry.name(scenario, "heap.init"), new Gauge<String>() {
+            @Override
+            public String getValue() {
+                return readableFileSize(mxBean.getHeapMemoryUsage().getInit());
+            }
+        });
+
+        gauges.put(MetricRegistry.name(scenario, "heap.used"), new Gauge<String>() {
+            @Override
+            public String getValue() {
+                return readableFileSize(mxBean.getHeapMemoryUsage().getUsed());
+            }
+        });
+
+        gauges.put(MetricRegistry.name(scenario, "heap.max"), new Gauge<String>() {
+            @Override
+            public String getValue() {
+                return readableFileSize(mxBean.getHeapMemoryUsage().getMax());
+            }
+        });
+
+        gauges.put(MetricRegistry.name(scenario, "heap.committed"), new Gauge<String>() {
+            @Override
+            public String getValue() {
+                return readableFileSize(mxBean.getHeapMemoryUsage().getCommitted());
+            }
+        });
+
+        gauges.put(MetricRegistry.name(scenario, "heap.usage"), new Gauge<String>() {
+            @Override
+            public String getValue() {
+                final MemoryUsage usage = mxBean.getHeapMemoryUsage();
+                NumberFormat percentFormat = NumberFormat.getPercentInstance();
+                percentFormat.setMaximumFractionDigits(2);
+                return percentFormat.format(((double) usage.getUsed()) / usage.getMax());
+            }
+        });
+
+        for (final MemoryPoolMXBean pool : memoryPools) {
+            gauges.put(name(scenario, pool.getName().toLowerCase().replace(" ", "."), "usage"), new Gauge<String>() {
+                @Override
+                public String getValue() {
+                    final long max = pool.getUsage().getMax() == -1 ? pool.getUsage().getCommitted() : pool.getUsage().getMax();
+                    NumberFormat percentFormat = NumberFormat.getPercentInstance();
+                    percentFormat.setMaximumFractionDigits(2);
+                    return percentFormat.format(((double) pool.getUsage().getUsed()) / max);
+                }
+            });
+            gauges.put(name(scenario, pool.getName().toLowerCase().replace(" ", "."), "used"), new Gauge<String>() {
+                @Override
+                public String getValue() {
+                    return readableFileSize(pool.getUsage().getUsed());
+                }
+            });
+        }
+
+        return Collections.unmodifiableMap(gauges);
+    }
+
+    private static String readableFileSize(long size) {
+        if (size <= 0)
+            return "0";
+        final String[] units = new String[] { "B", "kB", "MB", "GB", "TB" };
+        int digitGroups = (int) (Math.log10(size) / Math.log10(1024));
+        return new DecimalFormat("#,##0.#").format(size / Math.pow(1024, digitGroups)) + " " + units[digitGroups];
+    }
+
+}

--- a/kie-performance-kit/src/main/java/org/kie/perf/metrics/ThreadStatesGaugeSet.java
+++ b/kie-performance-kit/src/main/java/org/kie/perf/metrics/ThreadStatesGaugeSet.java
@@ -1,0 +1,94 @@
+package org.kie.perf.metrics;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.MetricSet;
+import com.codahale.metrics.jvm.ThreadDeadlockDetector;
+
+public class ThreadStatesGaugeSet implements MetricSet {
+
+    // do not compute stack traces.
+    private final static int STACK_TRACE_DEPTH = 0;
+
+    private Class<?> scenario;
+
+    private final ThreadMXBean threads;
+    private final ThreadDeadlockDetector deadlockDetector;
+
+    public ThreadStatesGaugeSet(Class<?> scenario) {
+        this.scenario = scenario;
+        this.threads = ManagementFactory.getThreadMXBean();
+        this.deadlockDetector = new ThreadDeadlockDetector();
+    }
+
+    @Override
+    public Map<String, Metric> getMetrics() {
+        final Map<String, Metric> gauges = new HashMap<String, Metric>();
+
+        for (final Thread.State state : Thread.State.values()) {
+            gauges.put(MetricRegistry.name(scenario, "thread.state", state.toString().toLowerCase(), "count"), new Gauge<Object>() {
+                @Override
+                public Object getValue() {
+                    return getThreadCount(state);
+                }
+            });
+        }
+
+        gauges.put(MetricRegistry.name(scenario, "threads.count"), new Gauge<Integer>() {
+            @Override
+            public Integer getValue() {
+                return threads.getThreadCount();
+            }
+        });
+
+        gauges.put(MetricRegistry.name(scenario, "daemon.count"), new Gauge<Integer>() {
+            @Override
+            public Integer getValue() {
+                return threads.getDaemonThreadCount();
+            }
+        });
+
+        gauges.put(MetricRegistry.name(scenario, "deadlock.count"), new Gauge<Integer>() {
+            @Override
+            public Integer getValue() {
+                return deadlockDetector.getDeadlockedThreads().size();
+            }
+        });
+
+        gauges.put(MetricRegistry.name(scenario, "deadlocks"), new Gauge<Set<String>>() {
+            @Override
+            public Set<String> getValue() {
+                return deadlockDetector.getDeadlockedThreads();
+            }
+        });
+
+        return Collections.unmodifiableMap(gauges);
+    }
+
+    private int getThreadCount(Thread.State state) {
+        final ThreadInfo[] allThreads = getThreadInfo();
+        int count = 0;
+        for (ThreadInfo info : allThreads) {
+            if (info != null && info.getThreadState() == state) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    ThreadInfo[] getThreadInfo() {
+        return threads.getThreadInfo(threads.getAllThreadIds(), STACK_TRACE_DEPTH);
+    }
+
+}

--- a/kie-performance-kit/src/main/java/org/kie/perf/run/Duration.java
+++ b/kie-performance-kit/src/main/java/org/kie/perf/run/Duration.java
@@ -1,0 +1,25 @@
+package org.kie.perf.run;
+
+import org.kie.perf.TestConfig;
+
+public class Duration implements IRunType {
+
+    private long endTime;
+    private int limit;
+    
+    private int i;
+    
+    @Override
+    public void start(int limit) {
+        this.limit = limit;
+        endTime = System.currentTimeMillis() + TestConfig.getInstance().getDuration()*1000;
+        i = 0;
+    }
+
+    @Override
+    public boolean isEnd() {
+        i++;
+        return i > limit || System.currentTimeMillis() > endTime;
+    }
+
+}

--- a/kie-performance-kit/src/main/java/org/kie/perf/run/IRunType.java
+++ b/kie-performance-kit/src/main/java/org/kie/perf/run/IRunType.java
@@ -1,0 +1,9 @@
+package org.kie.perf.run;
+
+public interface IRunType {
+
+    public void start(int limit);
+    
+    public boolean isEnd();
+    
+}

--- a/kie-performance-kit/src/main/java/org/kie/perf/run/Iteration.java
+++ b/kie-performance-kit/src/main/java/org/kie/perf/run/Iteration.java
@@ -1,0 +1,22 @@
+package org.kie.perf.run;
+
+import org.kie.perf.TestConfig;
+
+public class Iteration implements IRunType {
+
+    private int i;
+    private int limit;
+    
+    @Override
+    public void start(int limit) {
+        i = 0;
+        this.limit = limit;
+    }
+
+    @Override
+    public boolean isEnd() {
+        i++;
+        return i > limit || i > TestConfig.getInstance().getIterations();
+    }
+
+}

--- a/kie-performance-kit/src/main/java/org/kie/perf/scenario/IPerfTest.java
+++ b/kie-performance-kit/src/main/java/org/kie/perf/scenario/IPerfTest.java
@@ -1,0 +1,17 @@
+package org.kie.perf.scenario;
+
+public interface IPerfTest {
+
+    /**
+     * Shouldn't contain MetricRegistry metrics = SharedMetricRegistry.getInstance();
+     * For initialization of metrics use initMetrics.
+     */
+    public void init();
+    
+    public void initMetrics();
+    
+    public void execute();
+    
+    public void close();
+    
+}

--- a/kie-performance-kit/src/main/java/org/kie/perf/suite/ConcurrentLoadSuite.java
+++ b/kie-performance-kit/src/main/java/org/kie/perf/suite/ConcurrentLoadSuite.java
@@ -1,0 +1,78 @@
+package org.kie.perf.suite;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kie.perf.SharedMetricRegistry;
+import org.kie.perf.TestConfig;
+import org.kie.perf.annotation.KPKLimit;
+import org.kie.perf.run.IRunType;
+import org.kie.perf.scenario.IPerfTest;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+
+public class ConcurrentLoadSuite implements ITestSuite {
+
+    protected int iterations = 1; // default
+    protected int threads = 1; // default
+
+    @Override
+    public String getTestPackage() {
+        return "org.kie.perf.scenario.load";
+    }
+
+    @Override
+    public void initScenario(final IPerfTest scenario) throws Exception {
+        TestConfig tc = TestConfig.getInstance();
+        iterations = tc.getIterations();
+        threads = tc.getThreads();
+
+        scenario.init();
+    }
+
+    @Override
+    public void startScenario(final IPerfTest scenario) {
+        List<Thread> threadsList = new ArrayList<Thread>();
+
+        KPKLimit limit = scenario.getClass().getAnnotation(KPKLimit.class);
+        final int max = (limit != null) ? limit.value() : Integer.MAX_VALUE;
+
+        Timer duration = SharedMetricRegistry.getInstance().timer(MetricRegistry.name(scenario.getClass(), "scenario.total.duration"));
+        Timer.Context context = duration.time();
+        for (int i = 0; i < threads; ++i) {
+            Thread t = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    Timer duration = SharedMetricRegistry.getInstance().timer(MetricRegistry.name(scenario.getClass(), "scenario.single.duration"));
+                    IRunType run = TestConfig.getInstance().getRunType().newInstance();
+
+                    run.start(max);
+                    while (!run.isEnd()) {
+                        Timer.Context context = duration.time();
+                        scenario.execute();
+                        context.stop();
+                    }
+                }
+            });
+            threadsList.add(t);
+        }
+
+        for (Thread t : threadsList) {
+            t.start();
+        }
+
+        for (Thread t : threadsList) {
+            try {
+                t.join();
+            } catch (Exception ex) {
+                ex.printStackTrace();
+            }
+        }
+        context.stop();
+
+        scenario.close();
+        threadsList.clear();
+    }
+
+}

--- a/kie-performance-kit/src/main/java/org/kie/perf/suite/ITestSuite.java
+++ b/kie-performance-kit/src/main/java/org/kie/perf/suite/ITestSuite.java
@@ -1,0 +1,14 @@
+package org.kie.perf.suite;
+
+import org.kie.perf.scenario.IPerfTest;
+
+
+public interface ITestSuite {
+    
+    public String getTestPackage();
+
+    public void initScenario(final IPerfTest scenario) throws Exception;
+    
+    public void startScenario(final IPerfTest scenario);
+    
+}

--- a/kie-performance-kit/src/main/java/org/kie/perf/suite/LoadSuite.java
+++ b/kie-performance-kit/src/main/java/org/kie/perf/suite/LoadSuite.java
@@ -1,0 +1,58 @@
+package org.kie.perf.suite;
+
+import org.kie.perf.SharedMetricRegistry;
+import org.kie.perf.TestConfig;
+import org.kie.perf.annotation.KPKLimit;
+import org.kie.perf.run.IRunType;
+import org.kie.perf.scenario.IPerfTest;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+
+public class LoadSuite implements ITestSuite {
+
+    protected int iterations;
+    
+    @Override
+    public String getTestPackage() {
+        return "org.kie.perf.scenario.load";
+    }
+
+    @Override
+    public void initScenario(final IPerfTest scenario) throws Exception {
+        TestConfig tc = TestConfig.getInstance();
+        iterations = tc.getIterations();
+        
+        scenario.init();
+    }
+
+    @Override
+    public void startScenario(final IPerfTest scenario) {
+        MetricRegistry metrics = SharedMetricRegistry.getInstance();
+        IRunType run = TestConfig.getInstance().getRunType().newInstance();
+
+        Timer duration = metrics.timer(MetricRegistry.name(scenario.getClass(), "scenario.total.duration"));
+        Timer.Context contextDuration = duration.time();
+        
+        KPKLimit limit = scenario.getClass().getAnnotation(KPKLimit.class);
+        int max = Integer.MAX_VALUE;
+        if (limit != null) {
+            max = limit.value();
+        }
+        
+        Timer scenarioDuration = metrics.timer(MetricRegistry.name(scenario.getClass(), "scenario.single.duration"));
+        run.start(max);
+        while (!run.isEnd()) {
+            Timer.Context context = scenarioDuration.time();
+            try {
+                scenario.execute();
+            } catch (Exception ex) {
+                ex.printStackTrace();
+            }
+            context.stop();
+        }
+        contextDuration.stop();
+        scenario.close();
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
     <module>kie-examples-api</module>
     <module>jbpm-process-svg</module>
     <module>drools-osgi</module>
+    <module>kie-performance-kit</module>
   </modules>
 
   <profiles>


### PR DESCRIPTION
This is kie-performance-kit for performance tests of jbpm engine, remote APIs and other internal tests. It needs to be built together with other modules to be in the Maven repository, so the kit could be used anywhere.

kie-performance-kit: refactoring of executor
kie-performance-kit: Added warmup
kie-performance-kit: added runtimeManagerStrategy
kie-performance-kit: Fixed metrics during warmup
kie-performance-kit: added pessimistic locking and concurrent user count properties
kie-performance-kit: Added CsvSingleReporter and MemoryUsageGaugeSet
kie-performance-kit: extended TestConfig, added support for optional measures MemoryUsage, FileDescriptors and ThreadStates
kie-performance-kit: Format report output