### PR TITLE
Collection of improvements for KIE Server

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerConstants.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerConstants.java
@@ -63,6 +63,8 @@ public class KieServerConstants {
 
     public static final String CFG_KIE_MVN_SETTINGS = "kie.maven.settings.custom";
 
+    public static final String CFG_SYNC_DEPLOYMENT = "org.kie.server.sync.deploy";
+
     public static final String KIE_SERVER_PARAM_MODULE_METADATA = "KieModuleMetaData";
 
     public static final String CAPABILITY_BRM = "BRM"; // Business Rules Management

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
@@ -143,7 +143,14 @@ public class KieServerImpl {
                                                                                         containerManager,
                                                                                         this), "KieServer-ControllerConnect");
             connectToControllerThread.start();
-
+            if (Boolean.parseBoolean(currentState.getConfiguration().getConfigItemValue(KieServerConstants.CFG_SYNC_DEPLOYMENT, "true"))) {
+                logger.info("Containers were requested to be deployed synchronously, holding application start...");
+                try {
+                    connectToControllerThread.join();
+                } catch (InterruptedException e1) {
+                    logger.debug("Interrupt exception when waiting for deployments");
+                }
+            }
         }
 
         if (readyToRun) {

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/JbpmKieServerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/JbpmKieServerExtension.java
@@ -72,6 +72,7 @@ import org.kie.api.task.UserGroupCallback;
 import org.kie.internal.runtime.conf.DeploymentDescriptor;
 import org.kie.internal.runtime.conf.MergeMode;
 import org.kie.internal.runtime.conf.NamedObjectModel;
+import org.kie.internal.task.api.UserInfo;
 import org.kie.scanner.KieModuleMetaData;
 import org.kie.internal.runtime.conf.RuntimeStrategy;
 import org.kie.server.api.KieServerConstants;
@@ -170,9 +171,12 @@ public class JbpmKieServerExtension implements KieServerExtension {
         // configure user group callback
         UserGroupCallback userGroupCallback = UserDataServiceProvider.getUserGroupCallback();
 
+        UserInfo userInfo = UserDataServiceProvider.getUserInfo();
+
         TaskService taskService = HumanTaskServiceFactory.newTaskServiceConfigurator()
                 .entityManagerFactory(emf)
                 .userGroupCallback(userGroupCallback)
+                .userInfo(userInfo)
                 .getTaskService();
 
         // build runtime data service

--- a/kie-server-parent/kie-server-wars/kie-server/pom.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/pom.xml
@@ -187,6 +187,19 @@
       <groupId>xerces</groupId>
       <artifactId>xercesImpl</artifactId>
     </dependency>
+
+    <!-- Timer dependencies -->
+    <dependency>
+      <groupId>org.quartz-scheduler</groupId>
+      <artifactId>quartz</artifactId>
+      <scope>runtime</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.transaction</groupId>
+          <artifactId>jta</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <build>

--- a/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-ee6-container.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-ee6-container.xml
@@ -80,6 +80,8 @@
         <include>org.hibernate:hibernate-validator</include>
         <include>dom4j:dom4j</include>
         <include>org.slf4j:slf4j-jdk14</include>
+
+        <include>org.quartz-scheduler:quartz</include>
       </includes>
       <outputDirectory>WEB-INF/lib</outputDirectory>
       <useTransitiveFiltering>true</useTransitiveFiltering>

--- a/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-ee7-container.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-ee7-container.xml
@@ -69,6 +69,8 @@
         <include>org.hibernate:hibernate-core</include>
         <include>org.hibernate:hibernate-validator</include>
         <include>dom4j:dom4j</include>
+
+        <include>org.quartz-scheduler:quartz</include>
       </includes>
       <excludes>
         <exclude>org.jboss.resteasy:*</exclude>

--- a/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-servlet-container.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-servlet-container.xml
@@ -67,6 +67,8 @@
         <include>xerces:xercesImpl</include>
 
         <include>org.jboss.spec.javax.jms:jboss-jms-api_1.1_spec</include>
+
+        <include>org.quartz-scheduler:quartz</include>
       </includes>
       <outputDirectory>WEB-INF/lib</outputDirectory>
       <useTransitiveFiltering>true</useTransitiveFiltering>


### PR DESCRIPTION
this PR comes with three updates for KIE Server mainly from jBPM point of view:
- add quartz to war files to allow to be used as timer service
- allow to set UserInfo via system properties same as for UserGroupCallback
- makes the load of containers from controller synchronous (it's configurable) to make sure that kie server is not yet available until it receives containers and they're fully loaded to avoid issues with too early use of the server