### PR TITLE
DROOLS-733 - Extended tests to support Oracle database

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/RuntimeDataServiceBase.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/RuntimeDataServiceBase.java
@@ -91,11 +91,11 @@ public class RuntimeDataServiceBase {
         if (processName != null && !processName.isEmpty()) {
             logger.debug("About to search for process instances with process name '{}' with page {} and page size {}", processName, page, pageSize);
 
-            instances = runtimeDataService.getProcessInstancesByProcessName(status, processName, nullEmpty(initiator), buildQueryContext(page, pageSize));
+            instances = runtimeDataService.getProcessInstancesByProcessName(status, processName, nullEmpty(initiator), buildQueryContext(page, pageSize, "ProcessInstanceId", true));
             logger.debug("Found {} process instances for process name '{}', statuses '{}'", instances.size(), processName, status);
         } else {
             logger.debug("About to search for process instances with page {} and page size {}", page, pageSize);
-            instances = runtimeDataService.getProcessInstances(status, nullEmpty(initiator), buildQueryContext(page, pageSize));
+            instances = runtimeDataService.getProcessInstances(status, nullEmpty(initiator), buildQueryContext(page, pageSize, "ProcessInstanceId", true));
 
             logger.debug("Found {} process instances , statuses '{}'", instances.size(), status);
         }
@@ -113,7 +113,7 @@ public class RuntimeDataServiceBase {
         }
         logger.debug("About to search for process instances with process id '{}' with page {} and page size {}", processId, page, pageSize);
 
-        Collection<ProcessInstanceDesc> instances = runtimeDataService.getProcessInstancesByProcessId(status, processId, nullEmpty(initiator), buildQueryContext(page, pageSize));
+        Collection<ProcessInstanceDesc> instances = runtimeDataService.getProcessInstancesByProcessId(status, processId, nullEmpty(initiator), buildQueryContext(page, pageSize, "ProcessInstanceId", true));
         logger.debug("Found {} process instance for process id '{}', statuses '{}'", instances.size(), processId, status);
 
         ProcessInstanceList processInstanceList = convertToProcessInstanceList(instances);
@@ -131,7 +131,7 @@ public class RuntimeDataServiceBase {
         }
         logger.debug("About to search for process instance belonging to container '{}' with page {} and page size {}", containerId, page, pageSize);
 
-        Collection<ProcessInstanceDesc> instances = runtimeDataService.getProcessInstancesByDeploymentId(containerId, status, buildQueryContext(page, pageSize));
+        Collection<ProcessInstanceDesc> instances = runtimeDataService.getProcessInstancesByDeploymentId(containerId, status, buildQueryContext(page, pageSize, "ProcessInstanceId", true));
         logger.debug("Found {} process instance for container '{}', statuses '{}'", instances.size(), containerId, status);
 
         ProcessInstanceList processInstanceList = convertToProcessInstanceList(instances);
@@ -147,7 +147,7 @@ public class RuntimeDataServiceBase {
 
         CorrelationKey actualCorrelationKey = correlationKeyFactory.newCorrelationKey(Arrays.asList(correlationProperties));
 
-        Collection<ProcessInstanceDesc> instances = runtimeDataService.getProcessInstancesByCorrelationKey(actualCorrelationKey, buildQueryContext(page, pageSize));
+        Collection<ProcessInstanceDesc> instances = runtimeDataService.getProcessInstancesByCorrelationKey(actualCorrelationKey, buildQueryContext(page, pageSize, "ProcessInstanceId", true));
 
         ProcessInstanceList processInstanceList = convertToProcessInstanceList(instances);
         logger.debug("Returning result of process instance search: {}", processInstanceList);
@@ -176,12 +176,12 @@ public class RuntimeDataServiceBase {
         if (variableValue != null && !variableValue.isEmpty()) {
             logger.debug("About to search for process instance that has variable '{}' with value '{}' with page {} and page size {}", variableName, variableValue, page, pageSize);
 
-            instances = runtimeDataService.getProcessInstancesByVariableAndValue(variableName, variableValue, status, buildQueryContext(page, pageSize));
+            instances = runtimeDataService.getProcessInstancesByVariableAndValue(variableName, variableValue, status, buildQueryContext(page, pageSize, "ProcessInstanceId", true));
             logger.debug("Found {} process instance with variable {} and variable value {}", instances.size(), variableName, variableValue);
         } else {
             logger.debug("About to search for process instance that has variable '{}' with page {} and page size {}", variableName, page, pageSize);
 
-            instances = runtimeDataService.getProcessInstancesByVariable(variableName, status, buildQueryContext(page, pageSize));
+            instances = runtimeDataService.getProcessInstancesByVariable(variableName, status, buildQueryContext(page, pageSize, "ProcessInstanceId", true));
             logger.debug("Found {} process instance with variable {} ", instances.size(), variableName);
         }
 
@@ -465,7 +465,7 @@ public class RuntimeDataServiceBase {
     public TaskEventInstanceList getTaskEvents(long taskId, Integer page, Integer pageSize) {
 
         logger.debug("About to search for task {} events", taskId);
-        List<TaskEvent> tasks = runtimeDataService.getTaskEvents(taskId, buildQueryFilter(page, pageSize));
+        List<TaskEvent> tasks = runtimeDataService.getTaskEvents(taskId, buildQueryFilter(page, pageSize, "Id", true));
 
 
         logger.debug("Found {} task events available for task '{}'", tasks.size(), taskId);
@@ -600,6 +600,9 @@ public class RuntimeDataServiceBase {
         return new QueryFilter(page * pageSize, pageSize);
     }
 
+    protected QueryFilter buildQueryFilter(Integer page, Integer pageSize, String orderBy, boolean asc) {
+        return new QueryFilter(page * pageSize, pageSize, orderBy, asc);
+    }
 
     protected List<Status> buildTaskStatuses(List<String> status) {
         if (status == null || status.isEmpty()) {

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/JobServiceJmsIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/JobServiceJmsIntegrationTest.java
@@ -44,7 +44,7 @@ public class JobServiceJmsIntegrationTest extends JbpmKieServerBaseIntegrationTe
             "1.0.0.Final");
 
     private static final long NUMBER_OF_JOBS = 10;
-    private static final long MAXIMUM_PROCESSING_TIME = 5000;
+    private static final long MAXIMUM_PROCESSING_TIME = 10000;
     private static final String CONTAINER_ID = "definition-project";
     private static final long SERVICE_TIMEOUT = 2000;
     private static final long TIMEOUT_BETWEEN_CALLS = 100;
@@ -98,7 +98,7 @@ public class JobServiceJmsIntegrationTest extends JbpmKieServerBaseIntegrationTe
         }
         long durationTime = Calendar.getInstance().getTimeInMillis() - startTime;
 
-        // All jobs should be processed and done in less than 1 s.
+        // All jobs should be processed and done in less than 10 s.
         assertTrue("Job processing exceeded expected time!", durationTime < MAXIMUM_PROCESSING_TIME);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerBaseIntegrationTest.java
@@ -388,6 +388,12 @@ public abstract class KieServerBaseIntegrationTest {
         }
     }
 
+    protected static void assertNullOrEmpty(String result ) {
+        if (result != null) {
+            assertTrue("String is not empty.", result.isEmpty());
+        }
+    }
+
     protected static KieServicesConfiguration createKieServicesJmsConfiguration() {
         try {
             InitialContext context = TestConfig.getInitialRemoteContext();

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/BARuntimeDataServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/BARuntimeDataServiceIntegrationTest.java
@@ -74,7 +74,7 @@ public class BARuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegr
             TaskSummary taskInstance = tasks.get(0);
             assertNotNull(taskInstance);
             assertEquals("First task", taskInstance.getName());
-            assertEquals("", taskInstance.getDescription());
+            assertNullOrEmpty(taskInstance.getDescription());
             assertEquals("Reserved", taskInstance.getStatus());
             assertEquals(0, taskInstance.getPriority().intValue());
             assertEquals("yoda", taskInstance.getActualOwner());

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/JbpmKieServerBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/JbpmKieServerBaseIntegrationTest.java
@@ -82,9 +82,9 @@ public abstract class JbpmKieServerBaseIntegrationTest extends RestJmsSharedBase
         } else {
             configuration.setMarshallingFormat(marshallingFormat);
             configuration.addJaxbClasses(new HashSet<Class<?>>(extraClasses.values()));
+            configuration.setTimeout(15000);
             kieServicesClient =  KieServicesFactory.newKieServicesClient(configuration, kieContainer.getClassLoader());
         }
-        configuration.setTimeout(5000);
         setupClients(kieServicesClient);
 
         return kieServicesClient;

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/JobServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/JobServiceIntegrationTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
+import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kie.api.KieServices;
@@ -52,6 +53,19 @@ public class JobServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest 
         buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project").getFile());
 
         kieContainer = KieServices.Factory.get().newKieContainer(releaseId);
+    }
+
+    @After
+    public void finishAllJobs() throws Exception {
+        List<String> status = new ArrayList<String>();
+        status.add(STATUS.QUEUED.toString());
+        status.add(STATUS.RUNNING.toString());
+        status.add(STATUS.RETRYING.toString());
+        List<RequestInfoInstance> requests = jobServicesClient.getRequestsByStatus(status, 0, 100);
+        for (RequestInfoInstance instance : requests) {
+            jobServicesClient.cancelRequest(instance.getId());
+            waitForJobToFinish(instance.getId());
+        }
     }
 
     @Override

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/RuntimeDataServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/RuntimeDataServiceIntegrationTest.java
@@ -453,7 +453,7 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
             assertEquals("1.0", instance.getProcessVersion());
             assertEquals("yoda", instance.getInitiator());
             assertEquals("definition-project", instance.getContainerId());
-            assertEquals("", instance.getCorrelationKey());
+            assertNullOrEmpty(instance.getCorrelationKey());
             assertEquals("evaluation", instance.getProcessInstanceDescription());
             assertEquals(-1, instance.getParentId().longValue());
         } finally {
@@ -738,14 +738,14 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
                 if ("personData".equals(variableInstance.getVariableName())) {
                     assertNotNull(variableInstance);
                     assertEquals(processInstanceId, variableInstance.getProcessInstanceId());
-                    assertEquals("", variableInstance.getOldValue());
+                    assertNullOrEmpty(variableInstance.getOldValue());
                     assertEquals("Person{name='john'}", variableInstance.getValue());
                     assertEquals("personData", variableInstance.getVariableName());
                 } else if ("stringData".equals(variableInstance.getVariableName())) {
 
                     assertNotNull(variableInstance);
                     assertEquals(processInstanceId, variableInstance.getProcessInstanceId());
-                    assertEquals("", variableInstance.getOldValue());
+                    assertNullOrEmpty(variableInstance.getOldValue());
                     assertEquals("waiting for signal", variableInstance.getValue());
                     assertEquals("stringData", variableInstance.getVariableName());
                 } else {
@@ -760,7 +760,7 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
             VariableInstance variableInstance = varHistory.get(0);
             assertNotNull(variableInstance);
             assertEquals(processInstanceId, variableInstance.getProcessInstanceId());
-            assertEquals("", variableInstance.getOldValue());
+            assertNullOrEmpty(variableInstance.getOldValue());
             assertEquals("waiting for signal", variableInstance.getValue());
             assertEquals("stringData", variableInstance.getVariableName());
 
@@ -773,7 +773,7 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
             variableInstance = currentState.get(0);
             assertNotNull(variableInstance);
             assertEquals(processInstanceId, variableInstance.getProcessInstanceId());
-            assertEquals("", variableInstance.getOldValue());
+            assertNullOrEmpty(variableInstance.getOldValue());
             assertEquals("Person{name='john'}", variableInstance.getValue());
             assertEquals("personData", variableInstance.getVariableName());
 
@@ -799,7 +799,7 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
             variableInstance = varHistory.get(1);
             assertNotNull(variableInstance);
             assertEquals(processInstanceId, variableInstance.getProcessInstanceId());
-            assertEquals("", variableInstance.getOldValue());
+            assertNullOrEmpty(variableInstance.getOldValue());
             assertEquals("waiting for signal", variableInstance.getValue());
             assertEquals("stringData", variableInstance.getVariableName());
 
@@ -827,7 +827,7 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
             TaskSummary taskInstance = tasks.get(0);
             assertNotNull(taskInstance);
             assertEquals("First task", taskInstance.getName());
-            assertEquals("", taskInstance.getDescription());
+            assertNullOrEmpty(taskInstance.getDescription());
             assertEquals("Reserved", taskInstance.getStatus());
             assertEquals(0, taskInstance.getPriority().intValue());
             assertEquals("yoda", taskInstance.getActualOwner());
@@ -840,7 +840,7 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
             TaskInstance taskById = taskClient.findTaskById(taskInstance.getId());
             assertNotNull(taskById);
             assertEquals("First task", taskById.getName());
-            assertEquals("", taskById.getDescription());
+            assertNullOrEmpty(taskById.getDescription());
             assertEquals("Reserved", taskById.getStatus());
             assertEquals(0, taskById.getPriority().intValue());
             assertEquals("yoda", taskById.getActualOwner());
@@ -856,7 +856,7 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
             taskById = taskClient.findTaskByWorkItemId(workItems.get(0).getId());
             assertNotNull(taskById);
             assertEquals("First task", taskById.getName());
-            assertEquals("", taskById.getDescription());
+            assertNullOrEmpty(taskById.getDescription());
             assertEquals("Reserved", taskById.getStatus());
             assertEquals(0, taskById.getPriority().intValue());
             assertEquals("yoda", taskById.getActualOwner());
@@ -971,7 +971,7 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
             TaskSummary taskInstance = tasks.get(0);
             assertNotNull(taskInstance);
             assertEquals("First task", taskInstance.getName());
-            assertEquals("", taskInstance.getDescription());
+            assertNullOrEmpty(taskInstance.getDescription());
             assertEquals("Reserved", taskInstance.getStatus());
             assertEquals(0, taskInstance.getPriority().intValue());
             assertEquals("yoda", taskInstance.getActualOwner());
@@ -996,7 +996,7 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
             taskInstance = tasks.get(0);
             assertNotNull(taskInstance);
             assertEquals("First task", taskInstance.getName());
-            assertEquals("", taskInstance.getDescription());
+            assertNullOrEmpty(taskInstance.getDescription());
             assertEquals("InProgress", taskInstance.getStatus());
             assertEquals(0, taskInstance.getPriority().intValue());
             assertEquals("yoda", taskInstance.getActualOwner());
@@ -1030,7 +1030,7 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
             TaskSummary taskInstance = tasks.get(0);
             assertNotNull(taskInstance);
             assertEquals("First task", taskInstance.getName());
-            assertEquals("", taskInstance.getDescription());
+            assertNullOrEmpty(taskInstance.getDescription());
             assertEquals("Reserved", taskInstance.getStatus());
             assertEquals(0, taskInstance.getPriority().intValue());
             assertEquals("yoda", taskInstance.getActualOwner());
@@ -1055,7 +1055,7 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
             taskInstance = tasks.get(0);
             assertNotNull(taskInstance);
             assertEquals("First task", taskInstance.getName());
-            assertEquals("", taskInstance.getDescription());
+            assertNullOrEmpty(taskInstance.getDescription());
             assertEquals("InProgress", taskInstance.getStatus());
             assertEquals(0, taskInstance.getPriority().intValue());
             assertEquals("yoda", taskInstance.getActualOwner());
@@ -1092,7 +1092,7 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
             TaskSummary taskInstance = tasks.get(0);
             assertNotNull(taskInstance);
             assertEquals("First task", taskInstance.getName());
-            assertEquals("", taskInstance.getDescription());
+            assertNullOrEmpty(taskInstance.getDescription());
             assertEquals("Reserved", taskInstance.getStatus());
             assertEquals(0, taskInstance.getPriority().intValue());
             assertEquals("yoda", taskInstance.getActualOwner());
@@ -1117,7 +1117,7 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
             taskInstance = tasks.get(0);
             assertNotNull(taskInstance);
             assertEquals("First task", taskInstance.getName());
-            assertEquals("", taskInstance.getDescription());
+            assertNullOrEmpty(taskInstance.getDescription());
             assertEquals("InProgress", taskInstance.getStatus());
             assertEquals(0, taskInstance.getPriority().intValue());
             assertEquals("yoda", taskInstance.getActualOwner());

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/UserTaskServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/UserTaskServiceIntegrationTest.java
@@ -388,8 +388,8 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
             TaskInstance taskInstance = taskClient.getTaskInstance("definition-project", taskSummary.getId());
             assertNotNull(taskInstance);
             assertEquals("First task", taskInstance.getName());
-            assertEquals("", taskInstance.getDescription());
-            assertEquals("", taskInstance.getSubject());
+            assertNullOrEmpty(taskInstance.getDescription());
+            assertNullOrEmpty(taskInstance.getSubject());
             assertEquals("Reserved", taskInstance.getStatus());
             assertEquals(0, taskInstance.getPriority().intValue());
             assertEquals("yoda", taskInstance.getActualOwner());
@@ -437,8 +437,8 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
             TaskInstance taskInstance = taskClient.getTaskInstance("definition-project", taskSummary.getId(), true, true, true);
             assertNotNull(taskInstance);
             assertEquals("First task", taskInstance.getName());
-            assertEquals("", taskInstance.getDescription());
-            assertEquals("", taskInstance.getSubject());
+            assertNullOrEmpty(taskInstance.getDescription());
+            assertNullOrEmpty(taskInstance.getSubject());
             assertEquals("Reserved", taskInstance.getStatus());
             assertEquals(0, taskInstance.getPriority().intValue());
             assertEquals("yoda", taskInstance.getActualOwner());
@@ -635,7 +635,7 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
             assertNull(taskSummary.getExpirationTime());
             assertTrue(taskSummary.getSkipable().booleanValue());
             assertEquals("First task", taskSummary.getName());
-            assertTrue(taskSummary.getDescription().isEmpty());
+            assertNullOrEmpty(taskSummary.getDescription());
 
             // set task properties
             Calendar currentTime = Calendar.getInstance();
@@ -701,7 +701,13 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
             // Verifying second comment returned by getTaskCommentsByTaskId().
             List<TaskComment> taskComments = taskClient.getTaskCommentsByTaskId(CONTAINER_ID, taskSummary.getId());
             assertEquals(2, taskComments.size());
-            TaskComment secondTaskComment = taskComments.get(1);
+
+            TaskComment secondTaskComment = null;
+            if (secondCommentId.equals(taskComments.get(0).getId())) {
+                secondTaskComment = taskComments.get(0);
+            } else {
+                secondTaskComment = taskComments.get(1);
+            }
             assertEquals(secondCommentTime.getTime(), secondTaskComment.getAddedAt());
             assertEquals(USER_JOHN, secondTaskComment.getAddedBy());
             assertEquals(secondCommentId, secondTaskComment.getId());
@@ -761,7 +767,13 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
             // Verifying second attachment returned by getTaskAttachmentsByTaskId().
             List<TaskAttachment> taskAttachments = taskClient.getTaskAttachmentsByTaskId(CONTAINER_ID, taskSummary.getId());
             assertEquals(2, taskAttachments.size());
-            TaskAttachment secondTaskAttachment = taskAttachments.get(1);
+
+            TaskAttachment secondTaskAttachment = null;
+            if (secondAttachmentId.equals(taskAttachments.get(0).getId())) {
+                secondTaskAttachment = taskAttachments.get(0);
+            } else {
+                secondTaskAttachment = taskAttachments.get(1);
+            }
             assertNotNull(secondTaskAttachment.getAddedAt());
             assertEquals(USER_JOHN, secondTaskAttachment.getAddedBy());
             assertNotNull(secondTaskAttachment.getAttachmentContentId());


### PR DESCRIPTION
tested Oracle database has some differences compared to H2 used in tests:
- returns null instead of empty String for values which weren't set
- returns results in random order - tests modified for attachments and comments , will prepare another PR for other sorting issues
- Adjusted timeouts as they were too short for remote database