### PR TITLE
Karaf version is detected using Maven.

### DIFF
--- a/drools-osgi/drools-karaf-itests/README
+++ b/drools-osgi/drools-karaf-itests/README
@@ -4,6 +4,8 @@ These additional properties can be used to execute tests against custom karaf
 or karaf like container (for example JBoss FUSE). 
 
 karaf.dist.file - path to karaf distribution file (if not defined, the default karaf is downloaded from maven central)
+karafVersion - Version of Karaf container. This parameter is mandatory when a custom Karaf distribution file is specified.
+                (for example Jboss Fuse 6.2. uses Karaf container version 2.4.0)
 karaf.keep.runtime.folder - keep pax exam runtime folder after the test execution is finished
 karaf.maxpermsize - increase the maximal size of PermGen space for karaf container in Java 7
 karaf.osgi.framework - specifies base OSGi framework for Karaf (e.g. felix or equinox)

--- a/drools-osgi/drools-karaf-itests/README
+++ b/drools-osgi/drools-karaf-itests/README
@@ -4,7 +4,7 @@ These additional properties can be used to execute tests against custom karaf
 or karaf like container (for example JBoss FUSE). 
 
 karaf.dist.file - path to karaf distribution file (if not defined, the default karaf is downloaded from maven central)
-karafVersion - Version of Karaf container. This parameter is mandatory when a custom Karaf distribution file is specified.
+karaf.version - Version of Karaf container. This parameter is mandatory when a custom Karaf distribution file is specified.
                 (for example Jboss Fuse 6.2. uses Karaf container version 2.4.0)
 karaf.keep.runtime.folder - keep pax exam runtime folder after the test execution is finished
 karaf.maxpermsize - increase the maximal size of PermGen space for karaf container in Java 7

--- a/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/AbstractKarafIntegrationTest.java
+++ b/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/AbstractKarafIntegrationTest.java
@@ -51,7 +51,7 @@ abstract public class AbstractKarafIntegrationTest {
      * Karaf distribution file is specified (for example Jboss Fuse 6.2.
      * uses Karaf container version 2.4.0).
      */
-    public static final String PROP_KARAF_VERSION = "karafVersion";
+    public static final String PROP_KARAF_VERSION = "karaf.version";
     
     /**
      * Maximal size of perm gen memory. For example "512M". This property
@@ -115,7 +115,7 @@ abstract public class AbstractKarafIntegrationTest {
         if (karafVersion == null) {
             if(System.getProperty(PROP_KARAF_DISTRIBUTION_FILE) != null) {
                 throw new RuntimeException("When you are running against custom container "
-                        + "it is necessary to define Karaf version by defining system property karafVersion.");
+                        + "it is necessary to define Karaf version by defining system property karaf.version.");
             }
             
             // set the Karaf version defined by Maven


### PR DESCRIPTION
Karaf version is detected using Maven. Previously there was constant 2.4.2 in the code. The user has to specify a version of Karaf container in the case he wants to test against custom Karaf container.