### PR TITLE
drools-karaf-itests: add test for Spring context in META-INF/spring

### DIFF
--- a/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/KieSpringMetaInfAppContextOnKarafKarafIntegrationTest.java
+++ b/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/KieSpringMetaInfAppContextOnKarafKarafIntegrationTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2015 Red Hat
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.drools.karaf.itest;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.api.runtime.KieSession;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.karaf.options.LogLevelOption;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerMethod;
+import org.osgi.framework.Constants;
+
+import javax.inject.Inject;
+
+import static org.junit.Assert.assertNotNull;
+import static org.ops4j.pax.exam.CoreOptions.streamBundle;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureConsole;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
+import static org.ops4j.pax.tinybundles.core.TinyBundles.bundle;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerMethod.class)
+public class KieSpringMetaInfAppContextOnKarafKarafIntegrationTest extends AbstractKarafIntegrationTest {
+
+    private static final String SPRING_APP_CONTEXT_LOCATION = "/org/drools/karaf/itest/kie-beans-service.xml";
+
+    @Inject
+    KieSession kieSession;
+
+    @Test
+    public void testKieBase() throws Exception {
+        assertNotNull(kieSession);
+    }
+
+    @Configuration
+    public static Option[] configure() {
+        return new Option[]{
+                // Install Karaf Container
+                getKarafDistributionOption(),
+
+                // It is really nice if the container sticks around after the test so you can check the contents
+                // of the data directory when things go wrong.
+                keepRuntimeFolder(),
+                // Don't bother with local console output as it just ends up cluttering the logs
+                configureConsole().ignoreLocalConsole(),
+                // Force the log level to INFO so we have more details during the test.  It defaults to WARN.
+                logLevel(LogLevelOption.LogLevel.INFO),
+
+                // Option to be used to do remote debugging
+                //  debugConfiguration("5005", true),
+
+                // Load Kie-Spring
+                loadKieFeatures("kie-spring"),
+
+                // Create a bundle with META-INF/spring/kie-beans.xml - this should be processed automatically by Spring
+                streamBundle(bundle()
+                        .add("META-INF/spring/kie-beans-service.xml",
+                                KieSpringMetaInfAppContextOnKarafKarafIntegrationTest.class.getResource(SPRING_APP_CONTEXT_LOCATION))
+                        .set(Constants.IMPORT_PACKAGE, "*")
+                        .set(Constants.BUNDLE_SYMBOLICNAME, "Test-Spring-Bundle")
+                        .set(Constants.DYNAMICIMPORT_PACKAGE, "*")
+                        .build()).start()
+
+        };
+    }
+}

--- a/drools-osgi/drools-karaf-itests/src/test/resources/org/drools/karaf/itest/kie-beans-service.xml
+++ b/drools-osgi/drools-karaf-itests/src/test/resources/org/drools/karaf/itest/kie-beans-service.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:kie="http://drools.org/schema/kie-spring"
+       xmlns:osgi="http://www.springframework.org/schema/osgi"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+       http://drools.org/schema/kie-spring http://drools.org/schema/kie-spring.xsd
+       http://www.springframework.org/schema/osgi http://www.springframework.org/schema/osgi/spring-osgi.xsd
+">
+
+  <bean id="kiePostProcessor" class="org.drools.osgi.spring.OsgiKModuleBeanFactoryPostProcessor"/>
+
+  <kie:kmodule id="someid">
+    <kie:kbase name="drl_kiesample" packages="drl_kiesample">
+      <kie:ksession name="ksession9" type="stateless"/>
+      <kie:ksession name="ksession99"/>
+    </kie:kbase>
+  </kie:kmodule>
+
+  <osgi:service ref="ksession99" interface="org.kie.api.runtime.KieSession" />
+
+</beans>


### PR DESCRIPTION
Added test for case when Spring auto-detects application context stored in META-INF/spring/ in a bundle.

This use-case failed for me because of my mistake (not using OSGi-enabled KModuleBeanFactoryPostProcessor), adding the test just to prevent possible regression in future.