### PR TITLE
[DROOLS-999] remove usage of mockito-all uberjar

### DIFF
--- a/kie-remote/kie-remote-client/pom.xml
+++ b/kie-remote/kie-remote-client/pom.xml
@@ -180,11 +180,6 @@
     <!-- powermock -->
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>

--- a/kie-remote/kie-remote-services/pom.xml
+++ b/kie-remote/kie-remote-services/pom.xml
@@ -249,11 +249,6 @@
     <!-- TEST: mock -->
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm/pom.xml
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm/pom.xml
@@ -100,11 +100,6 @@
     <!-- Test -->
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency> 


### PR DESCRIPTION
 * all touched modules already contain mockito-core,
   which is sufficient