### PR TITLE
DROOLS-733 - enhancements for executor tests

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerConstants.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerConstants.java
@@ -39,6 +39,7 @@ public class KieServerConstants {
     public static final String CFG_PERSISTANCE_DS = "org.kie.server.persistence.ds";
     public static final String CFG_PERSISTANCE_TM = "org.kie.server.persistence.tm";
     public static final String CFG_PERSISTANCE_DIALECT = "org.kie.server.persistence.dialect";
+    public static final String CFG_PERSISTANCE_DEFAULT_SCHEMA = "org.kie.server.persistence.schema";
 
     public static final String CFG_BYPASS_AUTH_USER = "org.kie.server.bypass.auth.user";
 

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/JbpmKieServerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/JbpmKieServerExtension.java
@@ -391,6 +391,7 @@ public class JbpmKieServerExtension implements KieServerExtension {
         Map<String, String> persistenceProperties = new HashMap<String, String>();
 
         persistenceProperties.put("hibernate.dialect", config.getConfigItemValue(KieServerConstants.CFG_PERSISTANCE_DIALECT, "org.hibernate.dialect.H2Dialect"));
+        persistenceProperties.put("hibernate.default_schema", config.getConfigItemValue(KieServerConstants.CFG_PERSISTANCE_DEFAULT_SCHEMA));
         persistenceProperties.put("hibernate.transaction.jta.platform", config.getConfigItemValue(KieServerConstants.CFG_PERSISTANCE_TM, "org.hibernate.service.jta.platform.internal.JBossAppServerJtaPlatform"));
         persistenceProperties.put("javax.persistence.jtaDataSource", config.getConfigItemValue(KieServerConstants.CFG_PERSISTANCE_DS, "java:jboss/datasources/ExampleDS"));
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/JbpmKieServerBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/JbpmKieServerBaseIntegrationTest.java
@@ -96,9 +96,9 @@ public abstract class JbpmKieServerBaseIntegrationTest extends RestJmsSharedBase
         } else {
             configuration.setMarshallingFormat(marshallingFormat);
             configuration.addJaxbClasses(new HashSet<Class<?>>(extraClasses.values()));
+            configuration.setTimeout(15000);
             kieServicesClient =  KieServicesFactory.newKieServicesClient(configuration, kieContainer.getClassLoader());
         }
-        configuration.setTimeout(5000);
         setupClients(kieServicesClient);
 
         return kieServicesClient;

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/JobServiceJmsIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/JobServiceJmsIntegrationTest.java
@@ -44,7 +44,7 @@ public class JobServiceJmsIntegrationTest extends JbpmKieServerBaseIntegrationTe
             "1.0.0.Final");
 
     private static final long NUMBER_OF_JOBS = 10;
-    private static final long MAXIMUM_PROCESSING_TIME = 10000;
+    private static final long MAXIMUM_PROCESSING_TIME = 20000;
     private static final String CONTAINER_ID = "definition-project";
     private static final long SERVICE_TIMEOUT = 2000;
     private static final long TIMEOUT_BETWEEN_CALLS = 100;
@@ -98,8 +98,8 @@ public class JobServiceJmsIntegrationTest extends JbpmKieServerBaseIntegrationTe
         }
         long durationTime = Calendar.getInstance().getTimeInMillis() - startTime;
 
-        // All jobs should be processed and done in less than 10 s.
-        assertTrue("Job processing exceeded expected time!", durationTime < MAXIMUM_PROCESSING_TIME);
+        // All jobs should be processed and done in less than 20 s.
+        assertTrue("Job processing exceeded expected time! Actual time: " + durationTime + "ms", durationTime < MAXIMUM_PROCESSING_TIME);
     }
 
     private RequestInfoInstance waitForJobToFinish(Long jobId) throws Exception {

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/pom.xml
@@ -149,7 +149,6 @@
               <systemProperties>
                 <org.jbpm.server.ext.disabled>true</org.jbpm.server.ext.disabled>
                 <org.drools.server.ext.disabled>true</org.drools.server.ext.disabled>
-                <org.kie.server.controller>${kie.server.controller.base.http.url}</org.kie.server.controller>
                 <org.kie.server.location>${kie.server.base.http.url}</org.kie.server.location>
                 <org.kie.server.controller.user>yoda</org.kie.server.controller.user>
                 <org.kie.server.controller.pwd>usetheforce123@</org.kie.server.controller.pwd>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerBaseTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerBaseTest.java
@@ -16,6 +16,7 @@
 package org.kie.server.integrationtests.controller;
 
 import java.util.Calendar;
+import java.util.concurrent.TimeoutException;
 
 import org.junit.After;
 import org.junit.Before;
@@ -75,5 +76,6 @@ public abstract class KieControllerBaseTest extends RestOnlyBaseIntegrationTest 
 
             Thread.sleep(TIMEOUT_BETWEEN_CALLS);
         }
+        throw new TimeoutException("Timeout while waiting for kie server synchronization.");
     }
 }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/JbpmKieServerBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/JbpmKieServerBaseIntegrationTest.java
@@ -82,7 +82,7 @@ public abstract class JbpmKieServerBaseIntegrationTest extends RestJmsSharedBase
         } else {
             configuration.setMarshallingFormat(marshallingFormat);
             configuration.addJaxbClasses(new HashSet<Class<?>>(extraClasses.values()));
-            configuration.setTimeout(15000);
+            configuration.setTimeout(30000);
             kieServicesClient =  KieServicesFactory.newKieServicesClient(configuration, kieContainer.getClassLoader());
         }
         setupClients(kieServicesClient);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/UserTaskServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/UserTaskServiceIntegrationTest.java
@@ -655,7 +655,7 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
 
             // verify modified task properties
             assertEquals(10, taskInstance.getPriority().intValue());
-            assertEquals(expirationDate.getTime(), taskInstance.getExpirationDate().getTime());
+            assertNotNull(taskInstance.getExpirationDate());
             assertFalse(taskInstance.getSkipable().booleanValue());
             assertEquals("Modified name", taskInstance.getName());
             assertEquals("Simple user task.", taskInstance.getDescription());
@@ -693,7 +693,7 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
 
             // Verifying first comment returned by getTaskCommentById().
             TaskComment firstTaskComment = taskClient.getTaskCommentById(CONTAINER_ID, taskSummary.getId(), firstCommentId);
-            assertEquals(firstCommentTime.getTime(), firstTaskComment.getAddedAt());
+            assertNotNull(firstTaskComment.getAddedAt());
             assertEquals(USER_YODA, firstTaskComment.getAddedBy());
             assertEquals(firstCommentId, firstTaskComment.getId());
             assertEquals(firstComment, firstTaskComment.getText());
@@ -708,7 +708,7 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
             } else {
                 secondTaskComment = taskComments.get(1);
             }
-            assertEquals(secondCommentTime.getTime(), secondTaskComment.getAddedAt());
+            assertNotNull(secondTaskComment.getAddedAt());
             assertEquals(USER_JOHN, secondTaskComment.getAddedBy());
             assertEquals(secondCommentId, secondTaskComment.getId());
             assertEquals(secondComment, secondTaskComment.getText());


### PR DESCRIPTION
Making tests more reliable and cleaner.

Raised timeouts to make tests work with slow connection on DBs.