### PR TITLE
enhanced credentials for kie server client to allow various authoriza…

### DIFF
--- a/kie-remote/kie-remote-common/src/main/java/org/kie/remote/common/rest/Base64Util.java
+++ b/kie-remote/kie-remote-common/src/main/java/org/kie/remote/common/rest/Base64Util.java
@@ -31,7 +31,7 @@ import java.io.UnsupportedEncodingException;
  * @author rob@iharder.net
  * @version 2.3.7
  */
-class Base64Util {
+public class Base64Util {
 
     /** The equals sign (=) as a byte. */
     private final static byte EQUALS_SIGN = (byte) '=';

--- a/kie-remote/kie-remote-common/src/main/java/org/kie/remote/common/rest/KieRemoteHttpRequest.java
+++ b/kie-remote/kie-remote-common/src/main/java/org/kie/remote/common/rest/KieRemoteHttpRequest.java
@@ -1042,6 +1042,17 @@ public class KieRemoteHttpRequest {
     }
 
     /**
+     * Set the 'Authorization' header to given values in Bearer/Token authentication
+     * format
+     *
+     * @param token
+     * @return this request
+     */
+    public KieRemoteHttpRequest tokenAuthorization( final String token ) {
+        return header(AUTHORIZATION, "Bearer " + token);
+    }
+
+    /**
      * Set the 'Content-Type' request header to the given value
      *
      * @param contentType

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerConstants.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerConstants.java
@@ -45,11 +45,19 @@ public class KieServerConstants {
 
     public static final String CFG_BYPASS_AUTH_USER = "org.kie.server.bypass.auth.user";
 
+    /**
+     * security settings used to connect to KIE Server
+     */
     public static final String CFG_KIE_USER = "org.kie.server.user";
     public static final String CFG_KIE_PASSWORD = "org.kie.server.pwd";
+    public static final String CFG_KIE_TOKEN = "org.kie.server.token";
 
+    /**
+     * Security settings used to connect to KIE Server Controller
+     */
     public static final String CFG_KIE_CONTROLLER_USER = "org.kie.server.controller.user";
     public static final String CFG_KIE_CONTROLLER_PASSWORD = "org.kie.server.controller.pwd";
+    public static final String CFG_KIE_CONTROLLER_TOKEN = "org.kie.server.controller.token";
 
     // non kie server parameters but used by its extensions etc
     public static final String CFG_HT_CALLBACK = "org.jbpm.ht.callback";

--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/KieServerInstanceManager.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/KieServerInstanceManager.java
@@ -30,6 +30,7 @@ import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.client.KieServicesClient;
 import org.kie.server.client.KieServicesConfiguration;
 import org.kie.server.client.KieServicesFactory;
+import org.kie.server.client.credentials.EnteredTokenCredentialsProvider;
 import org.kie.server.controller.api.model.runtime.Container;
 import org.kie.server.controller.api.model.runtime.ServerInstanceKey;
 import org.kie.server.controller.api.model.spec.ContainerSpec;
@@ -281,6 +282,11 @@ public class KieServerInstanceManager {
 
         configuration.setMarshallingFormat(MarshallingFormat.JSON);
 
+        String authToken = getToken();
+        if (authToken != null && !authToken.isEmpty()) {
+            configuration.setCredentialsProvider(new EnteredTokenCredentialsProvider(authToken));
+        }
+
         KieServicesClient kieServicesClient =  KieServicesFactory.newKieServicesClient(configuration);
 
         return kieServicesClient;
@@ -304,6 +310,9 @@ public class KieServerInstanceManager {
         return System.getProperty(KieServerConstants.CFG_KIE_PASSWORD, "kieserver1!");
     }
 
+    protected String getToken() {
+        return System.getProperty(KieServerConstants.CFG_KIE_TOKEN);
+    }
     private class RemoteKieServerOperation<T> {
 
         public T doOperation(KieServicesClient client, Container container) {

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/CredentialsProvider.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/CredentialsProvider.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.client;
+
+/**
+ * Responsible for providing user credentials that can be obtained in various ways
+ * that depends on the implementation.
+ */
+public interface CredentialsProvider {
+
+    public static final String BASIC_AUTH_PREFIX = "Basic ";
+    public static final String TOKEN_AUTH_PREFIX = "Bearer ";
+
+    /**
+     * Returns name of the HTTP header to be set with given authorization
+     * @return
+     */
+    String getHeaderName();
+
+    /**
+     * Returns authorization string that shall be used for setting up
+     * "Authorization" header for HTTP communication. It's expected to be completely setup
+     * including prefix (such as Basic) and encryption (such as Base64 in case of basic) if needed.
+     * @return
+     */
+    String getAuthorization();
+}

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/KieServicesConfiguration.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/KieServicesConfiguration.java
@@ -89,4 +89,8 @@ public interface KieServicesConfiguration {
 
     List<String> getCapabilities();
 
+    void setCredentialsProvider(CredentialsProvider credentialsProvider);
+
+    CredentialsProvider getCredentialsProvider();
+
 }

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/KieServicesFactory.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/KieServicesFactory.java
@@ -48,6 +48,14 @@ public class KieServicesFactory {
         return new KieServicesConfigurationImpl( serverUrl, login, password, timeout );
     }
 
+    public static KieServicesConfiguration newRestConfiguration( String serverUrl, CredentialsProvider credentialsProvider ) {
+        return new KieServicesConfigurationImpl( serverUrl, credentialsProvider );
+    }
+
+    public static KieServicesConfiguration newRestConfiguration( String serverUrl, CredentialsProvider credentialsProvider, long timeout ) {
+        return new KieServicesConfigurationImpl( serverUrl, credentialsProvider, timeout );
+    }
+
     /**
      * Creates a new configuration object for JMS based service
      * @param connectionFactory a JMS connection factory
@@ -99,6 +107,10 @@ public class KieServicesFactory {
 
     public static KieServicesClient newKieServicesRestClient( String serverUrl, String login, String password ) {
         return new KieServicesClientImpl( newRestConfiguration( serverUrl, login, password ) );
+    }
+
+    public static KieServicesClient newKieServicesRestClient( String serverUrl, CredentialsProvider credentialsProvider ) {
+        return new KieServicesClientImpl( newRestConfiguration( serverUrl, credentialsProvider ) );
     }
 
     public static KieServicesClient newKieServicesJMSClient( ConnectionFactory connectionFactory, Queue requestQueue, Queue responseQueue ) {

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/credentials/EnteredCredentialsProvider.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/credentials/EnteredCredentialsProvider.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.client.credentials;
+
+import org.kie.remote.common.rest.Base64Util;
+import org.kie.server.client.CredentialsProvider;
+
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+
+/**
+ * Default implementation of <code>CredentialsProvider</code> that is expected to get
+ * user name and password when instantiating instance and then return
+ * Basic type of authorization header.
+ */
+public class EnteredCredentialsProvider implements CredentialsProvider {
+
+    private String username;
+    private String password;
+
+    public EnteredCredentialsProvider(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    @Override
+    public String getHeaderName() {
+        return AUTHORIZATION;
+    }
+
+    @Override
+    public String getAuthorization() {
+        return BASIC_AUTH_PREFIX + Base64Util.encode(username + ':' + password);
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/credentials/EnteredTokenCredentialsProvider.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/credentials/EnteredTokenCredentialsProvider.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.client.credentials;
+
+import org.kie.server.client.CredentialsProvider;
+
+import static javax.ws.rs.core.HttpHeaders.*;
+
+/**
+ * Token based implementation of <code>CredentialsProvider</code> that is expected to get
+ * valid token when instantiating instance and then return
+ * Bearer type of authorization header.
+ */
+public class EnteredTokenCredentialsProvider implements CredentialsProvider {
+
+    private String token;
+
+    public EnteredTokenCredentialsProvider(String token) {
+        this.token = token;
+    }
+
+    @Override
+    public String getHeaderName() {
+        return AUTHORIZATION;
+    }
+
+    @Override
+    public String getAuthorization() {
+        return TOKEN_AUTH_PREFIX + token;
+    }
+}

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/AbstractKieServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/AbstractKieServicesClientImpl.java
@@ -320,8 +320,13 @@ public abstract class AbstractKieServicesClientImpl {
                 KieRemoteHttpRequest.newRequest( uri ).followRedirects( true ).timeout( config.getTimeout() );
         httpRequest.accept( getMediaType( config.getMarshallingFormat() ) );
         httpRequest.header(KieServerConstants.KIE_CONTENT_TYPE_HEADER, config.getMarshallingFormat().toString());
-        if ( config.getUserName() != null && config.getPassword() != null ) {
-            httpRequest.basicAuthorization( config.getUserName(), config.getPassword() );
+        // apply authorization
+        if (config.getCredentialsProvider() != null) {
+            String authorization = config.getCredentialsProvider().getAuthorization();
+            // add authorization only when it's not empty to allow anonymous requests
+            if (authorization != null && !authorization.isEmpty()) {
+                httpRequest.header(config.getCredentialsProvider().getHeaderName(), authorization);
+            }
         }
         return httpRequest;
     }

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/controller/DefaultRestControllerImpl.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/controller/DefaultRestControllerImpl.java
@@ -49,9 +49,9 @@ public class DefaultRestControllerImpl implements KieServerController {
     }
 
     @SuppressWarnings("unchecked")
-    protected <T> T makeHttpPutRequestAndCreateCustomResponse(String uri, String body, Class<T> resultType, String user, String password) {
+    protected <T> T makeHttpPutRequestAndCreateCustomResponse(String uri, String body, Class<T> resultType, String user, String password, String token) {
         logger.debug("About to send PUT request to '{}' with payload '{}'", uri, body);
-        KieRemoteHttpRequest request = newRequest( uri, user, password ).body(body).put();
+        KieRemoteHttpRequest request = newRequest( uri, user, password, token ).body(body).put();
         KieRemoteHttpResponse response = request.response();
 
         if ( response.code() == Response.Status.CREATED.getStatusCode() ||
@@ -65,9 +65,9 @@ public class DefaultRestControllerImpl implements KieServerController {
     }
 
     @SuppressWarnings("unchecked")
-    protected <T> T makeHttpDeleteRequestAndCreateCustomResponse(String uri, Class<T> resultType, String user, String password) {
+    protected <T> T makeHttpDeleteRequestAndCreateCustomResponse(String uri, Class<T> resultType, String user, String password, String token) {
         logger.debug("About to send DELETE request to '{}' ", uri);
-        KieRemoteHttpRequest request = newRequest( uri, user, password ).delete();
+        KieRemoteHttpRequest request = newRequest( uri, user, password, token ).delete();
         KieRemoteHttpResponse response = request.response();
 
         if ( response.code() == Response.Status.OK.getStatusCode() ||
@@ -80,11 +80,15 @@ public class DefaultRestControllerImpl implements KieServerController {
         }
     }
 
-    private KieRemoteHttpRequest newRequest(String uri, String userName, String password) {
+    private KieRemoteHttpRequest newRequest(String uri, String userName, String password, String token) {
 
         KieRemoteHttpRequest httpRequest = KieRemoteHttpRequest.newRequest(uri).followRedirects(true).timeout(5000);
         httpRequest.accept(MediaType.APPLICATION_JSON);
-        httpRequest.basicAuthorization(userName, password);
+        if (token != null && !token.isEmpty()) {
+            httpRequest.tokenAuthorization(token);
+        } else {
+            httpRequest.basicAuthorization(userName, password);
+        }
 
         return httpRequest;
 
@@ -129,9 +133,10 @@ public class DefaultRestControllerImpl implements KieServerController {
 
                     String userName = config.getConfigItemValue(KieServerConstants.CFG_KIE_CONTROLLER_USER, "kieserver");
                     String password = config.getConfigItemValue(KieServerConstants.CFG_KIE_CONTROLLER_PASSWORD, "kieserver1!");
+                    String token = config.getConfigItemValue(KieServerConstants.CFG_KIE_CONTROLLER_TOKEN);
 
                     try {
-                        KieServerSetup kieServerSetup = makeHttpPutRequestAndCreateCustomResponse(connectAndSyncUrl, serialize(serverInfo), KieServerSetup.class, userName, password);
+                        KieServerSetup kieServerSetup = makeHttpPutRequestAndCreateCustomResponse(connectAndSyncUrl, serialize(serverInfo), KieServerSetup.class, userName, password, token);
 
                         if (kieServerSetup != null) {
                             // once there is non null list let's return it
@@ -171,9 +176,9 @@ public class DefaultRestControllerImpl implements KieServerController {
 
                     String userName = config.getConfigItemValue(KieServerConstants.CFG_KIE_CONTROLLER_USER, "kieserver");
                     String password = config.getConfigItemValue(KieServerConstants.CFG_KIE_CONTROLLER_PASSWORD, "kieserver1!");
+                    String token = config.getConfigItemValue(KieServerConstants.CFG_KIE_CONTROLLER_TOKEN);
 
-
-                    makeHttpDeleteRequestAndCreateCustomResponse(connectAndSyncUrl, null, userName, password);
+                    makeHttpDeleteRequestAndCreateCustomResponse(connectAndSyncUrl, null, userName, password, token);
 
 
                     break;


### PR DESCRIPTION
…tion mechanisms

@romartin @yurloc @krisv - fyi - as we discussed it today. This PR allows to use Token based authorization for kie server client and for integration between kie server and controller (workbench). As it comes for th first one it's done as implementation of CredentialsProvider and we provide two out of the box (at the moment and more to come):
- EnteredCredentialsProvider is simplest one that expects to have user name and password given
- EnteredTokenCredentialsProvider is very similar and expects to have complete token given

In addition to allow use of token for kie server and controller interactions users can give the token instead of username and password as system properties for both apps to allow their smooth interaction.