### PR TITLE
DROOLS-925 - fixed cannot deploy kie-server on wildfly 10.x.x

### DIFF
--- a/kie-server-parent/kie-server-wars/kie-server/src/main/shared-ee6-ee7-resources/META-INF/kie-server-jms.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/src/main/shared-ee6-ee7-resources/META-INF/kie-server-jms.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<messaging-deployment xmlns="urn:jboss:messaging-deployment:1.0">
-  <hornetq-server>
+<messaging-deployment xmlns="urn:jboss:messaging-activemq-deployment:1.0">
+  <server>
     <jms-destinations>
 
       <!-- Kie Server REQUEST queue -->
@@ -21,5 +21,5 @@
       </jms-queue>
 
     </jms-destinations>
-  </hornetq-server>
+  </server>
 </messaging-deployment>


### PR DESCRIPTION
DROOLS-925 - fixed cannot deploy kie-server on wildfly 10.x.x due to HornetQ is to be deprecated.