### PR TITLE
DROOLS-733 - fixed NPE when looking for nonexisting process definition

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/RuntimeDataServiceBase.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/RuntimeDataServiceBase.java
@@ -505,6 +505,10 @@ public class RuntimeDataServiceBase {
     }
 
     protected org.kie.server.api.model.instance.ProcessInstance convertToProcessInstance(ProcessInstanceDesc pi) {
+        if (pi == null) {
+            return null;
+        }
+
         org.kie.server.api.model.instance.ProcessInstance instance = org.kie.server.api.model.instance.ProcessInstance.builder()
                 .id(pi.getId())
                 .processId(pi.getProcessId())
@@ -561,6 +565,9 @@ public class RuntimeDataServiceBase {
     }
 
     protected org.kie.server.api.model.definition.ProcessDefinition convertToProcess(ProcessDefinition processDesc) {
+        if (processDesc == null) {
+            return null;
+        }
 
         org.kie.server.api.model.definition.ProcessDefinition processDefinition = org.kie.server.api.model.definition.ProcessDefinition.builder()
                 .id(processDesc.getId())

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/RuntimeDataServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/RuntimeDataServiceIntegrationTest.java
@@ -234,12 +234,17 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     }
 
-    @Test(expected = KieServicesException.class)
+    @Test
     public void testGetProcessDefinitionByContainerAndNonExistingId() throws Exception {
         assertSuccess(client.createContainer("definition-project", new KieContainerResource("definition-project", releaseId)));
 
-        queryClient.findProcessByContainerIdProcessId("definition-project", "non-existing");
+        try {
+            queryClient.findProcessByContainerIdProcessId("definition-project", "non-existing");
+            fail("KieServicesException should be thrown complaining about process definition not found.");
 
+        } catch (KieServicesException e) {
+            assertResultContainsString(e.getMessage(), "Could not find process definition \"non-existing\" in container \"definition-project\"");
+        }
     }
 
     @Test
@@ -484,12 +489,17 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
         }
     }
 
-    @Test(expected = KieServicesException.class)
+    @Test
     public void testGetProcessInstanceByNonExistingId() throws Exception {
         assertSuccess(client.createContainer("definition-project", new KieContainerResource("definition-project", releaseId)));
 
-        queryClient.findProcessInstanceById(-9999l);
+        try {
+            queryClient.findProcessInstanceById(-9999l);
+            fail("KieServicesException should be thrown complaining about process instance not found.");
 
+        } catch (KieServicesException e) {
+            assertResultContainsString(e.getMessage(), "Could not find process instance with id");
+        }
     }
 
     @Test


### PR DESCRIPTION
One small thing found, error returned in testGetProcessDefinitionByContainerAndNonExistingId test has response code 500, I think some 4xx should be better in this case.
