### PR TITLE
BZ-1273109 - BPM cluster: Job executor fails with NPE while creating a deployment unit

### DIFF
--- a/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/DeployResourceBase.java
+++ b/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/DeployResourceBase.java
@@ -186,11 +186,11 @@ public class DeployResourceBase extends ResourceBase {
         }
         
         // Most recent job? 
-        JaxbDeploymentJobResult jobResult = jobResultMgr.getMostRecentJob(deploymentId);
-        if( jobResult != null ) { 
-            jaxbDepUnit = jobResult.getDeploymentUnit();
-            return jaxbDepUnit;
-        }
+//        JaxbDeploymentJobResult jobResult = jobResultMgr.getMostRecentJob(deploymentId);
+//        if( jobResult != null ) {
+//            jaxbDepUnit = jobResult.getDeploymentUnit();
+//            return jaxbDepUnit;
+//        }
         
         // Nonexistent? 
         String [] gavKK = deploymentId.split(":");

--- a/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/DeployResourceBase.java
+++ b/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/DeployResourceBase.java
@@ -184,15 +184,7 @@ public class DeployResourceBase extends ResourceBase {
                 return jaxbDepUnit;
             } 
         }
-        
-        // Most recent job? 
-//        JaxbDeploymentJobResult jobResult = jobResultMgr.getMostRecentJob(deploymentId);
-//        if( jobResult != null ) {
-//            jaxbDepUnit = jobResult.getDeploymentUnit();
-//            return jaxbDepUnit;
-//        }
-        
-        // Nonexistent? 
+
         String [] gavKK = deploymentId.split(":");
         switch( gavKK.length ) { 
         case 3:
@@ -207,7 +199,7 @@ public class DeployResourceBase extends ResourceBase {
         default:
             throw KieRemoteRestOperationException.notFound("Invalid deployment id: " + deploymentId);
         }
-        jaxbDepUnit.setStatus(JaxbDeploymentStatus.NONEXISTENT);
+        jaxbDepUnit.setStatus(JaxbDeploymentStatus.UNDEPLOYED);
         return jaxbDepUnit;
     }
 


### PR DESCRIPTION
This pr comes with two commits
- first to fix the problem of possible NPE when deployment job is executed on another node than the request came it - should check both input and output of the job for completeness and not only the output
- second is to remove most recent jobs cache as it might serve outdated information as the cache is only maintained in memory. so when there were two jobs - first to deploy and second to undeploy and these jobs were performed on cluster nodes the cache for most recent jobs will be outdated on one of the nodes and thus providing misleading response. This happens especially when cluster nodes have not sync yet

@mrietveld could you please have a look?