### PR TITLE
JBPM-4957 - signals / messages external scope is missing in kie execu…

### DIFF
--- a/kie-server-parent/kie-server-wars/kie-server/src/main/shared-ee6-ee7-resources/META-INF/kie-server-jms.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/src/main/shared-ee6-ee7-resources/META-INF/kie-server-jms.xml
@@ -20,6 +20,14 @@
         <entry name="queue/KIE.SERVER.EXECUTOR" />
       </jms-queue>
 
+      <!-- JMS queue for signals -->
+      <!-- enable when external signals are required -->
+      <!--
+      <jms-queue name="KIE.SERVER.SIGNAL.QUEUE">
+        <entry name="queue/KIE.SERVER.SIGNAL" />
+        <entry name="java:jboss/exported/jms/queue/KIE.SERVER.SIGNAL" />
+      </jms-queue>
+      -->
     </jms-destinations>
   </hornetq-server>
 </messaging-deployment>

--- a/kie-server-parent/kie-server-wars/kie-server/src/main/shared-ee6-ee7-resources/WEB-INF/ejb-jar.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/src/main/shared-ee6-ee7-resources/WEB-INF/ejb-jar.xml
@@ -1,0 +1,27 @@
+<ejb-jar id="ejb-jar_ID" version="3.1"
+      xmlns="http://java.sun.com/xml/ns/javaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+                          http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd">
+
+  <!-- enable when external signals are required and queue and connection factory is defined -->
+  <!--
+  <enterprise-beans>
+    <message-driven>
+      <ejb-name>JMSSignalReceiver</ejb-name>
+      <ejb-class>org.jbpm.process.workitem.jms.JMSSignalReceiver</ejb-class>
+      <transaction-type>Bean</transaction-type>
+      <activation-config>
+        <activation-config-property>
+          <activation-config-property-name>destinationType</activation-config-property-name>
+          <activation-config-property-value>javax.jms.Queue</activation-config-property-value>
+        </activation-config-property>
+        <activation-config-property>
+          <activation-config-property-name>destination</activation-config-property-name>
+          <activation-config-property-value>java:/queue/KIE.SERVER.SIGNAL</activation-config-property-value>
+        </activation-config-property>
+      </activation-config>
+    </message-driven>
+  </enterprise-beans>
+  -->
+</ejb-jar>

--- a/kie-server-parent/kie-server-wars/kie-server/src/main/shared-ee6-ee7-resources/WEB-INF/weblogic-ejb-jar.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/src/main/shared-ee6-ee7-resources/WEB-INF/weblogic-ejb-jar.xml
@@ -22,4 +22,14 @@
     </message-driven-descriptor>
   </weblogic-enterprise-bean>
 
+  <!-- enable when external signals are required and queue and connection factory is defined -->
+  <!--
+  <weblogic-enterprise-bean>
+    <ejb-name>JMSSignalReceiver</ejb-name>
+    <message-driven-descriptor>
+      <destination-jndi-name>jms/KIE.SIGNAL</destination-jndi-name>
+      <connection-factory-jndi-name>jms/cf/KIE.SIGNAL</connection-factory-jndi-name>
+    </message-driven-descriptor>
+  </weblogic-enterprise-bean>
+  -->
 </weblogic-ejb-jar>


### PR DESCRIPTION
…tion server

added configuration for message listener (mdb) for external signal handling. This is disabled by default to avoid extra queue to be created to avoid deployment failures if the queue is not there. Since this is not a frequently used feature it should be there to easy enable but does not have to be enabled by default.