### PR TITLE
[DROOLS-840] upgrade and configure jaxb2-maven-plugin to make it work on JDK8

### DIFF
--- a/kie-remote/kie-remote-jaxb-gen/pom.xml
+++ b/kie-remote/kie-remote-jaxb-gen/pom.xml
@@ -238,8 +238,32 @@
       </plugin>
 
       <plugin>
+        <!-- We use this plugin to ensure that our usage of the
+             jaxb2-maven-plugin is JDK 8 compatible. -->
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>properties-maven-plugin</artifactId>
+        <version>1.0-alpha-2</version>
+        <executions>
+          <execution>
+            <id>set-additional-system-properties</id>
+            <goals>
+              <goal>set-system-properties</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <properties>
+            <property>
+              <name>javax.xml.accessExternalSchema</name>
+              <value>file,http</value>
+            </property>
+          </properties>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>jaxb2-maven-plugin</artifactId>
+        <version>1.6</version>
         <executions>
           <!-- 2. generate xsd's based on unpacked sources -->
           <execution>


### PR DESCRIPTION
* the plugin version should be moved into `kie-parent-metadata` once we decide to merge this. Including it here so that it is easier to review and test the changes.

* tested on JDK 6, 7 and 8

@mrietveld could you please take a look and double check that this change does not break anything?