### PR TITLE
replaced javax.security.jacc

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-common/pom.xml
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/pom.xml
@@ -63,8 +63,8 @@
 
     <!-- security -->
     <dependency>
-      <groupId>javax.security.jacc</groupId>
-      <artifactId>javax.security.jacc-api</artifactId>
+      <groupId>org.jboss.spec.javax.security.jacc</groupId>
+      <artifactId>jboss-jacc-api_1.4_spec</artifactId>
     </dependency>
 
     <!-- Needed by aether-http stuff, but mistakenly excluded in assemblies so adding it here explicitly -->

--- a/kie-server-parent/kie-server-wars/kie-server/pom.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/pom.xml
@@ -31,8 +31,8 @@
           <artifactId>javax.servlet-api</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>javax.security.jacc</groupId>
-          <artifactId>javax.security.jacc-api</artifactId>
+          <groupId>org.jboss.spec.javax.security.jacc</groupId>
+          <artifactId>jboss-jacc-api_1.4_spec</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.slf4j</groupId>


### PR DESCRIPTION
replaced javax.security.jacc:javax.security.jacc-api by org.jboss.spec.javax.security.jacc:jboss-jacc-api_1.4_spec used in jboss-ip-bom