### PR TITLE
DROOLS-733 - Added tests covering client functionality.

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/JbpmKieServerBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/JbpmKieServerBaseIntegrationTest.java
@@ -38,8 +38,10 @@ public abstract class JbpmKieServerBaseIntegrationTest extends RestJmsSharedBase
 
     protected static final String USER_YODA = "yoda";
     protected static final String USER_JOHN = "john";
+    protected static final String USER_ADMINISTRATOR = "Administrator";
 
     protected static final String PROCESS_ID_USERTASK = "definition-project.usertask";
+    protected static final String PROCESS_ID_EVALUATION = "definition-project.evaluation";
 
     protected ProcessServicesClient processClient;
     protected UserTaskServicesClient taskClient;


### PR DESCRIPTION
Tests verifying exitTask() functionality and and correlation keys.
Shows error in getProcessInstance() method which doesn't return correlation key - test testStartCheckProcessWithCorrelationKey().