### PR TITLE
Upgrade takari-plugin-testing to 2.8.0 to fix failing tests

### DIFF
--- a/kie-maven-plugin/pom.xml
+++ b/kie-maven-plugin/pom.xml
@@ -97,12 +97,12 @@
       <dependency>
         <groupId>io.takari.maven.plugins</groupId>
         <artifactId>takari-plugin-testing</artifactId>
-        <version>2.1.0</version>
+        <version>2.8.0</version>
       </dependency>
       <dependency>
         <groupId>io.takari.maven.plugins</groupId>
         <artifactId>takari-plugin-integration-testing</artifactId>
-        <version>2.1.0</version>
+        <version>2.8.0</version>
         <type>pom</type>
       </dependency>
     </dependencies>


### PR DESCRIPTION
 * tests were failing in case of using custom settings.xml with
   additional repositories. The tooling in version 2.1.0 would
   not pass the content of settings.xml to the project under test
   which resulted in errors due to missing dependencies.

 * the versions will be moved to build-bootstrap/ip-bom

@mbiarnes this fixes the failing tests we saw in the latest two "prod" builds.