### PR TITLE
[DROOLS-1049] fix config after upgrading jaxb2-maven-plugin from 1.6 to 2.2

### DIFF
--- a/kie-remote/kie-remote-jaxb-gen/pom.xml
+++ b/kie-remote/kie-remote-jaxb-gen/pom.xml
@@ -257,32 +257,8 @@
       </plugin>
 
       <plugin>
-        <!-- We use this plugin to ensure that our usage of the
-             jaxb2-maven-plugin is JDK 8 compatible. -->
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
-        <version>1.0-alpha-2</version>
-        <executions>
-          <execution>
-            <id>set-additional-system-properties</id>
-            <goals>
-              <goal>set-system-properties</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <properties>
-            <property>
-              <name>javax.xml.accessExternalSchema</name>
-              <value>file,http</value>
-            </property>
-          </properties>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>jaxb2-maven-plugin</artifactId>
-        <version>1.6</version>
         <executions>
           <!-- 2. generate xsd's based on unpacked sources -->
           <execution>
@@ -292,11 +268,10 @@
               <goal>schemagen</goal>
             </goals>
             <configuration>
-              <includes>
-                <include>org/drools/**/*.java</include>
-                <include>org/jbpm/**/*.java</include>
-              </includes>
-              <verbose>true</verbose>
+              <sources>
+                <source>${project.basedir}/src/main/java/org/drools</source>
+                <source>${project.basedir}/src/main/java/org/jbpm</source>
+              </sources>
               <outputDirectory>${project.build.directory}/generated-xsd/</outputDirectory>
             </configuration>
           </execution>
@@ -310,8 +285,12 @@
             <configuration>
               <packageName>org.kie.remote.jaxb.gen</packageName>
               <outputDirectory>${basedir}/src/main/generated</outputDirectory>
-              <schemaDirectory>${project.build.directory}/generated-xsd/</schemaDirectory>
-              <bindingDirectory>${basedir}/src/main/resources/xjb/</bindingDirectory>
+              <sources>
+                <source>${project.build.directory}/generated-xsd/schema1.xsd</source>
+              </sources>
+              <xjbSources>
+                <xjbSource>${project.basedir}/src/main/resources/xjb/</xjbSource>
+              </xjbSources>
               <extension>true</extension>
             </configuration>
           </execution>


### PR DESCRIPTION
This upgrade _should_ fix intermittent build failures we see on Jenkins, related to jaxb2-maven-plugin:schemagen.

Needs to be merged together with https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/pull/141

@mrietveld could you please take a look?