### PR TITLE
BZ-1250323 - Not able to register KIE server if we use https protocol

### DIFF
--- a/kie-remote/kie-remote-common/src/main/java/org/kie/remote/common/rest/KieRemoteHttpRequest.java
+++ b/kie-remote/kie-remote-common/src/main/java/org/kie/remote/common/rest/KieRemoteHttpRequest.java
@@ -851,6 +851,19 @@ public class KieRemoteHttpRequest {
             } else {
                 connection = CONNECTION_FACTORY.create(getRequestInfo().getRequestUrl());
             }
+            // support for localhost and https
+            if (getRequestInfo().getRequestUrl().getProtocol().equalsIgnoreCase("https") && getRequestInfo().getRequestUrl().getHost().equalsIgnoreCase("localhost")) {
+                ((HttpsURLConnection) connection).setHostnameVerifier(new HostnameVerifier(){
+
+                    public boolean verify(String hostname, javax.net.ssl.SSLSession sslSession) {
+                        if (hostname.equalsIgnoreCase("localhost")) {
+                            return true;
+                        }
+                        return false;
+                    }
+                });
+            }
+
             connection.setRequestMethod(getRequestInfo().requestMethod);
             return connection;
         } catch( IOException ioe ) {


### PR DESCRIPTION
extension to KieRemoteHttpRequest to allow use of kie server client over https/ssl when running on localhost.

@mrietveld what do you think? is this a valid addon? it does certainly help when kie server client runs within workbench where users cannot set globally the host name verifier and thus cannot use workbench and kie server on localhost over https.
I believe (though have not tested) use of hostname instead of localhost might be a workaround as well for local machine, but it might be more tricky than it sounds.