### PR TITLE
Improve getBestSolution testing (backport to 6.4.x)

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerBaseIntegrationTest.java
@@ -307,7 +307,7 @@ public abstract class KieServerBaseIntegrationTest {
             mvnArgs.add("-s");
             mvnArgs.add(kjarsBuildSettingsXml);
         }
-        int mvnRunResult = cli.doMain(mvnArgs.toArray(new String[mvnArgs.size()]), basedir, System.out, System.out);
+        int mvnRunResult = cli.doMain(mvnArgs.toArray(new String[mvnArgs.size()]), basedir, System.out, System.err);
         if (mvnRunResult != 0) {
             throw new RuntimeException("Error while building Maven project from basedir " + basedir +
                     ". Return code=" + mvnRunResult);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/pom.xml
@@ -24,6 +24,12 @@
       <version>${version.org.kie}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-core-asl</artifactId>
+      <version>${version.org.codehaus.jackson}</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/src/main/java/org/kie/server/testing/CloudComputer.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/src/main/java/org/kie/server/testing/CloudComputer.java
@@ -17,6 +17,7 @@
 package org.kie.server.testing;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import org.codehaus.jackson.annotate.JsonIgnore;
 
 @XStreamAlias("CloudComputer")
 public class CloudComputer extends AbstractPersistable {
@@ -62,6 +63,7 @@ public class CloudComputer extends AbstractPersistable {
     // Complex methods
     // ************************************************************************
 
+    @JsonIgnore
     public int getMultiplicand() {
         return cpuPower * memory * networkBandwidth;
     }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/src/main/java/org/kie/server/testing/CloudProcess.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/src/main/java/org/kie/server/testing/CloudProcess.java
@@ -17,6 +17,7 @@
 package org.kie.server.testing;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import org.codehaus.jackson.annotate.JsonIgnore;
 import org.optaplanner.core.api.domain.entity.PlanningEntity;
 import org.optaplanner.core.api.domain.variable.PlanningVariable;
 
@@ -68,10 +69,12 @@ public class CloudProcess extends AbstractPersistable {
     // Complex methods
     // ************************************************************************
 
+    @JsonIgnore
     public int getRequiredMultiplicand() {
         return requiredCpuPower * requiredMemory * requiredNetworkBandwidth;
     }
 
+    @JsonIgnore
     public String getLabel() {
         return "Process " + id;
     }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/OptaplannerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/OptaplannerIntegrationTest.java
@@ -29,6 +29,7 @@ import org.optaplanner.core.api.domain.solution.Solution;
 
 import java.lang.Thread;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.*;
@@ -130,9 +131,14 @@ public class OptaplannerIntegrationTest
         assertEquals( "Expected FAILURE response, but got " + type + "!", ServiceResponse.ResponseType.FAILURE, type );
     }
 
-    @Ignore @Test(expected = KieServicesException.class)
+    @Test
     public void testDisposeNotExistingSolver() throws Exception {
-        solverClient.disposeSolver( CONTAINER_1_ID, SOLVER_1_ID );
+        try {
+            solverClient.disposeSolver( CONTAINER_1_ID, SOLVER_1_ID );
+            fail("A KieServicesException should have been thrown by now.");
+        } catch (KieServicesException e) {
+            assertResultContainsStringRegex(e.getMessage(), ".*Solver.*from container.*not found.*");
+        }
     }
 
     @Test
@@ -273,6 +279,12 @@ public class OptaplannerIntegrationTest
         }
         // TODO add "|| solution.getScore().isInitialized()" once PLANNER-405 is fixed
         assertTrue(solution.getScore() != null);
+
+        List<?> processList = (List<?>) valueOf(solution, "processList");
+        for(Object process : processList) {
+            Object computer = valueOf(process, "computer");
+            assertNotNull(computer);
+        }
 
         assertSuccess( solverClient.disposeSolver( CONTAINER_1_ID, SOLVER_1_ID ) );
     }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/OptaplannerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/OptaplannerIntegrationTest.java
@@ -208,7 +208,7 @@ public class OptaplannerIntegrationTest
 
         // the following status starts the solver
         instance.setStatus( SolverInstance.SolverStatus.SOLVING );
-        instance.setPlanningProblem( loadPlanningProblem( 5, 10 ) );
+        instance.setPlanningProblem( loadPlanningProblem( 5, 15 ) );
         response = solverClient.updateSolverState( CONTAINER_1_ID, SOLVER_1_ID, instance );
         assertSuccess( response );
 
@@ -236,7 +236,7 @@ public class OptaplannerIntegrationTest
 
         // start solver
         instance.setStatus( SolverInstance.SolverStatus.SOLVING );
-        instance.setPlanningProblem( loadPlanningProblem( 50, 300 ) );
+        instance.setPlanningProblem( loadPlanningProblem( 50, 150 ) );
         response = solverClient.updateSolverState( CONTAINER_1_ID, SOLVER_1_ID, instance );
         assertSuccess( response );
         assertEquals( SolverInstance.SolverStatus.SOLVING, response.getResult().getStatus() );
@@ -259,7 +259,7 @@ public class OptaplannerIntegrationTest
 
         // the following status starts the solver
         instance.setStatus( SolverInstance.SolverStatus.SOLVING );
-        instance.setPlanningProblem( loadPlanningProblem( 10, 100 ) );
+        instance.setPlanningProblem( loadPlanningProblem( 10, 30 ) );
         ServiceResponse<SolverInstance> response = solverClient.updateSolverState( CONTAINER_1_ID, SOLVER_1_ID, instance );
         assertSuccess( response );
         assertEquals( SolverInstance.SolverStatus.SOLVING, response.getResult().getStatus() );
@@ -280,7 +280,10 @@ public class OptaplannerIntegrationTest
         // TODO add "|| solution.getScore().isInitialized()" once PLANNER-405 is fixed
         assertTrue(solution.getScore() != null);
 
+        List<?> computerList = (List<?>) valueOf(solution, "computerList");
+        assertEquals(10, computerList.size());
         List<?> processList = (List<?>) valueOf(solution, "processList");
+        assertEquals(30, processList.size());
         for(Object process : processList) {
             Object computer = valueOf(process, "computer");
             assertNotNull(computer);
@@ -308,7 +311,7 @@ public class OptaplannerIntegrationTest
         SolverInstance instance = new SolverInstance();
         instance.setSolverConfigFile( SOLVER_1_CONFIG );
         instance.setStatus( SolverInstance.SolverStatus.NOT_SOLVING );
-        instance.setPlanningProblem( loadPlanningProblem( 5, 10 ) );
+        instance.setPlanningProblem( loadPlanningProblem( 5, 15 ) );
         try {
             solverClient.updateSolverState( CONTAINER_1_ID, SOLVER_1_ID, instance );
             fail("A KieServicesException should have been thrown by now.");
@@ -325,7 +328,7 @@ public class OptaplannerIntegrationTest
         assertSuccess( solverClient.createSolver( CONTAINER_1_ID, SOLVER_1_ID, instance ) );
 
         instance.setStatus( SolverInstance.SolverStatus.NOT_SOLVING );
-        instance.setPlanningProblem( loadPlanningProblem( 50, 300 ) );
+        instance.setPlanningProblem( loadPlanningProblem( 50, 150 ) );
         ServiceResponse<SolverInstance> updateSolverState = solverClient.updateSolverState( CONTAINER_1_ID, SOLVER_1_ID, instance );
         assertSuccess( updateSolverState );
         assertResultContainsStringRegex(updateSolverState.getMsg(), "Solver.*on container.*already terminated.");
@@ -343,7 +346,7 @@ public class OptaplannerIntegrationTest
 
         // start solver
         instance.setStatus( SolverInstance.SolverStatus.SOLVING );
-        instance.setPlanningProblem( loadPlanningProblem( 50, 300 ) );
+        instance.setPlanningProblem( loadPlanningProblem( 50, 150 ) );
         response = solverClient.updateSolverState( CONTAINER_1_ID, SOLVER_1_ID, instance );
         assertSuccess( response );
         assertEquals( SolverInstance.SolverStatus.SOLVING, response.getResult().getStatus() );

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/OptaplannerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/OptaplannerIntegrationTest.java
@@ -19,6 +19,7 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.KieServices;
+import org.kie.server.api.marshalling.MarshallingFormat;
 import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
@@ -33,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.*;
+import static org.junit.Assume.*;
 
 public class OptaplannerIntegrationTest
         extends OptaplannerKieServerBaseIntegrationTest {
@@ -249,8 +251,9 @@ public class OptaplannerIntegrationTest
         assertSuccess( solverClient.disposeSolver( CONTAINER_1_ID, SOLVER_1_ID ) );
     }
 
-    @Test
+    @Test // TODO This test currently fails for JSON (if not ignored through assumeFalse())
     public void testGetBestSolution() throws Exception {
+        assumeFalse(marshallingFormat == MarshallingFormat.JSON); // TODO Do not ignore this test for JSON
         SolverInstance instance = new SolverInstance();
         instance.setSolverConfigFile( SOLVER_1_CONFIG );
         assertSuccess( client.createContainer( CONTAINER_1_ID, new KieContainerResource( CONTAINER_1_ID, kjar1 ) ) );

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/OptaplannerKieServerBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/OptaplannerKieServerBaseIntegrationTest.java
@@ -51,4 +51,15 @@ public abstract class OptaplannerKieServerBaseIntegrationTest
         super.additionalConfiguration(configuration);
         configuration.setTimeout(30000);
     }
+
+    protected Object valueOf(Object object, String fieldName) {
+        try {
+            Field field = object.getClass().getDeclaredField( fieldName );
+            field.setAccessible( true );
+            return field.get( object );
+        } catch ( Exception e ) {
+            return null;
+        }
+    }
+
 }


### PR DESCRIPTION
JSON testing for that particular method is ignored for now as it's broken due the marshalling issue (and was already broken before these changes, the new tests just expose it).