### PR TITLE
Changed logger output from info to debug

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/JBPMKieContainerCommandServiceImpl.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/JBPMKieContainerCommandServiceImpl.java
@@ -131,7 +131,7 @@ public class JBPMKieContainerCommandServiceImpl implements KieContainerCommandSe
                 responses.add(new ServiceResponse(ServiceResponse.ResponseType.FAILURE, e.getMessage()));
             }
         }
-        logger.info("About to return responses '{}'", responses);
+        logger.debug("About to return responses '{}'", responses);
         return new ServiceResponsesList(responses);
     }
 }


### PR DESCRIPTION
The logger produces to much unnecessary information for every request:

16:09:32,108 INFO  [org.kie.server.services.jbpm.JBPMKieContainerCommandServiceImpl] (Thread-0 (HornetQ-client-global-threads-1663629582)) About to return responses '[ServiceResponse[SUCCESS, msg='']]'
16:09:32,130 INFO  [org.kie.server.services.jbpm.JBPMKieContainerCommandServiceImpl] (Thread-1 (HornetQ-client-global-threads-1663629582)) About to return responses '[ServiceResponse[SUCCESS, msg='']]'
16:09:32,154 INFO  [org.kie.server.services.jbpm.JBPMKieContainerCommandServiceImpl] (Thread-0 (HornetQ-client-global-threads-1663629582)) About to return responses '[ServiceResponse[SUCCESS, msg='']]'
16:09:32,178 INFO  [org.kie.server.services.jbpm.JBPMKieContainerCommandServiceImpl] (Thread-1 (HornetQ-client-global-threads-1663629582)) About to return responses '[ServiceResponse[SUCCESS, msg='']]'
16:09:32,195 INFO  [org.kie.server.services.jbpm.JBPMKieContainerCommandServiceImpl] (Thread-0 (HornetQ-client-global-threads-1663629582)) About to return responses '[ServiceResponse[SUCCESS, msg='']]'