### PR TITLE
[BZ-1305206] kie-maven-plugin: upgrade takari-lifecycle-plugin to 1.11.11.jbossorg-1

### DIFF
--- a/kie-maven-plugin/pom.xml
+++ b/kie-maven-plugin/pom.xml
@@ -26,7 +26,7 @@
       <plugin>
         <groupId>io.takari.maven.plugins</groupId>
         <artifactId>takari-lifecycle-plugin</artifactId>
-        <version>1.11.11</version>
+        <version>1.11.11.jbossorg-1</version>
         <extensions>true</extensions>
       </plugin>
     </plugins>


### PR DESCRIPTION
 * this is only temporary until there is a proper 1.11.12 release
   directly from Takari