### PR TITLE
kie-remote-client: use explicit dependency to fix parallel builds

### DIFF
--- a/kie-remote/kie-remote-client/pom.xml
+++ b/kie-remote/kie-remote-client/pom.xml
@@ -144,6 +144,14 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- Used by dependency:unpack. The explicit dependency is needed
+         in order to make parallel builds work. -->
+    <dependency>
+      <groupId>org.kie.remote</groupId>
+      <artifactId>kie-remote-jaxb-gen</artifactId>
+      <classifier>sources</classifier>
+      <scope>test</scope>
+    </dependency>
 
     <!-- serialization -->
     <dependency>


### PR DESCRIPTION
@mrietveld could you please double check this? I believe it is safe as we are using the same on master and 6.3.x for some time now.