### PR TITLE
kie-maven-plugin: use takari-maven-plugin packaging

### DIFF
--- a/kie-maven-plugin/pom.xml
+++ b/kie-maven-plugin/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.kie</groupId>
   <artifactId>kie-maven-plugin</artifactId>
-  <packaging>maven-plugin</packaging>
+  <packaging>takari-maven-plugin</packaging>
 
   <name>KIE :: Maven Plugin</name>
 
@@ -22,56 +22,12 @@
         <configuration>
           <goalPrefix>kie</goalPrefix>
         </configuration>
-        <executions>
-          <execution>
-            <id>generated-helpmojo</id>
-            <goals>
-              <goal>helpmojo</goal>
-            </goals>
-            <phase>process-classes</phase>
-          </execution>
-          <execution>
-            <id>generate-descriptor</id>
-            <goals>
-              <goal>descriptor</goal>
-            </goals>
-            <phase>process-classes</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-component-metadata</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>generate-metadata</goal>
-              <goal>generate-test-metadata</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>io.takari.maven.plugins</groupId>
         <artifactId>takari-lifecycle-plugin</artifactId>
-        <version>1.10.2</version>
+        <version>1.11.11</version>
         <extensions>true</extensions>
-        <executions>
-          <execution>
-            <id>testProperties</id>
-            <phase>process-test-resources</phase>
-            <goals>
-              <goal>testProperties</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <configuration>
-          <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=1024m</argLine>
-        </configuration>
       </plugin>
     </plugins>
   </build>
@@ -97,12 +53,12 @@
       <dependency>
         <groupId>io.takari.maven.plugins</groupId>
         <artifactId>takari-plugin-testing</artifactId>
-        <version>2.1.0</version>
+        <version>2.8.0</version>
       </dependency>
       <dependency>
         <groupId>io.takari.maven.plugins</groupId>
         <artifactId>takari-plugin-integration-testing</artifactId>
-        <version>2.1.0</version>
+        <version>2.8.0</version>
         <type>pom</type>
       </dependency>
     </dependencies>
@@ -116,6 +72,12 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.eclipse.sisu</groupId>
+          <artifactId>org.eclipse.sisu.inject</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
 * better alternative to the standard maven-plugin packaging.
   Requires less configuration in pom + by default adds support
   for integration testing

@mariofusco please take a look.