### PR TITLE
BZ 1310439: add reproducer

### DIFF
--- a/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/RuntimeManagerFeatureKarafIntegrationTest.java
+++ b/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/RuntimeManagerFeatureKarafIntegrationTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.karaf.itest;
+
+import org.apache.karaf.features.FeaturesService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.api.runtime.manager.RuntimeManagerFactory;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.karaf.options.LogLevelOption;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerMethod;
+
+import javax.inject.Inject;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureConsole;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerMethod.class)
+public class RuntimeManagerFeatureKarafIntegrationTest extends AbstractKarafIntegrationTest {
+
+    @Inject
+    protected FeaturesService featuresService;
+
+    @Test
+    public void testJbpmRuntimeManager() throws Exception {
+        // attempt to obtain RuntimeManagerFactory when KIE-API and Drools features are installed, but no jBPM
+        RuntimeManagerFactory runtimeManagerFactory = RuntimeManagerFactory.Factory.get();
+        assertNull("KIE-API created non-null RuntimeManagerFactory when jBPM was not installed.", runtimeManagerFactory);
+
+        // install jBPM feature
+        featuresService.installFeature("jbpm");
+
+        // attempt to obtain RuntimeManagerFactory once again, now jBPM is installed so it should succeed
+        runtimeManagerFactory = RuntimeManagerFactory.Factory.get();
+        assertNotNull("KIE-API created null RuntimeManagerFactory after jBPM was installed.", runtimeManagerFactory);
+    }
+
+    @Configuration
+    public static Option[] configure() {
+        return new Option[]{
+                // Install Karaf Container
+                getKarafDistributionOption(),
+
+                // It is really nice if the container sticks around after the test so you can check the contents
+                // of the data directory when things go wrong.
+                keepRuntimeFolder(),
+                // Don't bother with local console output as it just ends up cluttering the logs
+                configureConsole().ignoreLocalConsole(),
+                // Force the log level to INFO so we have more details during the test.  It defaults to WARN.
+                logLevel(LogLevelOption.LogLevel.INFO),
+
+                // Option to be used to do remote debugging
+                //  debugConfiguration("5005", true),
+
+                // Load drools-module feature only (installs KIE-API and Drools, no jBPM)
+                loadKieFeatures("drools-module")
+        };
+    }
+}


### PR DESCRIPTION
Added reproducer for BZ 1310439.

The problem is when you install jbpm feature after drools-module feature (or kie-api, more precisely) had been installed before, and someone attempted to initialize jBPM both before jBPM is installed and after it was installed.