### PR TITLE
BZ-1273109 - BPM cluster: Job executor fails with NPE while

### DIFF
--- a/kie-remote/kie-remote-jaxb/src/main/java/org/kie/services/client/serialization/jaxb/impl/deploy/JaxbDeploymentJobResult.java
+++ b/kie-remote/kie-remote-jaxb/src/main/java/org/kie/services/client/serialization/jaxb/impl/deploy/JaxbDeploymentJobResult.java
@@ -15,6 +15,7 @@
 
 package org.kie.services.client.serialization.jaxb.impl.deploy;
 
+import java.io.Serializable;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -27,7 +28,7 @@ import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 @XmlRootElement(name="deployment-job-result")
 @XmlAccessorType(XmlAccessType.FIELD)
 @JsonIgnoreProperties({"jobId"})
-public class JaxbDeploymentJobResult {
+public class JaxbDeploymentJobResult implements Serializable {
 
     /**
      * An internal field used to track the job on the server side

--- a/kie-remote/kie-remote-jaxb/src/main/java/org/kie/services/client/serialization/jaxb/impl/deploy/JaxbDeploymentUnit.java
+++ b/kie-remote/kie-remote-jaxb/src/main/java/org/kie/services/client/serialization/jaxb/impl/deploy/JaxbDeploymentUnit.java
@@ -15,6 +15,7 @@
 
 package org.kie.services.client.serialization.jaxb.impl.deploy;
 
+import java.io.Serializable;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -28,7 +29,7 @@ import org.kie.internal.runtime.conf.RuntimeStrategy;
 @XmlRootElement(name="deployment-unit")
 @XmlAccessorType(XmlAccessType.FIELD)
 @JsonIgnoreProperties({"identifier"})
-public class JaxbDeploymentUnit {
+public class JaxbDeploymentUnit implements Serializable {
 
     @XmlElement
     @XmlSchemaType(name="string")

--- a/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/DeployResourceBase.java
+++ b/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/DeployResourceBase.java
@@ -264,9 +264,8 @@ public class DeployResourceBase extends ResourceBase {
         CommandContext ctx = new CommandContext();
         ctx.setData(DEPLOYMENT_UNIT,  deploymentUnit);
         ctx.setData(JOB_TYPE, jobType);
-        ctx.setData("businessKey", deploymentId);
         ctx.setData("retries", 0);
-	ctx.setData("owner", ExecutorService.EXECUTOR_ID);
+	    ctx.setData("owner", ExecutorService.EXECUTOR_ID);
        
         String jobTypeLower = jobType.toString().toLowerCase();
        
@@ -281,7 +280,10 @@ public class DeployResourceBase extends ResourceBase {
         logger.debug( "{} job [{}] for deployment '{}' created.", jobType.toString(), jobId, deploymentUnit.getIdentifier());
         jobResultMgr.putJob(jobResult.getJobId(), jobResult, jobType);
         Long executorJobId;
-        try { 
+        try {
+            ctx.setData("businessKey", jobId);
+            ctx.setData("jobResult", jobResult);
+
             executorJobId = jobExecutor.scheduleRequest(DeploymentCmd.class.getName(), ctx);
             jobResult.setIdentifier(executorJobId);
             jobResult.setSuccess(true);

--- a/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/async/cmd/DeploymentCmd.java
+++ b/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/async/cmd/DeploymentCmd.java
@@ -94,6 +94,7 @@ public class DeploymentCmd implements Command {
         }
         ExecutionResults results = new ExecutionResults();
         results.setData("Result", success);
+        results.setData("JobResult", jobResult);
         return results;
     }
 


### PR DESCRIPTION
this PR enables efficient and reliable job status checks within cluster. Since deployment and undeployment commands/jobs are executed asynchronously (jbpm executor) they might be executed on any cluster member. Thus when running clustered environment default map based cache did not work properly when request for checking job status was sent to other instance then the job was actually executed.
This PR uses executorService (component that actually executed the job) to find it in db in case it does not exist in the local cache. That way job status check is cluster aware and will cover efficient job execution distribution across cluster members while still allowing to find the job status regardless where it was executed. 
Especially important when kie-wb instances are running behind load balancer.

this is one of three PRs for this BZ - others are in guvnor (https://github.com/droolsjbpm/guvnor/pull/167) and jbpm (https://github.com/droolsjbpm/jbpm/pull/317), though they don't have any compile dependency