### PR TITLE
kie-server tests: remove additional dependencies for kie-maven-plugin

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
@@ -22,20 +22,6 @@
           <artifactId>kie-maven-plugin</artifactId>
           <version>${version.org.kie}</version>
           <extensions>true</extensions>
-          <dependencies>
-            <!-- needed to compile ruleflow processes -->
-            <dependency>
-              <groupId>org.jbpm</groupId>
-              <artifactId>jbpm-bpmn2</artifactId>
-              <version>${version.org.kie}</version>
-            </dependency>
-            <!-- needed to compile spreadsheet decision tables -->
-            <dependency>
-              <groupId>org.drools</groupId>
-              <artifactId>drools-decisiontables</artifactId>
-              <version>${version.org.kie}</version>
-            </dependency>
-          </dependencies>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
@@ -22,20 +22,6 @@
           <artifactId>kie-maven-plugin</artifactId>
           <version>${version.org.kie}</version>
           <extensions>true</extensions>
-          <dependencies>
-            <!-- needed to compile ruleflow processes -->
-            <dependency>
-              <groupId>org.jbpm</groupId>
-              <artifactId>jbpm-bpmn2</artifactId>
-              <version>${version.org.kie}</version>
-            </dependency>
-            <!-- needed to compile spreadsheet decision tables -->
-            <dependency>
-              <groupId>org.drools</groupId>
-              <artifactId>drools-decisiontables</artifactId>
-              <version>${version.org.kie}</version>
-            </dependency>
-          </dependencies>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
@@ -22,20 +22,6 @@
           <artifactId>kie-maven-plugin</artifactId>
           <version>${version.org.kie}</version>
           <extensions>true</extensions>
-          <dependencies>
-            <!-- needed to compile ruleflow processes -->
-            <dependency>
-              <groupId>org.jbpm</groupId>
-              <artifactId>jbpm-bpmn2</artifactId>
-              <version>${version.org.kie}</version>
-            </dependency>
-            <!-- needed to compile spreadsheet decision tables -->
-            <dependency>
-              <groupId>org.drools</groupId>
-              <artifactId>drools-decisiontables</artifactId>
-              <version>${version.org.kie}</version>
-            </dependency>
-          </dependencies>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
 * no need to include thhose additional dependencies, they are already
   brought in by the kie-maven-plugin by default