### PR TITLE
[BZ-1203351] add jbpm-services-cdi into bpms-distribution

### DIFF
--- a/droolsjbpm-bpms-distribution/pom.xml
+++ b/droolsjbpm-bpms-distribution/pom.xml
@@ -110,6 +110,10 @@
     </dependency>
     <dependency>
       <groupId>org.jbpm</groupId>
+      <artifactId>jbpm-services-cdi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jbpm</groupId>
       <artifactId>jbpm-services-ejb-api</artifactId>
     </dependency>
     <dependency>

--- a/droolsjbpm-bpms-distribution/src/main/assembly/pre-bin.xml
+++ b/droolsjbpm-bpms-distribution/src/main/assembly/pre-bin.xml
@@ -36,6 +36,7 @@
         <include>org.jbpm:jbpm-shared-services</include>
         <include>org.jbpm:jbpm-test</include>
         <include>org.jbpm:jbpm-runtime-manager</include>
+        <include>org.jbpm:jbpm-services-cdi</include>
         <include>org.jbpm:jbpm-services-ejb-api</include>
         <include>org.jbpm:jbpm-services-ejb-client</include>
         <include>org.jbpm:jbpm-services-ejb-impl</include>
@@ -85,6 +86,7 @@
         <exclude>org.jbpm:jbpm-shared-services</exclude>
         <exclude>org.jbpm:jbpm-test</exclude>
         <exclude>org.jbpm:jbpm-runtime-manager</exclude>
+        <exclude>org.jbpm:jbpm-services-cdi</exclude>
         <exclude>org.jbpm:jbpm-services-ejb-api</exclude>
         <exclude>org.jbpm:jbpm-services-ejb-client</exclude>
         <exclude>org.jbpm:jbpm-services-ejb-impl</exclude>


### PR DESCRIPTION
* the BZ is already closed as the artifact was manually added into the maven repo, but this should be the proper fix