### PR TITLE
DROOLS-733 - removed close method brought by Java 7

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/KieServerDroolsIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/KieServerDroolsIntegrationTest.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.drools.core.runtime.impl.ExecutionResultImpl;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -66,11 +65,6 @@ public class KieServerDroolsIntegrationTest extends DroolsKieServerBaseIntegrati
 
         File jar = MavenRepository.getMavenRepository().resolveArtifact(releaseId).getFile();
         kjarClassLoader = new URLClassLoader(new URL[]{jar.toURI().toURL()});
-    }
-
-    @AfterClass
-    public static void closeResources() throws Exception {
-        kjarClassLoader.close();
     }
 
     @Override


### PR DESCRIPTION
Fix allowing to run tests on Java 6.

See: 
https://github.com/droolsjbpm/droolsjbpm-integration/commit/2ebc435fd91e32ecf12ca59ddf74ee08a79b6ea8#commitcomment-12723871