### PR TITLE
- fix webservices exception ("getReader() has already been called for this request")

### DIFF
--- a/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/jaxb/DynamicJaxbContextFilter.java
+++ b/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/jaxb/DynamicJaxbContextFilter.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -17,10 +17,7 @@ package org.kie.remote.services.rest.jaxb;
 
 import static org.kie.remote.services.cdi.DeploymentInfoBean.emptyDeploymentId;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.lang.reflect.Field;
 
 import javax.inject.Inject;
 import javax.servlet.Filter;
@@ -30,22 +27,12 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
 
 import org.jbpm.kie.services.api.DeploymentIdResolver;
 import org.kie.remote.services.cdi.DeploymentInfoBean;
-import org.kie.remote.services.jaxb.JaxbCommandsRequest;
 import org.kie.services.client.serialization.JaxbSerializationProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.w3c.dom.Document;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-import org.xml.sax.SAXException;
 
 public class DynamicJaxbContextFilter implements Filter {
 
@@ -133,93 +120,6 @@ public class DynamicJaxbContextFilter implements Filter {
             return deploymentId;
         }
 
-        // extract command request
-        deploymentId = getDeploymentIdFromXml(request);
-        if( !emptyDeploymentId(deploymentId) ) {
-            return deploymentId;
-        }
-
         return DEFAULT_JAXB_CONTEXT_ID;
-    }
-
-    private static String COMMAND_REQUEST_ROOT_ELEMENT_NAME = null;
-    private static String DEPLOYMENT_ID_NODE_NAME = null;
-    static { 
-        XmlRootElement xmlRootElemAnno = JaxbCommandsRequest.class.getAnnotation(XmlRootElement.class);
-        if( xmlRootElemAnno != null ) { 
-            COMMAND_REQUEST_ROOT_ELEMENT_NAME = xmlRootElemAnno.name();
-        }
-        String depIdFieldName = "deploymentId";
-        Field deploymentIdField = null;
-        try { 
-            deploymentIdField = JaxbCommandsRequest.class.getDeclaredField(depIdFieldName);
-            XmlElement xmlElemAnno = deploymentIdField.getAnnotation(XmlElement.class);
-            if( xmlElemAnno != null ) { 
-               DEPLOYMENT_ID_NODE_NAME = xmlElemAnno.name();
-            }
-        } catch( NoSuchFieldException nsfe ) { 
-           logger.error("Unable to find " + JaxbCommandsRequest.class.getSimpleName() + "." + depIdFieldName + " field", nsfe); 
-        }
-    }
-   
-    /**
-     * Retrieves the {@link HttpServletRequest} content, and parses it to see if 
-     * the content contains a command-request xml structure with a deployment-id element containing a deployment id.
-     * @param request The {@link HttpServletRequest} instance
-     * @return The deployment id {@link String} or null, if none present
-     */
-    static String getDeploymentIdFromXml( HttpServletRequest request ) {
-        StringBuffer buffer = new StringBuffer();
-        BufferedReader reader = null;
-        try {
-            reader = request.getReader();
-            if( reader == null || ! reader.ready() ) { 
-               return null; 
-            }
-            String line = null;
-            while( (line = reader.readLine()) != null ) { 
-                buffer.append(line);
-            }
-        } catch( IOException ioe ) {
-            logger.debug("Unable to read " + HttpServletRequest.class.getSimpleName() + " content: " + ioe.getMessage(), ioe );
-        } finally {
-            if( reader != null ) {
-                try {
-                    reader.close();
-                } catch( IOException ioe ) {
-                    logger.debug( "Unable to close " + HttpServletRequest.class.getSimpleName() + " reader: " + ioe.getMessage(), 
-                            ioe);
-                }
-            }
-        }
-        
-        String body = buffer.toString();
-        try {
-            DocumentBuilder docBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-            ByteArrayInputStream bodyInput = new ByteArrayInputStream(body.getBytes());
-            Document doc = docBuilder.parse(bodyInput);
-            
-            Node commandRequestNode = doc.getFirstChild();
-            if( ! commandRequestNode.getNodeName().equals(COMMAND_REQUEST_ROOT_ELEMENT_NAME) ) { 
-               return null; 
-            }
-            NodeList requestChildNodes = commandRequestNode.getChildNodes();
-
-            for (int i = 0; i < requestChildNodes.getLength(); i++) {
-                Node childNode = requestChildNodes.item(i);
-                if(childNode.getNodeType()==Node.ELEMENT_NODE && childNode.getNodeName().equals(DEPLOYMENT_ID_NODE_NAME)) {
-                    return childNode.getTextContent();
-                }
-            }
-        } catch( ParserConfigurationException pce ) {
-            logger.debug( "Unable to create " + DocumentBuilder.class.getSimpleName() + " to parse " 
-                    + HttpServletRequest.class.getSimpleName() + " content.", pce);
-        } catch( SAXException saxe ) {
-            logger.debug( "Unable to parse " + HttpServletRequest.class.getSimpleName() + " content.", saxe );
-        } catch( IOException ioe ) {
-            logger.debug( "Unable to parse " + HttpServletRequest.class.getSimpleName() + " content.", ioe );
-        }
-
-        return null;
     }
 }

--- a/kie-remote/kie-remote-services/src/test/java/org/kie/remote/services/rest/jaxb/JaxbContextResolverTest.java
+++ b/kie-remote/kie-remote-services/src/test/java/org/kie/remote/services/rest/jaxb/JaxbContextResolverTest.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -40,6 +40,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 
+import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.xml.bind.JAXBContext;
@@ -56,9 +57,9 @@ import org.kie.remote.services.cdi.DeploymentProcessedEvent;
 import org.kie.services.client.serialization.SerializationException;
 
 /**
- * This tests test scenarios where: 
+ * This tests test scenarios where:
  * 1. different deployments have different versions of the same class
- * 
+ *
  *
  */
 @SuppressWarnings("unchecked")
@@ -66,67 +67,67 @@ public class JaxbContextResolverTest {
 
     private JaxbContextResolver resolver;
     private DynamicJaxbContext dynamicJaxbContext = new DynamicJaxbContext();
-    
+
     private DeploymentInfoBean mockDepInfoBean;
     private Map<String, Collection<Class<?>>> deploymentIdClassesMap = new HashMap<String, Collection<Class<?>>>();
     private MultivaluedMap<String, String> pathParams = new MultivaluedMapImpl<String, String>();
-    
+
     @Before
-    public void before() throws URISyntaxException { 
+    public void before() throws URISyntaxException {
        resolver = new JaxbContextResolver();
-       
+
        // Only created once to simulate Application scope
        resolver.dynamicContext = dynamicJaxbContext;
        mockDepInfoBean = mock(DeploymentInfoBean.class);
        dynamicJaxbContext.deploymentInfoBean = mockDepInfoBean;
     }
-    
+
     @After
-    public void cleanUp() { 
+    public void cleanUp() {
         DynamicJaxbContext.clearDeploymentJaxbContext();
     }
-   
+
     // Helper methods -------------------------------------------------------------------------------------------------------------
-   
-    private void undeploy(String deploymentid) { 
+
+    private void undeploy(String deploymentid) {
         dynamicJaxbContext.cleanUpOnUndeploy(new DeploymentProcessedEvent(deploymentid));
         deploymentIdClassesMap.remove(deploymentid);
     }
-    
-    private void addClassesToDeploymentAndInitializeDeploymentJaxbContext(String deploymentId, Class<?>... clazz) { 
+
+    private void addClassesToDeploymentAndInitializeDeploymentJaxbContext(String deploymentId, Class<?>... clazz) {
        Collection<Class<?>> depClasses = deploymentIdClassesMap.get(deploymentId);
        boolean initialize = false;
-       if( depClasses == null ) { 
+       if( depClasses == null ) {
            initialize = true;
            depClasses = new HashSet<Class<?>>();
            deploymentIdClassesMap.put(deploymentId, depClasses);
        }
        depClasses.addAll(Arrays.asList(clazz));
-       if( initialize ) { 
+       if( initialize ) {
            doReturn(depClasses).when(mockDepInfoBean).getDeploymentClasses(deploymentId);
        }
-       // setup jaxb context instance for deployment 
+       // setup jaxb context instance for deployment
        dynamicJaxbContext.setupDeploymentJaxbContext(new DeploymentProcessedEvent(deploymentId));
     }
-    
-    private void setDeploymentId(String deploymentId) { 
-       pathParams.putSingle("deploymentId", deploymentId); 
+
+    private void setDeploymentId(String deploymentId) {
+       pathParams.putSingle("deploymentId", deploymentId);
        dynamicJaxbContext.setupDeploymentJaxbContext(new DeploymentProcessedEvent(deploymentId));
     }
-    
+
     public String serialize(JAXBContext jaxbContext, Object object) {
         Marshaller marshaller = null;
-        try { 
+        try {
             marshaller = jaxbContext.createMarshaller();
             marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
-        } catch( JAXBException jaxbe ) { 
+        } catch( JAXBException jaxbe ) {
             throw new SerializationException("Unable to create JAXB marshaller.", jaxbe);
         }
         StringWriter stringWriter = new StringWriter();
 
         try {
             marshaller.marshal(object, stringWriter);
-        } catch( JAXBException jaxbe ) { 
+        } catch( JAXBException jaxbe ) {
             throw new SerializationException("Unable to marshall " + object.getClass().getSimpleName() + " instance.", jaxbe);
         }
         String output = stringWriter.toString();
@@ -138,44 +139,44 @@ public class JaxbContextResolverTest {
         Unmarshaller unmarshaller = null;
         try {
             unmarshaller = jaxbContext.createUnmarshaller();
-        } catch( JAXBException jaxbe ) { 
+        } catch( JAXBException jaxbe ) {
             throw new SerializationException("Unable to create unmarshaller.", jaxbe);
         }
         ByteArrayInputStream xmlStrInputStream = new ByteArrayInputStream(xmlStr.getBytes(Charset.forName("UTF-8")));
 
         Object jaxbObj = null;
-        try { 
+        try {
             jaxbObj = unmarshaller.unmarshal(xmlStrInputStream);
-        } catch( JAXBException jaxbe ) { 
+        } catch( JAXBException jaxbe ) {
            throw new SerializationException("Unable to unmarshal string.", jaxbe);
         }
 
         return (T) jaxbObj;
     }
 
-    private void verifyMyTypeInstance(Class myTypeClass, Object myTypeObj, Object roundTripTypeObj) throws Exception { 
+    private void verifyMyTypeInstance(Class myTypeClass, Object myTypeObj, Object roundTripTypeObj) throws Exception {
         Method getText = myTypeClass.getMethod("getText");
         String origText = (String) getText.invoke(myTypeObj);
         String copyText = (String) getText.invoke(roundTripTypeObj);
         assertEquals( origText, copyText );
-        
+
         Method getData = myTypeClass.getMethod("getData");
         Integer origData = (Integer) getData.invoke(myTypeObj);
         Integer copyData = (Integer) getData.invoke(roundTripTypeObj);
         assertEquals( origData, copyData );
     }
-    
-    private void verifyNewMyTypeInstance(Class newMyTypeClass, Object newMyTypeObj, Object roundTripNewTypeObj) throws Exception { 
+
+    private void verifyNewMyTypeInstance(Class newMyTypeClass, Object newMyTypeObj, Object roundTripNewTypeObj) throws Exception {
         Method getNotText = newMyTypeClass.getMethod("getNotText");
         String origText = (String) getNotText.invoke(newMyTypeObj);
         String copyText = (String) getNotText.invoke(roundTripNewTypeObj);
         assertEquals( origText, copyText );
     }
-    
+
     // TESTS ---------------------------------------------------------------------------------------------------------------------
-    
+
     @Test
-    public void simpleJaxbDeserializeTest() throws Exception { 
+    public void simpleJaxbDeserializeTest() throws Exception {
         String depId = "org.kie.remote:test:1.0";
         setDeploymentId(depId);
         Class<?> myTypeClass = getClassFromSource("MyType.java");
@@ -183,107 +184,107 @@ public class JaxbContextResolverTest {
 
         // after request
         DynamicJaxbContext.setDeploymentJaxbContext(depId);
-        
+
         JAXBContext jaxbContext = resolver.getContext(myTypeClass);
-        
+
         Constructor<?> myTypeCstr = myTypeClass.getConstructor(String.class, int.class);
         Object myTypeObj = myTypeCstr.newInstance("og & \"<>", 23);
-        
+
         String xmlStr = serialize(jaxbContext, myTypeObj);
         Object roundTripTypeObj = deserialize(jaxbContext, xmlStr, myTypeClass);
-       
+
         verifyMyTypeInstance(myTypeClass, myTypeObj, roundTripTypeObj);
-        
+
         // after request
         DynamicJaxbContext.clearDeploymentJaxbContext();
     }
-   
+
     @Test
-    public void cacheJaxbContextTest() throws Exception { 
+    public void cacheJaxbContextTest() throws Exception {
         // setup
         String depId = "org.kie.remote:test:1.0";
         setDeploymentId(depId);
         Class<?> myTypeClass = getClassFromSource("MyType.java");
         addClassesToDeploymentAndInitializeDeploymentJaxbContext(depId, myTypeClass);
-       
+
         // before request
         DynamicJaxbContext.setDeploymentJaxbContext(depId);
 
         JAXBContext jaxbContext = resolver.getContext(myTypeClass);
-        
+
         Constructor<?> myTypeCstr = myTypeClass.getConstructor(String.class, int.class);
         Object myTypeObj = myTypeCstr.newInstance("og", 23);
-        
+
         String xmlStr = serialize(jaxbContext, myTypeObj);
         Object roundTripTypeObj = deserialize(jaxbContext, xmlStr, myTypeClass);
-       
+
         verifyMyTypeInstance(myTypeClass, myTypeObj, roundTripTypeObj);
-        
+
         JAXBContext cachedJaxbContext = resolver.getContext(myTypeClass);
         assertTrue( "JAXBContext was not cached!", jaxbContext == cachedJaxbContext);
     }
-    
+
     @Test
-    public void multipleDeploymentsTest() throws Exception { 
+    public void multipleDeploymentsTest() throws Exception {
         // setup deployment
         String depId = "org.kie.remote:test:1.0";
         setDeploymentId(depId);
         Class<?> myTypeClass = getClassFromSource("MyType.java");
         addClassesToDeploymentAndInitializeDeploymentJaxbContext(depId, myTypeClass);
 
-        { 
+        {
         // before request
         DynamicJaxbContext.setDeploymentJaxbContext(depId);
 
         // get jaxb context
         JAXBContext jaxbContext = resolver.getContext(myTypeClass);
-        
+
         // create instance of object
         Constructor<?> myTypeCstr = myTypeClass.getConstructor(String.class, int.class);
         Object myTypeObj = myTypeCstr.newInstance("og", 23);
-       
+
         // round trip serialization
         String xmlStr = serialize(jaxbContext, myTypeObj);
         Object roundTripTypeObj = deserialize(jaxbContext, xmlStr, myTypeClass);
-       
+
         // check object content/round-trip correctness
         verifyMyTypeInstance(myTypeClass, myTypeObj, roundTripTypeObj);
-        
+
         // after request
         DynamicJaxbContext.clearDeploymentJaxbContext();
         }
-        
+
         // setup OTHER deployment
         String otherDepId = "org.kie.remote:other-test:1.0";
         setDeploymentId(otherDepId);
         Class<?> newMyTypeClass = getClassFromSource("NewMyType.java");
         addClassesToDeploymentAndInitializeDeploymentJaxbContext(otherDepId, newMyTypeClass);
-      
+
         {
         // before request
         DynamicJaxbContext.setDeploymentJaxbContext(otherDepId);
         // get jaxb context
         JAXBContext jaxbContext = resolver.getContext(newMyTypeClass);
-     
+
         // instance of new object -- which should only be accessible in other deployment
         Constructor<?> newMyTypeCstr = newMyTypeClass.getConstructor(String.class);
         Object newMyTypeObj = newMyTypeCstr.newInstance("og");
-        
+
         String xmlStr = serialize(jaxbContext, newMyTypeObj);
         Object roundTripNewMyTypeObject = deserialize(jaxbContext, xmlStr, newMyTypeClass);
-       
+
         // check object content/round-trip correctness
         verifyNewMyTypeInstance(newMyTypeClass, newMyTypeObj, roundTripNewMyTypeObject);
         // after request
         DynamicJaxbContext.clearDeploymentJaxbContext();
         }
     }
-    
+
     @Test
-    public void deployUndeployDeployTest() throws Exception { 
+    public void deployUndeployDeployTest() throws Exception {
         String depId = "org.kie.remote:test:1.0";
-       
-        { 
+
+        {
         // setup deployment
         setDeploymentId(depId);
         Class<?> myTypeClass = getClassFromSource("MyType.java");
@@ -291,65 +292,65 @@ public class JaxbContextResolverTest {
 
         // before request
         DynamicJaxbContext.setDeploymentJaxbContext(depId);
-        
+
         // get jaxb context
         JAXBContext jaxbContext = resolver.getContext(myTypeClass);
-        
+
         // create instance of object
         Constructor<?> myTypeCstr = myTypeClass.getConstructor(String.class, int.class);
         Object myTypeObj = myTypeCstr.newInstance("og", 23);
-       
+
         // use jaxb context for round trip serialization
         String xmlStr = serialize(jaxbContext, myTypeObj);
         Object roundTripTypeObj = deserialize(jaxbContext, xmlStr, myTypeClass);
-       
+
         // compare round trip results
         verifyMyTypeInstance(myTypeClass, myTypeObj, roundTripTypeObj);
         // after request
         DynamicJaxbContext.clearDeploymentJaxbContext();
         }
-        
+
         // undeploy!
         undeploy(depId);
-       
+
         {
         // new deployment of same deployment -- with a different class definition
         setDeploymentId(depId);
         Class<?> newMyTypeClass = getClassFromSource("NewMyType.java");
         addClassesToDeploymentAndInitializeDeploymentJaxbContext(depId, newMyTypeClass);
-        
+
         // before request
         DynamicJaxbContext.setDeploymentJaxbContext(depId);
         // get jaxb context
         JAXBContext jaxbContext = resolver.getContext(newMyTypeClass);
-     
+
         // create new instance (of new class!)
         Constructor<?> newMyTypeCstr = newMyTypeClass.getConstructor(String.class);
         Object newMyTypeObj = newMyTypeCstr.newInstance("og");
-        
+
         // round trip serialization
         String xmlStr = serialize(jaxbContext, newMyTypeObj);
         Object roundTripNewTypeObj = deserialize(jaxbContext, xmlStr, newMyTypeClass);
-      
+
         // check object content/round-trip correctness
         verifyNewMyTypeInstance(newMyTypeClass, newMyTypeObj, roundTripNewTypeObj);
 
-        try { 
+        try {
             newMyTypeClass.getMethod("getData");
             fail( "This method does not exist in the new definition of the class!");
-        } catch( Exception e ) { 
+        } catch( Exception e ) {
             // ignore
         }
         // after request
         DynamicJaxbContext.clearDeploymentJaxbContext();
         }
     }
-    
+
     @Test
-    public void requestDeploymentIdParsingTest() throws IOException { 
+    public void requestDeploymentIdParsingTest() throws IOException {
         // setup
        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
-    
+
        // tests
        String deploymentId = "org.test:kjar:1.0";
        String requestUri = "/rest/deployment/"+ deploymentId + "/deploy";
@@ -357,37 +358,24 @@ public class JaxbContextResolverTest {
        doReturn(null).when(mockRequest).getParameter("deploymentId");
        String parsedDepId = DynamicJaxbContextFilter.getDeploymentId(mockRequest);
        assertEquals( "deployment operation URL: deployment id", deploymentId, parsedDepId);
-       
+
        requestUri = "/rest/history/instance/23/variable";
        doReturn(requestUri).when(mockRequest).getRequestURI();
        doReturn(null).when(mockRequest).getParameter("deploymentId");
        parsedDepId = DynamicJaxbContextFilter.getDeploymentId(mockRequest);
-       assertEquals( "history operation URL: (default) deployment id", 
+       assertEquals( "history operation URL: (default) deployment id",
                DynamicJaxbContextFilter.DEFAULT_JAXB_CONTEXT_ID, parsedDepId);
-       
+
        requestUri = "/rest/runtime/" + deploymentId + "/execute";
        doReturn(requestUri).when(mockRequest).getRequestURI();
        doReturn(null).when(mockRequest).getParameter("deploymentId");
        parsedDepId = DynamicJaxbContextFilter.getDeploymentId(mockRequest);
        assertEquals( "runtime operation URL: deployment id", deploymentId, parsedDepId);
-       
+
        requestUri = "/rest/execute?deploymentId=" + deploymentId;
        doReturn(requestUri).when(mockRequest).getRequestURI();
        doReturn(deploymentId).when(mockRequest).getParameter("deploymentId");
        parsedDepId = DynamicJaxbContextFilter.getDeploymentId(mockRequest);
        assertEquals( "task operation URL (with parameter): deployment id", deploymentId, parsedDepId);
-       
-       mockRequest = mock(HttpServletRequest.class);
-       requestUri = "/rest/execute" + deploymentId;
-       doReturn(requestUri).when(mockRequest).getRequestURI();
-       String xmlRequestFile = "/command-request.xml";
-       InputStream xmlIn = getClass().getResourceAsStream(xmlRequestFile);
-       assertNotNull( "Unable to open or find [" + xmlRequestFile + "]", xmlIn);
-       BufferedReader reader = new BufferedReader(new InputStreamReader(xmlIn));
-       when(mockRequest.getReader()).thenReturn(reader);
-       
-       parsedDepId = DynamicJaxbContextFilter.getDeploymentId(mockRequest);
-       assertEquals( "rest execute with command-request xml", deploymentId, parsedDepId);
-       
     }
 }


### PR DESCRIPTION
Fixes the failing webservice test for the smoke tests. 

It turns out it's practically impossible to open the stream (and parse it for the deployment id) and then "reset" the stream so that the REST *and* WS frameworks can (re)open the stream in their code. 