### PR TITLE
Readme for org.drools.karaf.itest.

### DIFF
--- a/drools-osgi/drools-karaf-itests/README
+++ b/drools-osgi/drools-karaf-itests/README
@@ -1,0 +1,10 @@
+LIST OF ADDITIONAL JAVA SYSTEM PROPERTIES FOR org.drools.karaf.itest
+
+These additional properties can be used to execute tests against custom karaf
+or karaf like container (for example JBoss FUSE). 
+
+karaf.dist.file - path to karaf distribution file (if not defined, the default karaf is downloaded from maven central)
+karaf.keep.runtime.folder - keep pax exam runtime folder after the test execution is finished
+karaf.maxpermsize - increase the maximal size of PermGen space for karaf container in Java 7
+
+Example: mvn clean install -Dkaraf.dist.file=/path_to_karaf -Dkaraf.keep.runtime.folder -Dkaraf.maxpermsize=512m


### PR DESCRIPTION
PR contains readme for org.drools.karaf.itest. This readme describes Java system properties for running tests on custom karaf or karaf like container.