### PR TITLE
kie-server: added withVars query attribute to getProcessInstanceById …

### DIFF
--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm/src/main/java/org/kie/server/remote/rest/jbpm/RuntimeDataResource.java
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm/src/main/java/org/kie/server/remote/rest/jbpm/RuntimeDataResource.java
@@ -145,12 +145,11 @@ public class RuntimeDataResource {
     @GET
     @Path(PROCESS_INSTANCE_BY_INSTANCE_ID_GET_URI)
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
-    public Response getProcessInstanceById(@Context HttpHeaders headers, @PathParam("pInstanceId") long processInstanceId) {
+    public Response getProcessInstanceById(@Context HttpHeaders headers, @PathParam("pInstanceId") long processInstanceId, @QueryParam("withVars") boolean withVars) {
         Variant v = getVariant(headers);
         org.kie.server.api.model.instance.ProcessInstance processInstanceDesc = null;
         try{
-
-            processInstanceDesc = runtimeDataServiceBase.getProcessInstanceById(processInstanceId);
+            processInstanceDesc = runtimeDataServiceBase.getProcessInstanceById(processInstanceId, withVars);
         } catch(ProcessInstanceNotFoundException e) {
 
             return notFound(MessageFormat.format(PROCESS_INSTANCE_NOT_FOUND, processInstanceId), v);

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/RuntimeDataServiceBase.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/RuntimeDataServiceBase.java
@@ -19,7 +19,9 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.jbpm.services.api.ProcessInstanceNotFoundException;
 import org.jbpm.services.api.RuntimeDataService;
@@ -191,13 +193,25 @@ public class RuntimeDataServiceBase {
         return processInstanceList;
     }
 
-    public org.kie.server.api.model.instance.ProcessInstance getProcessInstanceById(long processInstanceId) {
+    public org.kie.server.api.model.instance.ProcessInstance getProcessInstanceById(long processInstanceId, boolean withVars) {
 
         ProcessInstanceDesc processInstanceDesc = runtimeDataService.getProcessInstanceById(processInstanceId);
         if (processInstanceDesc == null) {
             throw new ProcessInstanceNotFoundException("Could not find process instance with id " + processInstanceId);
         }
-        return convertToProcessInstance(processInstanceDesc);
+        
+        org.kie.server.api.model.instance.ProcessInstance processInstance = convertToProcessInstance(processInstanceDesc);
+        
+        if (Boolean.TRUE.equals(withVars)) {
+            Collection<VariableDesc> variableDescs = runtimeDataService.getVariablesCurrentState(processInstanceId);
+            Map<String, Object> vars = new HashMap<String, Object>();
+            for (VariableDesc var : variableDescs) {
+                vars.put(var.getVariableId(), var.getNewValue());
+            }
+            processInstance.setVariables(vars);
+        }
+        
+        return processInstance;
     }
 
 


### PR DESCRIPTION
…operation

KIE Server already provides getProcessInstance operation with query attribute withVars but only for an active process instance [1]. This PR adds this functionality to RuntimeDataResource to be able to query completed and aborted processes including their variables.

[1] https://github.com/droolsjbpm/droolsjbpm-integration/blob/master/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm/src/main/java/org/kie/server/remote/rest/jbpm/ProcessResource.java#L218