### PR TITLE
DROOLS-733 - Updated Javadoc and kie server client timeout

### DIFF
--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/KieServicesFactory.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/KieServicesFactory.java
@@ -41,10 +41,10 @@ public class KieServicesFactory {
      * @param serverUrl the URL to the server (e.g.: "http://localhost:8080")
      * @param login user login
      * @param password user password
-     * @param timeout the maximum timeout in seconds
+     * @param timeout the maximum timeout in milliseconds
      * @return configuration instance
      */
-    public static KieServicesConfiguration newRestConfiguration( String serverUrl, String login, String password, int timeout ) {
+    public static KieServicesConfiguration newRestConfiguration( String serverUrl, String login, String password, long timeout ) {
         return new KieServicesConfigurationImpl( serverUrl, login, password, timeout );
     }
 

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/KieServicesConfigurationImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/KieServicesConfigurationImpl.java
@@ -81,7 +81,7 @@ public final class KieServicesConfigurationImpl
      * @param url
      * @param username
      * @param password
-     * @param timeoutInSecs
+     * @param timeout the maximum timeout in milliseconds
      */
     public KieServicesConfigurationImpl(String url, String username, String password, long timeout) {
         this.transport = Transport.REST;


### PR DESCRIPTION
Corrected Javadoc for kie server client.
Changed timeout type to be consistent between KieServicesFactory and KieServicesConfigurationImpl.