### PR TITLE
Allow BigIntegers to be defined in the /process/*/start/ map parameters

### DIFF
--- a/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/ResourceBase.java
+++ b/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/ResourceBase.java
@@ -75,7 +75,6 @@ import org.kie.services.client.serialization.jaxb.impl.type.JaxbShort;
 import org.kie.services.client.serialization.jaxb.impl.type.JaxbString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.security.util.BigInt;
 
 public class ResourceBase {
 
@@ -310,7 +309,7 @@ public class ResourceBase {
         if (paramVal.matches(LONG_INTEGER_BIGINTEGER_REGEX)) {
             if (paramVal.matches(".*i$")) {
                 if (mustBeLong) {
-                    throw KieRemoteRestOperationException.badRequest(paramName
+                    throw KieRemoteRestOperationException.badRequest( paramName
                             + " parameter is numerical but contains the \"Integer\" suffix 'i' and must have no suffix or \"Long\" suffix 'l' ("
                             + paramVal + ")");
                 }

--- a/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/ResourceBase.java
+++ b/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/ResourceBase.java
@@ -19,6 +19,7 @@ import static org.kie.remote.common.rest.RestEasy960Util.defaultVariant;
 import static org.kie.remote.common.rest.RestEasy960Util.getVariant;
 
 import java.lang.reflect.Constructor;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -74,6 +75,7 @@ import org.kie.services.client.serialization.jaxb.impl.type.JaxbShort;
 import org.kie.services.client.serialization.jaxb.impl.type.JaxbString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import sun.security.util.BigInt;
 
 public class ResourceBase {
 
@@ -273,7 +275,7 @@ public class ResourceBase {
     private static Object getObjectFromString(String key, String mapVal) {
         if (mapVal.matches("^\".*\"$")) {
             return mapVal.substring(1, mapVal.length()-1);
-        } else if (mapVal.matches(LONG_INTEGER_REGEX) || mapVal.matches(FLOAT_REGEX) ) {
+        } else if (mapVal.matches(LONG_INTEGER_BIGINTEGER_REGEX) || mapVal.matches(FLOAT_REGEX) ) {
             return getNumberFromString(key, mapVal, false);
         } else if (mapVal.matches(BOOLEAN_REGEX) ) {
             return Boolean.parseBoolean(mapVal);
@@ -287,7 +289,7 @@ public class ResourceBase {
     private final static int MAX_LENGTH_FLOAT = 10;
 
     public static String BOOLEAN_REGEX ="^(TRUE|FALSE)";
-    public static String LONG_INTEGER_REGEX ="^\\d+[li]?$";
+    public static String LONG_INTEGER_BIGINTEGER_REGEX ="^\\d+[liI]?$";
     public static String FLOAT_REGEX = "^\\d[\\d\\.]{1,9}(E-?\\d{1,2})?f?$";
 
     /**
@@ -295,8 +297,9 @@ public class ResourceBase {
      * Otherwise, possible suffixes are:
      * <ul>
      * <li>i : returns an Integer</li>
-     * <li>l : returns an Long</li>
-     * <li>f : returns an Float</li>
+     * <li>I : returns a BigInteger</li>
+     * <li>l : returns a Long</li>
+     * <li>f : returns a Float</li>
      * </ul>
      *
      * @param paramName
@@ -304,10 +307,10 @@ public class ResourceBase {
      * @return
      */
     private static Number getNumberFromString(String paramName, String paramVal, boolean mustBeLong) {
-        if (paramVal.matches(LONG_INTEGER_REGEX)) {
+        if (paramVal.matches(LONG_INTEGER_BIGINTEGER_REGEX)) {
             if (paramVal.matches(".*i$")) {
                 if (mustBeLong) {
-                    throw KieRemoteRestOperationException.badRequest( paramName
+                    throw KieRemoteRestOperationException.badRequest(paramName
                             + " parameter is numerical but contains the \"Integer\" suffix 'i' and must have no suffix or \"Long\" suffix 'l' ("
                             + paramVal + ")");
                 }
@@ -317,6 +320,14 @@ public class ResourceBase {
                             + paramVal + "i)");
                 }
                 return Integer.parseInt(paramVal);
+            } else if (paramVal.matches(".*I$")) {
+                if (mustBeLong) {
+                    throw KieRemoteRestOperationException.badRequest(paramName
+                            + " parameter is numerical but contains the \"BigInteger\" suffix 'I' and must have no suffix or \"Long\" suffix 'l' ("
+                            + paramVal + ")");
+                }
+                paramVal = paramVal.substring(0, paramVal.length() - 1);
+                return new BigInteger(paramVal);
             } else {
                 if (paramVal.length() > MAX_LENGTH_LONG) {
                     throw KieRemoteRestOperationException.badRequest(paramName + " parameter is numerical but too large to be a long ("


### PR DESCRIPTION
This incremental improvement on the object marshaling of numeric map parameters allows BigIntegers to be placed on the process instance's parameters.  These big integers can better accommodate primary keys on relational databases.  