### PR TITLE
BZ-1278722 - Marshalling Error when executing command through SOAP interface

### DIFF
--- a/kie-remote/kie-remote-client/pom.xml
+++ b/kie-remote/kie-remote-client/pom.xml
@@ -285,6 +285,7 @@
               org.jsoup.*;resolution:=optional,
               *
             </Import-Package>
+            <Include-Resource>wsdl/=target/classes/wsdl</Include-Resource>
           </instructions>
         </configuration>
       </plugin>

--- a/kie-remote/kie-remote-client/src/main/java/org/kie/remote/client/jaxb/JaxbCommandsRequest.java
+++ b/kie-remote/kie-remote-client/src/main/java/org/kie/remote/client/jaxb/JaxbCommandsRequest.java
@@ -25,6 +25,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElements;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlSchemaType;
+import javax.xml.bind.annotation.XmlSeeAlso;
 
 import org.kie.api.command.Command;
 import org.kie.remote.jaxb.gen.*;
@@ -100,6 +101,7 @@ import org.kie.services.shared.ServicesVersion;
 @XmlRootElement(name = "command-request")
 @XmlAccessorType(XmlAccessType.FIELD)
 @SuppressWarnings("rawtypes")
+@XmlSeeAlso({org.kie.remote.jaxb.gen.List.class})
 public class JaxbCommandsRequest {
 
     @XmlElement(name = "deployment-id")

--- a/kie-remote/kie-remote-client/src/main/java/org/kie/services/client/api/RemoteCommandWebserviceClientBuilderImpl.java
+++ b/kie-remote/kie-remote-client/src/main/java/org/kie/services/client/api/RemoteCommandWebserviceClientBuilderImpl.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -55,33 +55,33 @@ import org.kie.services.shared.ServicesVersion;
 /**
  * This is the internal implementation of the {@link RemoteWebserviceClientBuilder} class.
  * </p>
- * It takes care of implementing the methods specified as well as managing the 
+ * It takes care of implementing the methods specified as well as managing the
  * state of the internal {@link RemoteConfiguration} instance.
  */
 class RemoteCommandWebserviceClientBuilderImpl extends RemoteWebserviceClientBuilderImpl<CommandWebService> {
 
     private final static String commandServiceNamespace = "http://services.remote.kie.org/" + ServicesVersion.VERSION + "/command";
     private final static QName commandServiceQName = new QName(commandServiceNamespace, "CommandServiceBasicAuth");
-  
+
     @Override
     public CommandWebService buildBasicAuthClient() {
         checkAndFinalizeConfig();
-        
+
         // wsdl authentication
         KieRemoteWsAuthenticator auth = new KieRemoteWsAuthenticator();
-        auth.setUserAndPassword(config.getUserName(), config.getPassword()); 
-   
+        auth.setUserAndPassword(config.getUserName(), config.getPassword());
+
         String wsdlLocationRelativePath = config.getWsdlLocationRelativePath();
 
         URL wsdlUrl;
-        try { 
+        try {
             wsdlUrl = new URL(config.getServerBaseUrl(), wsdlLocationRelativePath);
-        } catch( MalformedURLException murle ) { 
+        } catch( MalformedURLException murle ) {
             throw new IllegalStateException("WSDL URL is not correct: [" + config.getServerBaseUrl().toExternalForm() + wsdlLocationRelativePath + "]", murle);
         }
-  
+
         wsdlUrl = verifyURLWithRedirect(wsdlUrl);
-        
+
         // initial client proxy setup
         JaxWsProxyFactoryBean factory = new JaxWsProxyFactoryBean();
         factory.setServiceClass(CommandWebService.class);
@@ -94,13 +94,13 @@ class RemoteCommandWebserviceClientBuilderImpl extends RemoteWebserviceClientBui
         allClasses.add(JaxbCommandsResponse.class);
         allClasses.add(Execute.class);
         allClasses.add(ExecuteResponse.class);
-        
-        // JAXB: extra classes 
+
+        // JAXB: extra classes
         Set<Class<?>> extraClasses = config.getExtraJaxbClasses();
-        if( extraClasses != null && ! extraClasses.isEmpty() ) { 
+        if( extraClasses != null && ! extraClasses.isEmpty() ) {
            allClasses.addAll(extraClasses);
-        } 
-       
+        }
+
         // JAXB: setup
         JAXBDataBinding jaxbDataBinding;
         try {
@@ -109,53 +109,53 @@ class RemoteCommandWebserviceClientBuilderImpl extends RemoteWebserviceClientBui
             throw new RemoteApiException("Unable to initialize JAXB context for webservice client", jaxbe);
         }
         factory.getClientFactoryBean().setDataBinding(jaxbDataBinding);
-       
+
         // setup auth
         // - for webservice calls
         String pwd = config.getPassword();
         String user = config.getUserName();
         factory.setUsername(user);
         factory.setPassword(pwd);
-       
+
         CommandWebService commandService = (CommandWebService) factory.create();
         Client proxyClient = ClientProxy.getClient(commandService);
-        HTTPConduit conduit = (HTTPConduit) proxyClient.getConduit(); 
+        HTTPConduit conduit = (HTTPConduit) proxyClient.getConduit();
 
         // setup timeout
         HTTPClientPolicy httpClientPolicy = conduit.getClient();
         httpClientPolicy.setConnectionTimeout(config.getTimeout());
         httpClientPolicy.setReceiveTimeout(config.getTimeout());
         httpClientPolicy.setAutoRedirect(config.getHttpRedirect());
-        
+
         // if present, add deployment id for JAXB context
         String deploymentId = config.getDeploymentId();
-        if( ! emptyDeploymentId(deploymentId) ) { 
+        if( ! emptyDeploymentId(deploymentId) ) {
             Map<String, List<String>> headers = new HashMap<String, List<String>>(1);
             String [] depIdHeader = { deploymentId };
             headers.put(JaxbSerializationProvider.EXECUTE_DEPLOYMENT_ID_HEADER, Arrays.asList(depIdHeader));
             proxyClient.getRequestContext().put(org.apache.cxf.message.Message.PROTOCOL_HEADERS, headers);
         }
-       
+
         return commandService;
     }
 
     /**
-     * Verify that the given URL points to a valid URL by connecting to the URL and checking the response status. 
-     * </p> 
-     * If HTTP redirect has been enabled, return the 
-     * 
+     * Verify that the given URL points to a valid URL by connecting to the URL and checking the response status.
+     * </p>
+     * If HTTP redirect has been enabled, return the
+     *
      * @param wsdlUrl
      * @return
      */
-    private URL verifyURLWithRedirect(URL wsdlUrl) { 
+    private URL verifyURLWithRedirect(URL wsdlUrl) {
         int redirectTries = 0;
         URL newWsdlUrl = wsdlUrl;
         int connStatus = -1;
-        do { 
+        do {
             wsdlUrl = newWsdlUrl;
 
             HttpURLConnection conn;
-            try { 
+            try {
                 conn = (HttpURLConnection) wsdlUrl.openConnection();
                 conn.setInstanceFollowRedirects(false);
                 String encoded = Base64Utility.encode((config.getUserName() + ":" + config.getPassword()).getBytes("UTF-8"));
@@ -165,18 +165,18 @@ class RemoteCommandWebserviceClientBuilderImpl extends RemoteWebserviceClientBui
                 throw new IllegalStateException("Could not verify WSDL URL: [" + wsdlUrl.toExternalForm() + "]", e);
             }
 
-            switch( connStatus ) { 
+            switch( connStatus ) {
             case HttpURLConnection.HTTP_OK:
                 break;
             case HttpURLConnection.HTTP_MOVED_TEMP:
             case HttpURLConnection.HTTP_MOVED_PERM:
             case HttpURLConnection.HTTP_SEE_OTHER:
                 String newWsdlLoc = conn.getHeaderField(HttpHeaders.LOCATION);
-                if( config.getHttpRedirect() ) { 
-                    if( newWsdlLoc.startsWith("/") ) { 
+                if( config.getHttpRedirect() ) {
+                    if( newWsdlLoc.startsWith("/") ) {
                         URL baseUrl = config.getServerBaseUrl();
                         newWsdlLoc = baseUrl.getProtocol() + "://" + baseUrl.getAuthority() + newWsdlLoc;
-                    } else if( ! newWsdlLoc.startsWith("http") ) { 
+                    } else if( ! newWsdlLoc.startsWith("http") ) {
                         throw new RemoteCommunicationException("Could not parse redirect URL: [" + newWsdlLoc + "]");
                     }
                     try {
@@ -184,28 +184,28 @@ class RemoteCommandWebserviceClientBuilderImpl extends RemoteWebserviceClientBui
                     } catch( MalformedURLException murle ) {
                         throw new RemoteCommunicationException("Redirect URL returned by server is invalid: [" + newWsdlLoc + "]", murle);
                     }
-                } else { 
+                } else {
                     throw new RemoteCommunicationException("HTTP Redirect is not set but server redirected client to [" + newWsdlLoc + "]" );
                 }
                 break;
             default:
                 throw new RemoteCommunicationException("Status " + connStatus + " received when verifying WSDL URL: [" + wsdlUrl.toExternalForm() + "]");
-            } 
+            }
             ++redirectTries;
         } while( redirectTries < 3 && ! wsdlUrl.equals(newWsdlUrl) && connStatus != 200 );
 
-        if( connStatus != 200 ) { 
-            if( newWsdlUrl.equals(wsdlUrl) && connStatus >= 300 && connStatus < 400 ) { 
+        if( connStatus != 200 ) {
+            if( newWsdlUrl.equals(wsdlUrl) && connStatus >= 300 && connStatus < 400 ) {
                 throw new RemoteCommunicationException("Unable to verify WSDL URL: request returned a redirect to the same URL [" + newWsdlUrl + "]");
-            } else { 
+            } else {
                 throw new RemoteCommunicationException("Unable to verify WSDL URL: request returned status " + connStatus + " after " + redirectTries + " redirects [" + newWsdlUrl + "]");
             }
         }
-        
+
         if( ! wsdlUrl.equals(newWsdlUrl) ) {
             throw new RemoteCommunicationException("Server redirected (WSDL) request 3 times in a row. The last request URL was [" + newWsdlUrl + "]");
         }
-        
+
         return wsdlUrl;
     }
 }

--- a/kie-remote/kie-remote-client/src/test/java/org/kie/remote/services/ws/command/CommandServiceTest.java
+++ b/kie-remote/kie-remote-client/src/test/java/org/kie/remote/services/ws/command/CommandServiceTest.java
@@ -3,23 +3,24 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package org.kie.remote.services.ws.command;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.net.URL;
 import java.util.Random;
 import java.util.UUID;
@@ -28,8 +29,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import javax.xml.namespace.QName;
 import javax.xml.ws.BindingProvider;
 import javax.xml.ws.Endpoint;
-import javax.xml.ws.soap.SOAPFaultException;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.cxf.jaxws.EndpointImpl;
 import org.apache.cxf.ws.security.SecurityConstants;
 import org.junit.AfterClass;
@@ -41,60 +42,70 @@ import org.kie.remote.services.ws.command.generated.CommandServiceBasicAuthClien
 import org.kie.remote.services.ws.command.generated.CommandWebService;
 import org.kie.remote.services.ws.command.test.TestCommandBasicAuthImpl;
 import org.kie.remote.services.ws.command.test.TestServerPasswordCallback;
+import org.kie.services.client.builder.redirect.AvailablePortFinder;
 import org.kie.services.shared.ServicesVersion;
-
 
 public class CommandServiceTest {
 
     protected static URL[] wsdlURL = new URL[2];
-    protected static QName [] serviceName= new QName[2];
+    protected static QName[] serviceName = new QName[2];
     protected static QName[] portName = new QName[2];
 
     private final static Random random = new Random();
     private final static AtomicLong idGen = new AtomicLong(random.nextInt(10000));
 
     public final static String NAMESPACE = "http://services.remote.kie.org/" + ServicesVersion.VERSION + "/command";
-    
+
     static {
         serviceName[0] = new QName(NAMESPACE, "CommandServiceBasicAuth");
         portName[0] = new QName(NAMESPACE, "CommandServiceBasicAuthPort");
     }
 
     protected static Endpoint[] eps = new Endpoint[2];
-    
-    public static Endpoint setupCommandServiceEndpoint( URL wsdlUrl, String address, CommandWebService webServiceImpl ) {
+
+    public static Endpoint setupCommandServiceEndpoint( String address, CommandWebService webServiceImpl ) {
         EndpointImpl ep = (EndpointImpl) Endpoint.create(webServiceImpl);
         ep.setAddress(address);
         ep.getProperties().put(SecurityConstants.CALLBACK_HANDLER, new TestServerPasswordCallback());
-        
+
         ep.publish();
         return ep;
-    } 
-        
+    }
+
     @BeforeClass
     public static void setUp() throws Exception {
-        {
-            String address = "http://localhost:9000/ws/CommandService";
-            URL url = CommandServiceTest.class.getResource("/wsdl/CommandService.wsdl");
-            assertNotNull("Null URL for wsdl resource", url);
-            CommandWebService webServiceImpl = new TestCommandBasicAuthImpl();
-            eps[0] = setupCommandServiceEndpoint(url, address, webServiceImpl);
-            wsdlURL[0] = new URL(address + "?wsdl");
-        }
+        int port = AvailablePortFinder.getNextAvailable(1025);
+        String serverAdress = "http://localhost:" + port;
+        String address = serverAdress + "/ws/CommandService";
+        URL url = CommandServiceTest.class.getResource("/wsdl/CommandService.wsdl");
+        assertNotNull("Null URL for wsdl resource", url);
+
+        // replace "VERSION" with actual version
+        File file = new File(url.toURI());
+        String content = IOUtils.toString(new FileInputStream(new File(url.toURI())));
+        content = content.replaceAll("VERSION", ServicesVersion.VERSION);
+        IOUtils.write(content, new FileOutputStream(file), "UTF-8");
+
+        CommandWebService webServiceImpl = new TestCommandBasicAuthImpl();
+        eps[0] = setupCommandServiceEndpoint(address, webServiceImpl);
+        wsdlURL[0] = new URL(address + "?wsdl");
     }
 
     @AfterClass
     public static void tearDown() {
         for( Endpoint ep : eps ) {
             try {
-                ep.stop();
+                if( ep != null ) {
+                    ep.stop();
+                }
             } catch( Throwable t ) {
+                t.printStackTrace();
                 System.out.println("Error thrown: " + t.getMessage());
             }
         }
     }
 
-    private CommandServiceBasicAuthClient getPlainTextServiceClient( URL wsdlURL ) { 
+    private CommandServiceBasicAuthClient getPlainTextServiceClient( URL wsdlURL ) {
         return new CommandServiceBasicAuthClient(wsdlURL, serviceName[0]);
     }
 
@@ -114,16 +125,17 @@ public class CommandServiceTest {
         CommandWebService pws = psc.getCommandServiceBasicAuthPort();
         BindingProvider bindingProxy = (BindingProvider) pws;
 
-        /** no way to test auth here
-        // setup auth
-        bindingProxy.getRequestContext().put(BindingProvider.USERNAME_PROPERTY, "mary");
-        bindingProxy.getRequestContext().put(BindingProvider.PASSWORD_PROPERTY, "mary123@");
-        **/
-      
+        /**
+         * no way to test auth here
+         * // setup auth
+         * bindingProxy.getRequestContext().put(BindingProvider.USERNAME_PROPERTY, "mary");
+         * bindingProxy.getRequestContext().put(BindingProvider.PASSWORD_PROPERTY, "mary123@");
+         **/
+
         // request with auth
         JaxbCommandsRequest req = createRequest();
         JaxbCommandsResponse resp = pws.execute(req);
-       
+
         // test response
         assertNotNull("Null response", resp);
         assertEquals("Deployment id", req.getDeploymentId(), resp.getDeploymentId());
@@ -132,15 +144,16 @@ public class CommandServiceTest {
         psc = getPlainTextServiceClient(wsdlURL[0]);
         pws = psc.getCommandServiceBasicAuthPort();
         bindingProxy = (BindingProvider) pws;
-        
-        /** do request without auth
-        try { 
-            resp = pws.execute(req);
-            fail("The WS call should have failed without authentication");
-        } catch( SOAPFaultException soapfe ) { 
-            assertTrue( soapfe.getMessage().contains("No username") );
-        }
-        **/
+
+        /**
+         * do request without auth
+         * try {
+         * resp = pws.execute(req);
+         * fail("The WS call should have failed without authentication");
+         * } catch( SOAPFaultException soapfe ) {
+         * assertTrue( soapfe.getMessage().contains("No username") );
+         * }
+         **/
     }
 
 }

--- a/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/jaxb/JaxbCommandsRequest.java
+++ b/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/jaxb/JaxbCommandsRequest.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -25,6 +25,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElements;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlSchemaType;
+import javax.xml.bind.annotation.XmlSeeAlso;
 
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.drools.core.command.GetVariableCommand;
@@ -48,6 +49,7 @@ import org.drools.core.command.runtime.rule.DeleteCommand;
 import org.drools.core.command.runtime.rule.FireAllRulesCommand;
 import org.drools.core.command.runtime.rule.InsertObjectCommand;
 import org.drools.core.command.runtime.rule.UpdateCommand;
+import org.drools.core.xml.jaxb.util.JaxbListWrapper;
 import org.jbpm.process.audit.command.AuditCommand;
 import org.jbpm.process.audit.command.ClearHistoryLogsCommand;
 import org.jbpm.process.audit.command.FindActiveProcessInstancesCommand;
@@ -106,6 +108,7 @@ import org.kie.services.shared.ServicesVersion;
 @XmlRootElement(name = "command-request")
 @XmlAccessorType(XmlAccessType.FIELD)
 @SuppressWarnings("rawtypes")
+@XmlSeeAlso({JaxbListWrapper.class})
 public class JaxbCommandsRequest {
 
     @XmlElement(name = "deployment-id")
@@ -127,7 +130,7 @@ public class JaxbCommandsRequest {
     @XmlElement
     @XmlSchemaType(name = "string")
     private String correlationKeyString;
-    
+
     // This array is set during server-side processing of the JMS
     private transient String [] userPass;
 
@@ -136,7 +139,7 @@ public class JaxbCommandsRequest {
             @XmlElement(name = "complete-work-item", type = CompleteWorkItemCommand.class),
             @XmlElement(name = "abort-work-item", type = AbortWorkItemCommand.class),
             @XmlElement(name = "get-workitem", type = GetWorkItemCommand.class),
-            
+
             @XmlElement(name = "abort-process-instance", type = AbortProcessInstanceCommand.class),
             @XmlElement(name = "get-process-ids", type = GetProcessIdsCommand.class),
             @XmlElement(name = "get-process-instance-by-correlation-key", type = GetProcessInstanceByCorrelationKeyCommand.class),
@@ -146,18 +149,18 @@ public class JaxbCommandsRequest {
             @XmlElement(name = "signal-event", type = SignalEventCommand.class),
             @XmlElement(name = "start-correlated-process", type = StartCorrelatedProcessCommand.class),
             @XmlElement(name = "start-process", type = StartProcessCommand.class),
-            
+
             @XmlElement(name = "get-variable", type = GetVariableCommand.class),
             @XmlElement(name = "get-fact-count", type = GetFactCountCommand.class),
             @XmlElement(name = "get-global", type = GetGlobalCommand.class),
             @XmlElement(name = "get-id", type = GetIdCommand.class),
             @XmlElement(name = "set-global", type = SetGlobalCommand.class),
-            
+
             @XmlElement(name = "delete", type = DeleteCommand.class),
             @XmlElement(name = "fire-all-rules", type = FireAllRulesCommand.class),
             @XmlElement(name = "insert-object", type = InsertObjectCommand.class),
             @XmlElement(name = "update", type = UpdateCommand.class),
-           
+
             // task
             @XmlElement(name = "activate-task", type = ActivateTaskCommand.class),
             @XmlElement(name = "add-task", type = AddTaskCommand.class),
@@ -178,11 +181,11 @@ public class JaxbCommandsRequest {
             @XmlElement(name = "get-all-comments", type = GetAllCommentsCommand.class),
             @XmlElement(name = "get-comment", type = GetCommentCommand.class),
             @XmlElement(name = "set-task-property", type = SetTaskPropertyCommand.class),
-           
+
             @XmlElement(name = "add-content-from-user", type = AddContentFromUserCommand.class),
             @XmlElement(name = "get-content-by-id", type = GetContentByIdForUserCommand.class),
             @XmlElement(name = "get-content-map-for-user", type = GetContentMapForUserCommand.class),
-            
+
             @XmlElement(name = "get-task-as-business-admin", type = GetTaskAssignedAsBusinessAdminCommand.class),
             @XmlElement(name = "get-task-as-potential-owner", type = GetTaskAssignedAsPotentialOwnerCommand.class),
             @XmlElement(name = "get-task-by-workitemid", type = GetTaskByWorkItemIdCommand.class),
@@ -192,7 +195,7 @@ public class JaxbCommandsRequest {
             @XmlElement(name = "get-tasks-by-various", type = GetTasksByVariousFieldsCommand.class),
             @XmlElement(name = "get-tasks-owned", type = GetTasksOwnedCommand.class),
             @XmlElement(name = "task-query-where", type = TaskQueryWhereCommand.class),
-            
+
             @XmlElement(name = "nominate-task", type = NominateTaskCommand.class),
             @XmlElement(name = "release-task", type = ReleaseTaskCommand.class),
             @XmlElement(name = "resume-task", type = ResumeTaskCommand.class),
@@ -203,7 +206,7 @@ public class JaxbCommandsRequest {
             @XmlElement(name = "process-sub-tasks", type = ProcessSubTaskCommand.class),
             @XmlElement(name = "execute-task-rules", type = ExecuteTaskRulesCommand.class),
             @XmlElement(name = "cancel-deadline", type = CancelDeadlineCommand.class),
-            
+
             // audit
             @XmlElement(name = "clear-history-logs", type = ClearHistoryLogsCommand.class),
             @XmlElement(name = "find-active-process-instances", type = FindActiveProcessInstancesCommand.class),
@@ -226,7 +229,7 @@ public class JaxbCommandsRequest {
         this.commands.add(command);
         checkThatCommandsContainDeploymentIdIfNeeded(this.commands);
     }
-    
+
     public JaxbCommandsRequest(List<Command> commands) {
         checkThatCommandsAreAccepted(commands);
         this.commands = new ArrayList<Command>();
@@ -235,8 +238,8 @@ public class JaxbCommandsRequest {
     }
 
     private void checkThatCommandsContainDeploymentIdIfNeeded(List<Command> checkCommands) {
-        for( Command<?> command : checkCommands ) { 
-            if( ! (command instanceof TaskCommand<?>) && ! (command instanceof AuditCommand<?>) ) { 
+        for( Command<?> command : checkCommands ) {
+            if( ! (command instanceof TaskCommand<?>) && ! (command instanceof AuditCommand<?>) ) {
                 throw new UnsupportedOperationException( "A " + command.getClass().getSimpleName() + " requires that the deployment id has been set!" );
             }
         }
@@ -256,18 +259,18 @@ public class JaxbCommandsRequest {
         this.commands.addAll(commands);
     }
 
-    private void checkThatCommandsAreAccepted(Collection<Command> cmds) { 
-       for( Command cmd : cmds ) { 
-          checkThatCommandIsAccepted(cmd); 
+    private void checkThatCommandsAreAccepted(Collection<Command> cmds) {
+       for( Command cmd : cmds ) {
+          checkThatCommandIsAccepted(cmd);
        }
     }
-    
-    private void checkThatCommandIsAccepted(Command<?> cmd) { 
+
+    private void checkThatCommandIsAccepted(Command<?> cmd) {
         if( ! AcceptedServerCommands.isAcceptedCommandClass(cmd.getClass()) ) {
-           throw new UnsupportedOperationException(cmd.getClass().getName() + " is not an accepted command." ); 
+           throw new UnsupportedOperationException(cmd.getClass().getName() + " is not an accepted command." );
         }
     }
-    
+
     public String getDeploymentId() {
         return deploymentId;
     }
@@ -307,23 +310,23 @@ public class JaxbCommandsRequest {
     public void setCorrelationKeyString(String correlationKeyString) {
         this.correlationKeyString = correlationKeyString;
     }
-    
+
     public CorrelationKey getCorrelationKey() {
         return CorrelationKeyXmlAdapter.unmarshalCorrelationKey(this.correlationKeyString);
     }
-    
+
     public void setCommands(List<Command> commands) {
         checkThatCommandsAreAccepted(commands);
         this.commands = commands;
     }
 
     public List<Command> getCommands() {
-        if( this.commands == null ) { 
+        if( this.commands == null ) {
             this.commands = new ArrayList<Command>();
         }
         return this.commands;
     }
-   
+
     @JsonIgnore
     public String [] getUserPass() {
         return userPass;

--- a/kie-remote/kie-remote-services/src/test/java/org/kie/remote/services/RandomUtil.java
+++ b/kie-remote/kie-remote-services/src/test/java/org/kie/remote/services/RandomUtil.java
@@ -1,0 +1,21 @@
+package org.kie.remote.services;
+
+import java.util.Random;
+
+public class RandomUtil {
+
+    private static Random random = new Random();
+
+    public static int nextInt() {
+        return random.nextInt();
+    }
+
+    public static long nextLong() {
+        return random.nextLong();
+    }
+
+    public static int nextInt(int n) {
+        return random.nextInt(n);
+    }
+
+}

--- a/kie-remote/kie-remote-services/src/test/java/org/kie/remote/services/rest/query/AbstractQueryResourceTest.java
+++ b/kie-remote/kie-remote-services/src/test/java/org/kie/remote/services/rest/query/AbstractQueryResourceTest.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.UUID;
 
 import org.codehaus.jackson.map.ObjectMapper;
@@ -35,6 +34,7 @@ import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.task.TaskService;
 import org.kie.api.task.model.Task;
 import org.kie.remote.client.jaxb.ClientJaxbSerializationProvider;
+import org.kie.remote.services.RandomUtil;
 import org.kie.remote.services.jaxb.ServerJaxbSerializationProvider;
 import org.kie.services.client.serialization.JaxbSerializationProvider;
 import org.kie.test.MyType;
@@ -46,13 +46,13 @@ import ch.qos.logback.classic.Level;
 abstract class AbstractQueryResourceTest extends JbpmJUnitBaseTestCase {
 
     protected static final Logger logger = LoggerFactory.getLogger(QueryResourceQueryBuilderTest.class);
-    
+
     protected static final String PROCESS_STRING_VAR_FILE = "BPMN2-HumanTaskWithStringVariables.bpmn2";
     protected static final String PROCESS_STRING_VAR_ID = "org.var.human.task.string";
     protected static final String PROCESS_OBJ_VAR_FILE = "BPMN2-HumanTaskWithObjectVariables.bpmn2";
     protected static final String PROCESS_OBJ_VAR_ID = "org.var.human.task.object";
     protected static final String USER_ID = "john";
-    
+
     protected static ObjectMapper jsonMapper = new ObjectMapper();
     protected static JaxbSerializationProvider jaxbClientMapper = ServerJaxbSerializationProvider.newInstance();
     protected static JaxbSerializationProvider jaxbServerMapper = ClientJaxbSerializationProvider.newInstance();
@@ -67,124 +67,123 @@ abstract class AbstractQueryResourceTest extends JbpmJUnitBaseTestCase {
 
     public AbstractQueryResourceTest() {
         super(true, true, "org.jbpm.domain");
-        
+
         Logger logger = LoggerFactory.getLogger(DatabaseMetadata.class);
-        if( logger instanceof ch.qos.logback.classic.Logger ) { 
+        if( logger instanceof ch.qos.logback.classic.Logger ) {
             ((ch.qos.logback.classic.Logger) logger).setLevel(Level.OFF);
         }
     }
-    
-    protected <T> T roundTripJson(T in) throws Exception { 
+
+    protected <T> T roundTripJson(T in) throws Exception {
         String jsonStr = jsonMapper.writeValueAsString(in);
         logger.debug("\n" + jsonStr);
         return (T) jsonMapper.readValue(jsonStr, in.getClass());
     }
-   
-    protected <T> T roundTripXml(T in) throws Exception { 
+
+    protected <T> T roundTripXml(T in) throws Exception {
         String xmlStr = jaxbServerMapper.serialize(in);
         logger.debug("\n" + xmlStr);
         return (T) jaxbClientMapper.deserialize(xmlStr);
     }
-  
+
     // must be at least 5
     protected static int numTestProcesses = 10;
     protected boolean testDataInitialized = false;
     protected boolean addObjectProcessInstances = true;
-    
-    protected void setupTestData() { 
-        if( ! testDataInitialized ) { 
-            for( int i = 0; i < numTestProcesses; ++i ) { 
+
+    protected void setupTestData() {
+        if( ! testDataInitialized ) {
+            for( int i = 0; i < numTestProcesses; ++i ) {
                 runStringProcess(ksession, i);
-                if( addObjectProcessInstances ) { 
+                if( addObjectProcessInstances ) {
                     runObjectProcess(ksession, i);
                 }
             }
             testDataInitialized = true;
         }
-    } 
-        
-    protected void runStringProcess(KieSession ksession, int i) { 
+    }
+
+    protected void runStringProcess(KieSession ksession, int i) {
         Map<String, Object> params = new HashMap<String, Object>();
         String initValue = UUID.randomUUID().toString();
         params.put("inputStr", "proc-" + i + "-" + initValue );
-        params.put("otherStr", "proc-" + i + "-" + initValue ); 
-        params.put("secondStr", i + "-second-" + random.nextInt(Integer.MAX_VALUE));
+        params.put("otherStr", "proc-" + i + "-" + initValue );
+        params.put("secondStr", i + "-second-" + RandomUtil.nextInt(Integer.MAX_VALUE));
         ProcessInstance processInstance = ksession.startProcess(PROCESS_STRING_VAR_ID, params);
         assertTrue( processInstance != null && processInstance.getState() == ProcessInstance.STATE_ACTIVE);
         long procInstId = processInstance.getId();
         procInstIds.add(procInstId);
-        
+
         List<Long> taskIds = taskService.getTasksByProcessInstanceId(procInstId);
         assertFalse( "No tasks found!", taskIds.isEmpty() );
-        long taskId = taskIds.get(0); 
+        long taskId = taskIds.get(0);
         taskService.start(taskId, USER_ID);
-        
+
         Map<String, Object> taskResults = new HashMap<String, Object>();
         taskResults.put("taskOutputStr", "task-1-" + procInstId);
         taskService.complete(taskId, USER_ID, taskResults);
-    
+
         AuditLogService logService = new JPAAuditLogService(getEmf());
         List<VariableInstanceLog> vils = logService.findVariableInstances(procInstId);
         assertTrue( "No variable instance logs found", vils != null && ! vils.isEmpty() );
         assertTrue( "Too few variable instance logs found", vils.size() > 3 );
-        
+
         taskIds = taskService.getTasksByProcessInstanceId(procInstId);
         assertFalse( "No tasks found!", taskIds.isEmpty() );
-        taskId = taskIds.get(1); 
+        taskId = taskIds.get(1);
         Task task = taskService.getTaskById(taskId);
         taskService.start(taskId, USER_ID);
-        
+
         taskResults = new HashMap<String, Object>();
         taskResults.put("taskOutputStr", "task-2-" + procInstId);
         taskService.complete(taskId, USER_ID, taskResults);
-        
+
         assertNull("Process instance has not been finished.", ksession.getProcessInstance(procInstId) );
     }
 
-    protected static Random random = new Random();
-    
-    protected void runObjectProcess(KieSession ksession, int i) { 
+
+    protected void runObjectProcess(KieSession ksession, int i) {
         Map<String, Object> params = new HashMap<String, Object>();
         String initValue = "start-" + i;
-        params.put("inputStr", new MyType(initValue, random.nextInt()));
-        params.put("otherStr", new MyType(initValue, random.nextInt()));
+        params.put("inputStr", new MyType(initValue, RandomUtil.nextInt()));
+        params.put("otherStr", new MyType(initValue, RandomUtil.nextInt()));
         ProcessInstance processInstance = ksession.startProcess(PROCESS_OBJ_VAR_ID, params);
         assertTrue( processInstance != null && processInstance.getState() == ProcessInstance.STATE_ACTIVE);
         long procInstId = processInstance.getId();
-        
+
         List<Long> taskIds = taskService.getTasksByProcessInstanceId(procInstId);
         assertFalse( "No tasks found!", taskIds.isEmpty() );
-        long taskId = taskIds.get(0); 
+        long taskId = taskIds.get(0);
         taskService.start(taskId, USER_ID);
-        
+
         Map<String, Object> taskResults = new HashMap<String, Object>();
-        taskResults.put("taskOutputStr", new MyType("task-" + procInstId, random.nextInt()));
+        taskResults.put("taskOutputStr", new MyType("task-" + procInstId, RandomUtil.nextInt()));
         taskService.complete(taskId, USER_ID, taskResults);
-    
+
         assertNull("Process instance has not been finished.", ksession.getProcessInstance(procInstId) );
-        
+
         AuditLogService logService = new JPAAuditLogService(getEmf());
         List<VariableInstanceLog> vils = logService.findVariableInstances(procInstId);
         assertTrue( "No variable instance logs found", vils != null && ! vils.isEmpty() );
         assertTrue( "Too few variable instance logs found: " + vils.size(), vils.size() >= 3 );
-        
+
         VariableInstanceLog lastVil = null;
-        for( VariableInstanceLog vil : vils ) { 
-            if( ! vil.getVariableId().equals("inputStr") ) { 
-               continue; 
+        for( VariableInstanceLog vil : vils ) {
+            if( ! vil.getVariableId().equals("inputStr") ) {
+               continue;
             }
-            if( lastVil == null ) { 
+            if( lastVil == null ) {
                 lastVil = vil;
             }
-            if( lastVil.getId() < vil.getId() ) { 
+            if( lastVil.getId() < vil.getId() ) {
                 lastVil = vil;
             }
         }
-        assertTrue( lastVil.getVariableId() + ": " + lastVil.getValue(), 
+        assertTrue( lastVil.getVariableId() + ": " + lastVil.getValue(),
                 lastVil.getValue().contains("check") || lastVil.getVariableId().equals("otherStr") );
     }
 
-    protected static void addParams(Map<String, String[]> params, String name, String... values ) { 
+    protected static void addParams(Map<String, String[]> params, String name, String... values ) {
        params.put(name,  values);
     }
 }

--- a/kie-remote/kie-remote-services/src/test/java/org/kie/remote/services/rest/query/QueryResourceQueryHelperTest.java
+++ b/kie-remote/kie-remote-services/src/test/java/org/kie/remote/services/rest/query/QueryResourceQueryHelperTest.java
@@ -36,6 +36,7 @@ import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.internal.identity.IdentityProvider;
 import org.kie.internal.task.api.InternalTaskService;
+import org.kie.remote.services.RandomUtil;
 import org.kie.remote.services.cdi.ProcessRequestBean;
 import org.kie.remote.services.rest.QueryResourceImpl;
 import org.kie.remote.services.rest.query.helpers.InternalProcInstQueryHelper;

--- a/kie-remote/kie-remote-services/src/test/java/org/kie/remote/services/rest/query/QueryResourceTest.java
+++ b/kie-remote/kie-remote-services/src/test/java/org/kie/remote/services/rest/query/QueryResourceTest.java
@@ -45,6 +45,7 @@ import org.kie.api.task.model.Task;
 import org.kie.api.task.model.TaskSummary;
 import org.kie.internal.identity.IdentityProvider;
 import org.kie.internal.task.api.InternalTaskService;
+import org.kie.remote.services.RandomUtil;
 import org.kie.remote.services.cdi.ProcessRequestBean;
 import org.kie.remote.services.jaxb.JaxbTaskSummaryListResponse;
 import org.kie.remote.services.rest.QueryResourceImpl;
@@ -451,7 +452,7 @@ public class QueryResourceTest extends AbstractQueryResourceTest {
         String initValue = UUID.randomUUID().toString();
         processParams.put("inputStr", "proc-" + numTestProcesses + "-" + initValue );
         processParams.put("otherStr", "proc-" + numTestProcesses + "-" + initValue );
-        processParams.put("secondStr", numTestProcesses + "-second-" + random.nextInt(Integer.MAX_VALUE));
+        processParams.put("secondStr", numTestProcesses + "-second-" + RandomUtil.nextInt(Integer.MAX_VALUE));
         org.kie.api.runtime.process.ProcessInstance processInstance = ksession.startProcess(PROCESS_STRING_VAR_ID, processParams);
         assertTrue( processInstance != null && processInstance.getState() == ProcessInstance.STATE_ACTIVE);
         long procInstId = processInstance.getId();
@@ -468,6 +469,7 @@ public class QueryResourceTest extends AbstractQueryResourceTest {
         List<TaskSummary> taskSumList = resp.getResult();
         assertNotNull( "Null task summary list", taskSumList );
         assertFalse( "Empty task summary list", taskSumList.isEmpty() );
+
         Set<Long> uniqueTaskIds = new HashSet<Long>();
         for( TaskSummary taskSum : taskSumList ) {
             assertEquals( "Incorrect process instance id on task summary", procInstId, taskSum.getProcessInstanceId().longValue() );

--- a/kie-remote/kie-remote-services/src/test/java/org/kie/remote/services/ws/NamespacesTest.java
+++ b/kie-remote/kie-remote-services/src/test/java/org/kie/remote/services/ws/NamespacesTest.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -15,18 +15,17 @@
 
 package org.kie.remote.services.ws;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.lang.reflect.Field;
 import java.util.Set;
 
-import static org.junit.Assert.*;
-
 import javax.jws.WebService;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.reflections.Reflections;
-import org.reflections.scanners.FieldAnnotationsScanner;
-import org.reflections.scanners.MethodAnnotationsScanner;
 import org.reflections.scanners.SubTypesScanner;
 import org.reflections.scanners.TypeAnnotationsScanner;
 import org.reflections.util.ClasspathHelper;
@@ -36,19 +35,19 @@ public class NamespacesTest {
 
     Reflections reflections = new Reflections(ClasspathHelper.forPackage("org.kie.remote.services.ws"),
             new TypeAnnotationsScanner(), new SubTypesScanner());
-    
+
     @Test
-    public void nameSpacesAreCorrectTest() throws Exception { 
+    public void nameSpacesAreCorrectTest() throws Exception {
         Set<Class<?>> webServiceImplClasses = reflections.getTypesAnnotatedWith(WebService.class);
         assertTrue( "No classes found!", webServiceImplClasses.size() > 0 );
 
-        for( Class wsCl : webServiceImplClasses ) { 
-            if( wsCl.getSimpleName().endsWith("Impl") ) { 
+        for( Class wsCl : webServiceImplClasses ) {
+            if( wsCl.getSimpleName().endsWith("Impl") ) {
                Field nsField = wsCl.getDeclaredField("NAMESPACE");
                nsField.setAccessible(true);
                String implNamespace = (String) nsField.get(null);
                String defNamespace = ((WebService) wsCl.getAnnotation(WebService.class)).targetNamespace();
-               assertEquals(wsCl.getSimpleName() + " namespace is incorrectly defined in the impl class", 
+               assertEquals(wsCl.getSimpleName() + " namespace is incorrectly defined in the impl class",
                        defNamespace, implNamespace);
             } else if( wsCl.getSimpleName().endsWith("WebServce") ) {
                 fail( "Unexpected name for a webservice interface: " + wsCl.getName());


### PR DESCRIPTION
Because I have the unique (and lovely! /8( ) situation of having a client whose classpath must be different than the server side, easy integration tests for webservice (and REST) issues are not easy without a _lot_ of work (think a custom classloader framework, just for the test!). 

The test for this is available in https://github.com/droolsjbpm/kie-tests/pull/14

However, the fix in this PR is another hack. It works, but it's another band-aid/strand of spaghetti. For this reason, please do _not_ cherry-pick this to master. 

In master, classes will slowly be centralized in either `kie-core-jaxb` (one of the new `kie-core` modules, resulting from @mariofusco 's work to separate drools and jbpm from eachother) or in `kie-internal`. I will submit a PR for that fix later this week. 