### PR TITLE
DROOLS-733 - Fixed nondeterminism in jbpm executor tests.

### DIFF
--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/JobServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/JobServicesClientImpl.java
@@ -117,9 +117,10 @@ public class JobServicesClientImpl extends AbstractKieServicesClientImpl impleme
         if( config.isRest() ) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
             String statusQuery = getAdditionalParams("", "status", statuses);
+            String queryString = getPagingQueryString(statusQuery, page, pageSize);
 
             list = makeHttpGetRequestAndCreateCustomResponse(
-                    build(baseURI, JOB_INSTANCES_GET_URI, valuesMap) + statusQuery, RequestInfoInstanceList.class);
+                    build(baseURI, JOB_INSTANCES_GET_URI, valuesMap) + queryString, RequestInfoInstanceList.class);
 
 
 
@@ -146,8 +147,10 @@ public class JobServicesClientImpl extends AbstractKieServicesClientImpl impleme
             Map<String, Object> valuesMap = new HashMap<String, Object>();
             valuesMap.put(JOB_KEY, businessKey);
 
+            String queryString = getPagingQueryString("", page, pageSize);
+
             list = makeHttpGetRequestAndCreateCustomResponse(
-                    build(baseURI, JOB_INSTANCES_BY_KEY_GET_URI, valuesMap), RequestInfoInstanceList.class);
+                    build(baseURI, JOB_INSTANCES_BY_KEY_GET_URI, valuesMap) + queryString, RequestInfoInstanceList.class);
 
         } else {
             CommandScript script = new CommandScript( Collections.singletonList(
@@ -173,8 +176,10 @@ public class JobServicesClientImpl extends AbstractKieServicesClientImpl impleme
             Map<String, Object> valuesMap = new HashMap<String, Object>();
             valuesMap.put(JOB_CMD_NAME, command);
 
+            String queryString = getPagingQueryString("", page, pageSize);
+
             list = makeHttpGetRequestAndCreateCustomResponse(
-                    build(baseURI, JOB_INSTANCES_BY_CMD_GET_URI, valuesMap), RequestInfoInstanceList.class);
+                    build(baseURI, JOB_INSTANCES_BY_CMD_GET_URI, valuesMap) + queryString, RequestInfoInstanceList.class);
 
         } else {
             CommandScript script = new CommandScript( Collections.singletonList(

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/KieServerDroolsIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/KieServerDroolsIntegrationTest.java
@@ -60,19 +60,6 @@ public class KieServerDroolsIntegrationTest extends RestJmsXstreamSharedBaseInte
     }
 
     @Test
-    public void testGetServerInfo() throws Exception {
-        ServiceResponse<KieServerInfo> reply = client.getServerInfo();
-        Assert.assertEquals(ServiceResponse.ResponseType.SUCCESS, reply.getType());
-        KieServerInfo info = reply.getResult();
-        Assert.assertEquals(getServerVersion(), info.getVersion());
-    }
-
-    private String getServerVersion() {
-        // use the property if specified and fallback to KieServerEnvironment if no property set
-        return System.getProperty("kie.server.version", KieServerEnvironment.getVersion().toString());
-    }
-
-    @Test
     public void testCallContainer() throws Exception {
         client.createContainer("kie1", new KieContainerResource("kie1", releaseId1));
 


### PR DESCRIPTION
I didn't find a way how to get rid of Thread.sleep(), but at least I got rid of nondeterminism caused by timing of job executor.