### PR TITLE
Kie server test improvement for Oracle RAC

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/RuntimeDataServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/RuntimeDataServiceIntegrationTest.java
@@ -1148,6 +1148,7 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
         processInstanceIds.add(processClient.startProcess("definition-project", "definition-project.usertask", parameters));
         processInstanceIds.add(processClient.startProcess("definition-project", "definition-project.signalprocess", parameters));
 
+        Collections.sort(processInstanceIds);
         return processInstanceIds;
     }
 


### PR DESCRIPTION
Sometimes tests failed on Oracle RAC database due wrong id sequence caused by creating process instances.