### PR TITLE
kie-server tests: separated BTM for Tomcat builds

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/pom.xml
@@ -238,4 +238,47 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>tomcat7x</id>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.codehaus.cargo</groupId>
+              <artifactId>cargo-maven2-plugin</artifactId>
+              <configuration>
+                <container>
+                  <systemProperties combine.self="append">
+                    <bitronix.tm.configuration>${project.build.testOutputDirectory}/btm-config.properties</bitronix.tm.configuration>
+                  </systemProperties>
+                </container>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+    <profile>
+      <id>tomcat8x</id>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.codehaus.cargo</groupId>
+              <artifactId>cargo-maven2-plugin</artifactId>
+              <configuration>
+                <container>
+                  <systemProperties combine.self="append">
+                    <bitronix.tm.configuration>${project.build.testOutputDirectory}/btm-config.properties</bitronix.tm.configuration>
+                  </systemProperties>
+                </container>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/filtered-resources/btm-config.properties
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/filtered-resources/btm-config.properties
@@ -1,4 +1,0 @@
-bitronix.tm.serverId=tomcat-btm-node0
-bitronix.tm.journal.disk.logPart1Filename=${tmp.directory}/btm1.tlog
-bitronix.tm.journal.disk.logPart2Filename=${tmp.directory}/btm2.tlog
-bitronix.tm.resource.configuration=${conf.directory}/btm-resources.properties

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/filtered-resources/btm-resources.properties
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/filtered-resources/btm-resources.properties
@@ -1,9 +1,0 @@
-resource.ds1.className=bitronix.tm.resource.jdbc.lrc.LrcXADataSource
-resource.ds1.uniqueName=jdbc/jbpm
-resource.ds1.minPoolSize=10
-resource.ds1.maxPoolSize=20
-resource.ds1.driverProperties.driverClassName=org.h2.Driver
-resource.ds1.driverProperties.url=jdbc:h2:mem:test-db
-resource.ds1.driverProperties.user=sa
-resource.ds1.driverProperties.password=
-resource.ds1.allowLocalTransactions=true

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/filtered-resources/btm-config.properties
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/filtered-resources/btm-config.properties
@@ -1,4 +1,0 @@
-bitronix.tm.serverId=tomcat-btm-node0
-bitronix.tm.journal.disk.logPart1Filename=${tmp.directory}/btm1.tlog
-bitronix.tm.journal.disk.logPart2Filename=${tmp.directory}/btm2.tlog
-bitronix.tm.resource.configuration=${conf.directory}/btm-resources.properties

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/filtered-resources/btm-resources.properties
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/filtered-resources/btm-resources.properties
@@ -1,9 +1,0 @@
-resource.ds1.className=bitronix.tm.resource.jdbc.lrc.LrcXADataSource
-resource.ds1.uniqueName=jdbc/jbpm
-resource.ds1.minPoolSize=10
-resource.ds1.maxPoolSize=20
-resource.ds1.driverProperties.driverClassName=org.h2.Driver
-resource.ds1.driverProperties.url=jdbc:h2:mem:test-db
-resource.ds1.driverProperties.user=sa
-resource.ds1.driverProperties.password=
-resource.ds1.allowLocalTransactions=true

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/btm-config.properties
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/btm-config.properties
@@ -1,4 +1,0 @@
-bitronix.tm.serverId=tomcat-btm-node0
-bitronix.tm.journal.disk.logPart1Filename=${tmp.directory}/btm1.tlog
-bitronix.tm.journal.disk.logPart2Filename=${tmp.directory}/btm2.tlog
-bitronix.tm.resource.configuration=${conf.directory}/btm-resources.properties

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/btm-resources.properties
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/btm-resources.properties
@@ -1,9 +1,0 @@
-resource.ds1.className=bitronix.tm.resource.jdbc.lrc.LrcXADataSource
-resource.ds1.uniqueName=jdbc/jbpm
-resource.ds1.minPoolSize=10
-resource.ds1.maxPoolSize=20
-resource.ds1.driverProperties.driverClassName=org.h2.Driver
-resource.ds1.driverProperties.url=jdbc:h2:mem:test-db
-resource.ds1.driverProperties.user=sa
-resource.ds1.driverProperties.password=
-resource.ds1.allowLocalTransactions=true

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
@@ -234,4 +234,47 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>tomcat7x</id>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.codehaus.cargo</groupId>
+              <artifactId>cargo-maven2-plugin</artifactId>
+              <configuration>
+                <container>
+                  <systemProperties combine.self="append">
+                    <bitronix.tm.configuration>${project.build.testOutputDirectory}/btm-config.properties</bitronix.tm.configuration>
+                  </systemProperties>
+                </container>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+    <profile>
+      <id>tomcat8x</id>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.codehaus.cargo</groupId>
+              <artifactId>cargo-maven2-plugin</artifactId>
+              <configuration>
+                <container>
+                  <systemProperties combine.self="append">
+                    <bitronix.tm.configuration>${project.build.testOutputDirectory}/btm-config.properties</bitronix.tm.configuration>
+                  </systemProperties>
+                </container>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/OptaplannerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/OptaplannerIntegrationTest.java
@@ -25,7 +25,6 @@ import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.api.model.instance.SolverInstance;
 import org.kie.server.api.model.instance.SolverInstanceList;
 import org.kie.server.client.KieServicesException;
-import org.kie.server.client.impl.KieServicesClientImpl;
 import org.optaplanner.core.api.domain.solution.Solution;
 
 import java.lang.Thread;
@@ -355,7 +354,7 @@ public class OptaplannerIntegrationTest
 
             Method method = cbgc.getMethod( "createCloudBalance", int.class, int.class );
             problem = (Solution) method.invoke( cbgi, computerListSize, processListSize );
-        } catch ( ReflectiveOperationException e ) {
+        } catch ( Exception e ) {
             e.printStackTrace();
             fail( "Exception trying to create cloud balance unsolved problem.");
         }

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -371,7 +371,6 @@
                     <tomcat.home>${project.build.directory}/cargo/configurations/tomcat7x</tomcat.home>
                     <conf.directory>${project.build.testOutputDirectory}</conf.directory>
                     <tmp.directory>${project.build.directory}</tmp.directory>
-                    <bitronix.tm.configuration>${project.build.testOutputDirectory}/btm-config.properties</bitronix.tm.configuration>
                     <jbpm.tsr.jndi.lookup>java:comp/env/TransactionSynchronizationRegistry</jbpm.tsr.jndi.lookup>
                     <org.kie.server.persistence.tm>org.hibernate.service.jta.platform.internal.BitronixJtaPlatform</org.kie.server.persistence.tm>
                     <org.kie.server.persistence.ds>java:comp/env/jdbc/jbpm</org.kie.server.persistence.ds>
@@ -484,7 +483,6 @@
                     <tomcat.home>${project.build.directory}/cargo/configurations/tomcat7x</tomcat.home>
                     <conf.directory>${project.build.testOutputDirectory}</conf.directory>
                     <tmp.directory>${project.build.directory}</tmp.directory>
-                    <bitronix.tm.configuration>${project.build.testOutputDirectory}/btm-config.properties</bitronix.tm.configuration>
                     <jbpm.tsr.jndi.lookup>java:comp/env/TransactionSynchronizationRegistry</jbpm.tsr.jndi.lookup>
                     <org.kie.server.persistence.tm>org.hibernate.service.jta.platform.internal.BitronixJtaPlatform</org.kie.server.persistence.tm>
                     <org.kie.server.persistence.ds>java:comp/env/jdbc/jbpm</org.kie.server.persistence.ds>


### PR DESCRIPTION
Removed BTM config files from integration tests which doesn't use BPM extension.
Java 6 fix for OptaPlanner integration test.