### PR TITLE
DROOLS-733 - added removing services when disposing container, other small fixes

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/api/KieServerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/api/KieServerExtension.java
@@ -30,7 +30,7 @@ public interface KieServerExtension {
 
     void createContainer(String id, KieContainerInstance kieContainerInstance, Map<String, Object> parameters);
 
-    void disposeContainer(String id, Map<String, Object> parameters);
+    void disposeContainer(String id, KieContainerInstance kieContainerInstance, Map<String, Object> parameters);
 
     List<Object> getAppComponents(SupportedTransports type);
 

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerContainerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerContainerExtension.java
@@ -53,7 +53,7 @@ public class KieServerContainerExtension implements KieServerExtension {
     }
 
     @Override
-    public void disposeContainer(String id, Map<String, Object> parameters) {
+    public void disposeContainer(String id, KieContainerInstance kieContainerInstance, Map<String, Object> parameters) {
         // no-op
     }
 

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
@@ -299,7 +299,7 @@ public class KieServerImpl {
                             // process server extensions
                             List<KieServerExtension> extensions = context.getServerExtensions();
                             for (KieServerExtension extension : extensions) {
-                                extension.disposeContainer(containerId, new HashMap<String, Object>());
+                                extension.disposeContainer(containerId, kci, new HashMap<String, Object>());
                                 logger.debug("Container {} (for release id {}) {} shutdown: DONE", containerId, kci.getResource().getReleaseId(), extension);
                                 disposedExtensions.add(extension);
                             }

--- a/kie-server-parent/kie-server-services/kie-server-services-drools/src/main/java/org/kie/server/services/drools/DroolsKieServerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-drools/src/main/java/org/kie/server/services/drools/DroolsKieServerExtension.java
@@ -115,8 +115,8 @@ public class DroolsKieServerExtension implements KieServerExtension {
     }
 
     @Override
-    public void disposeContainer(String id, Map<String, Object> parameters) {
-        // no-op?
+    public void disposeContainer(String id, KieContainerInstance kieContainerInstance, Map<String, Object> parameters) {
+        kieContainerInstance.removeService(batchCommandService.getClass());
     }
 
     @Override

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/jpa/PersistenceUnitInfoImpl.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/jpa/PersistenceUnitInfoImpl.java
@@ -78,6 +78,9 @@ public class PersistenceUnitInfoImpl implements PersistenceUnitInfo {
 
     @Override
     public DataSource getJtaDataSource() {
+        if (jtaDataSource == null) {
+            return null;
+        }
         try {
             return (DataSource) initialContext.lookup(jtaDataSource);
         } catch (NamingException e) {
@@ -87,6 +90,9 @@ public class PersistenceUnitInfoImpl implements PersistenceUnitInfo {
 
     @Override
     public DataSource getNonJtaDataSource() {
+        if (nonJtaDataSource == null) {
+            return null;
+        }
         try {
             return (DataSource) initialContext.lookup(nonJtaDataSource);
         } catch (NamingException e) {

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/pom.xml
@@ -149,7 +149,7 @@
               <systemProperties>
                 <org.jbpm.server.ext.disabled>true</org.jbpm.server.ext.disabled>
                 <org.drools.server.ext.disabled>true</org.drools.server.ext.disabled>
-                <org.kie.server.controller>${kie.server.controller.context.http.url}</org.kie.server.controller>
+                <org.kie.server.controller>${kie.server.controller.base.http.url}</org.kie.server.controller>
                 <org.kie.server.location>${kie.server.base.http.url}</org.kie.server.location>
                 <org.kie.server.controller.user>yoda</org.kie.server.controller.user>
                 <org.kie.server.controller.pwd>usetheforce123@</org.kie.server.controller.pwd>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/JobServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/JobServiceIntegrationTest.java
@@ -115,8 +115,9 @@ public class JobServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest 
         jobServicesClient.cancelRequest(jobId);
         jobRequest = jobServicesClient.getRequestById(jobId, false, false);
 
-        // If job finished before we canceled it then create new job and cancel it.
-        if(STATUS.DONE.toString().equals(jobRequest.getStatus())) {
+        // If job finished before we canceled it or already running then create new job and cancel it.
+        if(STATUS.DONE.toString().equals(jobRequest.getStatus()) ||
+                STATUS.RUNNING.toString().equals(jobRequest.getStatus())) {
             jobId = jobServicesClient.scheduleRequest(jobRequestInstance);
 
             jobServicesClient.cancelRequest(jobId);

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -26,7 +26,6 @@
     <kie.server.context>kie-server-services</kie.server.context>
     <kie.server.controller.context>kie-server-controller-services</kie.server.controller.context>
     <kie.server.base.http.url>http://${container.hostname}:${container.port}/${kie.server.context}/services/rest/server</kie.server.base.http.url>
-    <kie.server.controller.context.http.url>http://${container.hostname}:${container.port}/${kie.server.controller.context}</kie.server.controller.context.http.url>
     <kie.server.controller.base.http.url>http://${container.hostname}:${container.port}/${kie.server.controller.context}/controller</kie.server.controller.base.http.url>
     <kie.server.testing.server.local.repo.dir>${project.build.directory}/kie-server-testing-server-local-repo</kie.server.testing.server.local.repo.dir>
     <kie.server.testing.remote.repo.dir>${project.build.directory}/kie-server-testing-remote-repo</kie.server.testing.remote.repo.dir>

--- a/kie-server-parent/kie-server-wars/kie-server/src/main/shared-ee6-ee7-resources/WEB-INF/weblogic-ejb-jar.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/src/main/shared-ee6-ee7-resources/WEB-INF/weblogic-ejb-jar.xml
@@ -17,8 +17,8 @@
   <weblogic-enterprise-bean>
     <ejb-name>KieExecutorMDB</ejb-name>
     <message-driven-descriptor>
-      <destination-jndi-name>jms/KIE.EXECUTOR</destination-jndi-name>
-      <connection-factory-jndi-name>jms/cf/KIE.EXECUTOR</connection-factory-jndi-name>
+      <destination-jndi-name>jms/KIE.SERVER.EXECUTOR</destination-jndi-name>
+      <connection-factory-jndi-name>jms/cf/KIE.SERVER.EXECUTOR</connection-factory-jndi-name>
     </message-driven-descriptor>
   </weblogic-enterprise-bean>
 


### PR DESCRIPTION
PersistenceUnitInfoImpl changes done because Hibernate in Ejb3Configuration class stores content of persistence unit info into log when debugging enabled (see LogHelper.logPersistenceUnitInfo(info)). 
There are invoked getJtaDataSource and getNonJtaDataSource which caused issues as they aren't set or contain default value.

Just a suggestions for fix, feel free to improve/make better.

<kie.server.controller.context.http.url> removed as it isn't needed after unification of controller URL.