### PR TITLE
DROOLS-733 - extended processing time for JMS job executor

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/JobServiceJmsIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/JobServiceJmsIntegrationTest.java
@@ -44,7 +44,7 @@ public class JobServiceJmsIntegrationTest extends JbpmKieServerBaseIntegrationTe
             "1.0.0.Final");
 
     private static final long NUMBER_OF_JOBS = 10;
-    private static final long MAXIMUM_PROCESSING_TIME = 2000;
+    private static final long MAXIMUM_PROCESSING_TIME = 5000;
     private static final String CONTAINER_ID = "definition-project";
     private static final long SERVICE_TIMEOUT = 2000;
     private static final long TIMEOUT_BETWEEN_CALLS = 100;


### PR DESCRIPTION
This test can become nondeterministic on slower computers/using slower containers like WLS.
For example running this test on WLS using JMS configuration for kie server client results in durationTime value around 1700ms which is quite close to the limit.
For predicable results I suggest to raise processing time limit to some safer value, like 5000ms.

What do you think?

It is a small change, I suggest to add it to some other commit to avoid branch spamming.