### PR TITLE
DROOLS-733 - controller tests - added kie server synchronization waiting loop

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerIntegrationTest.java
@@ -332,6 +332,7 @@ public class KieControllerIntegrationTest extends KieControllerBaseTest {
         assertEquals(KieContainerStatus.STARTED, containerResponseEntity.getStatus());
 
         // Check that container is deployed in kie server.
+        waitForKieServerSynchronization(1);
         containerInfo = client.getContainerInfo(CONTAINER_ID);
         assertEquals(ServiceResponse.ResponseType.SUCCESS, containerInfo.getType());
         assertEquals(CONTAINER_ID, containerInfo.getResult().getContainerId());
@@ -347,6 +348,7 @@ public class KieControllerIntegrationTest extends KieControllerBaseTest {
         assertEquals(KieContainerStatus.STOPPED, containerResponseEntity.getStatus());
 
         // Check that container is not deployed in kie server (as container is in STOPPED state).
+        waitForKieServerSynchronization(0);
         containerInfo = client.getContainerInfo(CONTAINER_ID);
         assertEquals(ServiceResponse.ResponseType.FAILURE, containerInfo.getType());
         assertResultContainsString(containerInfo.getMsg(), "Container " + CONTAINER_ID + " is not instantiated.");

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerStartupIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerStartupIntegrationTest.java
@@ -186,6 +186,7 @@ public class KieControllerStartupIntegrationTest extends KieControllerBaseTest {
         controllerClient.startContainer(kieServerInfo.getResult().getServerId(), CONTAINER_ID);
 
         // Check that there is one container deployed.
+        waitForKieServerSynchronization(1);
         ServiceResponse<KieContainerResourceList> containersList = client.listContainers();
         assertEquals(ServiceResponse.ResponseType.SUCCESS, containersList.getType());
         assertNotNull(containersList.getResult().getContainers());


### PR DESCRIPTION
When kie server controller is deployed as part of workbench then synchronization with kie server is handled asynchronously with KieServerWBControllerAdminImpl [1]
This may cause issues in tests as some tests relies on immediate synchronization.
This PR brings waiting loop which assures that synchronization changes are applied before continuing with test execution.


[1] https://github.com/droolsjbpm/kie-wb-common/blob/559deda7566874795c5f986f11cbe31699edf2f1/kie-wb-common-screens/kie-wb-common-server-ui/kie-wb-common-server-ui-backend/src/main/java/org/kie/workbench/common/screens/server/management/backend/KieServerWBControllerAdminImpl.java