### PR TITLE
Handle bundle resource naming convention used by Karaf Equinox framework

### DIFF
--- a/drools-osgi/drools-osgi-integration/src/main/java/org/drools/osgi/compiler/OsgiKieModule.java
+++ b/drools-osgi/drools-osgi-integration/src/main/java/org/drools/osgi/compiler/OsgiKieModule.java
@@ -125,7 +125,14 @@ public class OsgiKieModule extends AbstractKieModule {
 
     private static Bundle getBundle(String url) {
         String urlString = url.toString();
-        String id = urlString.substring("bundle://".length(), urlString.indexOf('.'));
+        String id = null;
+        if (urlString.startsWith("bundle://")) {
+            id = urlString.substring("bundle://".length(), urlString.indexOf('.'));
+        } else if (urlString.startsWith("bundleresource://")) {
+            id = urlString.substring("bundleresource://".length(), urlString.indexOf('.'));
+        } else {
+            return null;
+        }
         long bundleId = Long.parseLong(id);
         return FrameworkUtil.getBundle(OsgiKieModule.class).getBundleContext().getBundle(bundleId);
     }

--- a/drools-osgi/drools-osgi-integration/src/main/java/org/drools/osgi/spring/OsgiKModuleBeanFactoryPostProcessor.java
+++ b/drools-osgi/drools-osgi-integration/src/main/java/org/drools/osgi/spring/OsgiKModuleBeanFactoryPostProcessor.java
@@ -40,7 +40,7 @@ public class OsgiKModuleBeanFactoryPostProcessor extends KModuleBeanFactoryPostP
 
     @Override
     protected InternalKieModule createKieModule(KieModuleModel kieProject) {
-        if (!configFileURL.toString().startsWith("bundle:")) {
+        if (!configFileURL.toString().startsWith("bundle:") && !configFileURL.toString().startsWith("bundleresource:")) {
             return super.createKieModule(kieProject);
         }
         return OsgiKieModule.create(configFileURL, releaseId, kieProject);

--- a/kie-spring/src/main/java/org/kie/spring/KModuleBeanFactoryPostProcessor.java
+++ b/kie-spring/src/main/java/org/kie/spring/KModuleBeanFactoryPostProcessor.java
@@ -173,7 +173,7 @@ public class KModuleBeanFactoryPostProcessor implements BeanFactoryPostProcessor
     }
 
     protected InternalKieModule createKieModule(KieModuleModel kieProject) {
-        if (configFileURL.toString().startsWith("bundle:")) {
+        if (configFileURL.toString().startsWith("bundle:") || configFileURL.toString().startsWith("bundleresource:")) {
             return createOsgiKModule(kieProject);
         }
 


### PR DESCRIPTION
Apache Karaf supports 2 OSGi frameworks - Felix and Equinox. I am able to use Drools under Felix framework. But when I use with Equinox, it gives the below exception. It appears that when Drools tries to search for META-INF/kmodule.xml file, Felix returns URL in format "bundle://..." whereas under Equinoix it is of format "bundleresource://...". Submitting this patch to handle the format returned by Equinox classloader as well

2015-09-01 18:10:29,701 | INFO  | 7]-nio2-thread-1 | ServerSession                    | 28 - org.apache.sshd.core - 0.12.0 | Server session created from /0:0:0:0:0:0:0:1:56365
2015-09-01 18:10:29,713 | INFO  | 7]-nio2-thread-3 | ServerSession                    | 28 - org.apache.sshd.core - 0.12.0 | Kex: server->client aes128-ctr hmac-sha1 none
2015-09-01 18:10:29,713 | INFO  | 7]-nio2-thread-3 | ServerSession                    | 28 - org.apache.sshd.core - 0.12.0 | Kex: client->server aes128-ctr hmac-sha1 none
2015-09-01 18:10:29,805 | INFO  | 7]-nio2-thread-4 | ServerUserAuthService            | 28 - org.apache.sshd.core - 0.12.0 | Session karaf@/0:0:0:0:0:0:0:1:56365 authenticated
2015-09-01 18:10:43,393 | INFO  | h for user karaf | FeaturesServiceImpl              | 20 - org.apache.karaf.features.core - 3.0.3 | Installing feature simple-rule 6.2.0.Final
2015-09-01 18:10:43,393 | INFO  | h for user karaf | FeaturesServiceImpl              | 20 - org.apache.karaf.features.core - 3.0.3 | Installing feature drools-module 6.2.0.Final
2015-09-01 18:10:43,393 | INFO  | h for user karaf | FeaturesServiceImpl              | 20 - org.apache.karaf.features.core - 3.0.3 | Installing feature drools-common 6.2.0.Final
2015-09-01 18:10:43,393 | INFO  | h for user karaf | FeaturesServiceImpl              | 20 - org.apache.karaf.features.core - 3.0.3 | Installing feature cxf-specs 2.7.14
2015-09-01 18:10:43,685 | INFO  | h for user karaf | FeaturesServiceImpl              | 20 - org.apache.karaf.features.core - 3.0.3 | Installing feature kie 6.2.0.Final
2015-09-01 18:10:43,690 | INFO  | h for user karaf | FeaturesServiceImpl              | 20 - org.apache.karaf.features.core - 3.0.3 | Installing feature lib 1.0.0-SNAPSHOT
2015-09-01 18:10:43,719 | INFO  | h for user karaf | ClasspathKieProject              | 275 - org.drools.compiler - 6.2.0.201509011753 | Found kmodule: bundleresource://288.fwk259158925/META-INF/kmodule.xml
2015-09-01 18:10:43,720 | INFO  | h for user karaf | ClasspathKieProject              | 275 - org.drools.compiler - 6.2.0.201509011753 | Bundle url: bundleresource://288.fwk259158925/META-INF/kmodule.xml
2015-09-01 18:10:43,723 | ERROR | h for user karaf | ClasspathKieProject              | 275 - org.drools.compiler - 6.2.0.201509011753 | Failure creating a OsgiKieModule caused by: null
java.lang.reflect.InvocationTargetException
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)[:1.7.0_79]
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)[:1.7.0_79]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)[:1.7.0_79]
        at java.lang.reflect.Method.invoke(Method.java:606)[:1.7.0_79]
        at org.drools.compiler.kie.builder.impl.ClasspathKieProject.fetchOsgiKModule(ClasspathKieProject.java:139)
        at org.drools.compiler.kie.builder.impl.ClasspathKieProject.fetchKModule(ClasspathKieProject.java:124)
        at org.drools.compiler.kie.builder.impl.ClasspathKieProject.discoverKieModules(ClasspathKieProject.java:96)
        at org.drools.compiler.kie.builder.impl.ClasspathKieProject.init(ClasspathKieProject.java:68)
        at org.drools.compiler.kie.builder.impl.KieContainerImpl.<init>(KieContainerImpl.java:84)
        at org.drools.compiler.kie.builder.impl.KieServicesImpl.newKieClasspathContainer(KieServicesImpl.java:83)
        at org.drools.example.osgi.CanDrinkRuleOsgiActivator.start(CanDrinkRuleOsgiActivator.java:24)
        at org.eclipse.osgi.framework.internal.core.BundleContextImpl$1.run(BundleContextImpl.java:711)
        at java.security.AccessController.doPrivileged(Native Method)[:1.7.0_79]
        at org.eclipse.osgi.framework.internal.core.BundleContextImpl.startActivator(BundleContextImpl.java:702)
        at org.eclipse.osgi.framework.internal.core.BundleContextImpl.start(BundleContextImpl.java:683)
        at org.eclipse.osgi.framework.internal.core.BundleHost.startWorker(BundleHost.java:381)
        at org.eclipse.osgi.framework.internal.core.AbstractBundle.start(AbstractBundle.java:300)
        at org.eclipse.osgi.framework.internal.core.AbstractBundle.start(AbstractBundle.java:292)
        at org.apache.karaf.features.internal.FeaturesServiceImpl.startBundle(FeaturesServiceImpl.java:501)
        at org.apache.karaf.features.internal.FeaturesServiceImpl.installFeatures(FeaturesServiceImpl.java:459)
        at org.apache.karaf.features.internal.FeaturesServiceImpl.installFeature(FeaturesServiceImpl.java:400)
        at org.apache.karaf.features.internal.FeaturesServiceImpl.installFeature(FeaturesServiceImpl.java:378)
        at Proxy42813755_2a59_4044_9d44_b95eb141959e.installFeature(Unknown Source)
        at org.apache.karaf.features.command.InstallFeatureCommand.doExecute(InstallFeatureCommand.java:67)
        at org.apache.karaf.features.command.FeaturesCommandSupport.doExecute(FeaturesCommandSupport.java:38)
        at org.apache.karaf.shell.console.AbstractAction.execute(AbstractAction.java:33)[25:org.apache.karaf.shell.console:3.0.3]
        at org.apache.karaf.shell.console.OsgiCommandSupport.execute(OsgiCommandSupport.java:39)[25:org.apache.karaf.shell.console:3.0.3]
        at org.apache.karaf.shell.commands.basic.AbstractCommand.execute(AbstractCommand.java:33)[25:org.apache.karaf.shell.console:3.0.3]
        at Proxy832d7b21_5d00_4e48_95a2_02063b8fd3b3.execute(Unknown Source)[:]
        at Proxy832d7b21_5d00_4e48_95a2_02063b8fd3b3.execute(Unknown Source)[:]
        at org.apache.felix.gogo.runtime.CommandProxy.execute(CommandProxy.java:78)[25:org.apache.karaf.shell.console:3.0.3]
        at org.apache.felix.gogo.runtime.Closure.executeCmd(Closure.java:477)[25:org.apache.karaf.shell.console:3.0.3]
        at org.apache.felix.gogo.runtime.Closure.executeStatement(Closure.java:403)[25:org.apache.karaf.shell.console:3.0.3]
        at org.apache.felix.gogo.runtime.Pipe.run(Pipe.java:108)[25:org.apache.karaf.shell.console:3.0.3]
        at org.apache.felix.gogo.runtime.Closure.execute(Closure.java:183)[25:org.apache.karaf.shell.console:3.0.3]
        at org.apache.felix.gogo.runtime.Closure.execute(Closure.java:120)[25:org.apache.karaf.shell.console:3.0.3]
        at org.apache.felix.gogo.runtime.CommandSessionImpl.execute(CommandSessionImpl.java:92)
        at org.apache.karaf.shell.console.impl.jline.ConsoleImpl.run(ConsoleImpl.java:208)
        at org.apache.karaf.shell.ssh.ShellFactoryImpl$ShellImpl$1.runConsole(ShellFactoryImpl.java:158)[251:org.apache.karaf.shell.ssh:3.0.3]
        at org.apache.karaf.shell.ssh.ShellFactoryImpl$ShellImpl$1$1.run(ShellFactoryImpl.java:133)
        at java.security.AccessController.doPrivileged(Native Method)[:1.7.0_79]
        at org.apache.karaf.jaas.modules.JaasHelper.doAs(JaasHelper.java:57)[26:org.apache.karaf.jaas.modules:3.0.3]
        at org.apache.karaf.shell.ssh.ShellFactoryImpl$ShellImpl$1.run(ShellFactoryImpl.java:129)[251:org.apache.karaf.shell.ssh:3.0.3]
Caused by: java.lang.NumberFormatException: For input string: "ource://288"
        at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)[:1.7.0_79]
        at java.lang.Long.parseLong(Long.java:441)[:1.7.0_79]
        at java.lang.Long.parseLong(Long.java:483)[:1.7.0_79]
        at org.drools.osgi.compiler.OsgiKieModule.getBundle(OsgiKieModule.java:114)
        at org.drools.osgi.compiler.OsgiKieModule.create(OsgiKieModule.java:83)
        ... 43 more