### PR TITLE
[6.4.x] [DROOLS-967] re-enable kie-aries-blueprint tests

### DIFF
--- a/kie-aries-blueprint/pom.xml
+++ b/kie-aries-blueprint/pom.xml
@@ -111,6 +111,12 @@
       <artifactId>named-kiesession</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
     <!-- test persistence -->
     <!--<dependency>
       <groupId>org.hibernate</groupId>

--- a/kie-aries-blueprint/src/main/java/org/kie/aries/blueprint/KieNamespaceHandler.java
+++ b/kie-aries-blueprint/src/main/java/org/kie/aries/blueprint/KieNamespaceHandler.java
@@ -89,7 +89,6 @@ public class KieNamespaceHandler implements org.apache.aries.blueprint.Namespace
 
     @Override
     public Set<Class> getManagedClasses() {
-        //System.out.println("getManagedClasses ::");
         return null;
     }
 

--- a/kie-aries-blueprint/src/test/java/org/kie/aries/blueprint/KieBlueprintContainer.java
+++ b/kie-aries-blueprint/src/test/java/org/kie/aries/blueprint/KieBlueprintContainer.java
@@ -25,51 +25,59 @@ import java.util.Set;
 import org.apache.aries.blueprint.container.BlueprintContainerImpl;
 import org.apache.aries.blueprint.container.SimpleNamespaceHandlerSet;
 import org.apache.aries.blueprint.parser.NamespaceHandlerSet;
+import org.apache.aries.blueprint.reflect.PassThroughMetadataImpl;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.wiring.BundleWiring;
 
 public class KieBlueprintContainer extends BlueprintContainerImpl {
 
     public KieBlueprintContainer(ClassLoader loader, List<URL> resources) throws Exception {
-        super(loader, resources);
+        this(loader, resources, null, true);
     }
 
     public KieBlueprintContainer(ClassLoader loader, List<URL> resources, boolean init) throws Exception {
-        super(loader, resources, init);
+        this(loader, resources, null, init);
     }
 
     public KieBlueprintContainer(ClassLoader loader, List<URL> resources, Map<String, String> properties, boolean init) throws Exception {
-        super(loader, resources, properties, init);
+        super(loader, resources, properties, createKieNamespaceHandlerSet(loader), false);
+        // kie-aries-blueprint relies on the following for retrieving bundle classloader [BZ-1310039]
+        getComponentDefinitionRegistry().registerComponentDefinition(new PassThroughMetadataImpl("blueprintBundleContext", createMockBundleContext(loader)));
+        // the initialization must happen after blueprintBundleContext is registered
+        if (init) {
+            super.init();
+        }
     }
 
-    @Override
-    public void init() throws Exception {
-        super.init();
-    }
-
-    /**
-     * Readd when org.apache.aries.blueprint.noosgi 1.0.1 is released
-     * 
-    @Override
-    protected NamespaceHandlerSet createNamespaceHandlerSet(Set<URI> namespaces) {
+    private static NamespaceHandlerSet createKieNamespaceHandlerSet(ClassLoader classloader) {
         NamespaceHandlerSet handlerSet = new SimpleNamespaceHandlerSet();
-        try {
-            URI namespaceURL = URI.create("http://drools.org/schema/kie-aries-blueprint/1.0.0");
-            URL schemaURL = getResource("org/kie/aries/blueprint/kie-aries-blueprint.xsd");
-            KieNamespaceHandler namespaceHandler = new KieNamespaceHandler();
-            ((SimpleNamespaceHandlerSet)handlerSet).addNamespace(namespaceURL, schemaURL, namespaceHandler);
-        } catch(Exception e) {
-            e.printStackTrace();
-        }
-        // Check namespaces
-        Set<URI> unsupported = new LinkedHashSet<URI>();
-        for (URI ns : namespaces) {
-            if (!handlerSet.getNamespaces().contains(ns)) {
-                unsupported.add(ns);
-            }
-        }
-        if (unsupported.size() > 0) {
-            throw new IllegalArgumentException("Unsupported namespaces: " + unsupported.toString());
-        }
+        URI namespaceURL = URI.create("http://drools.org/schema/kie-aries-blueprint/1.0.0");
+        URL schemaURL = classloader.getResource("org/kie/aries/blueprint/kie-aries-blueprint.xsd");
+        KieNamespaceHandler namespaceHandler = new KieNamespaceHandler();
+        ((SimpleNamespaceHandlerSet) handlerSet).addNamespace(namespaceURL, schemaURL, namespaceHandler);
         return handlerSet;
     }
-    */
+
+    private static BundleContext createMockBundleContext(ClassLoader classLoader) {
+        BundleContext mockBundleContext = Mockito.mock(BundleContext.class);
+        Bundle mockBundle = createMockBundle(classLoader);
+        Mockito.when(mockBundleContext.getBundle()).thenReturn(mockBundle);
+        return mockBundleContext;
+    }
+
+    private static Bundle createMockBundle(ClassLoader classLoader) {
+        Bundle mockBundle = Mockito.mock(Bundle.class);
+        BundleWiring mockBundleWiring = createMockBundleWiring(classLoader);
+        Mockito.when(mockBundle.adapt(Matchers.eq(BundleWiring.class))).thenReturn(mockBundleWiring);
+        return mockBundle;
+    }
+
+    private static BundleWiring createMockBundleWiring(ClassLoader classLoader) {
+        BundleWiring mockBundleWiring = Mockito.mock(BundleWiring.class);
+        Mockito.when(mockBundleWiring.getClassLoader()).thenReturn(classLoader);
+        return mockBundleWiring;
+    }
 }

--- a/kie-aries-blueprint/src/test/java/org/kie/aries/blueprint/tests/KieBlueprintBPMNTest.java
+++ b/kie-aries-blueprint/src/test/java/org/kie/aries/blueprint/tests/KieBlueprintBPMNTest.java
@@ -34,7 +34,6 @@ import org.kie.aries.blueprint.KieBlueprintContainer;
 
 import static org.junit.Assert.*;
 
-@Ignore("Add when org.apache.aries.blueprint.noosgi 1.0.1 is released")
 public class KieBlueprintBPMNTest {
 
     static BlueprintContainerImpl container = null;

--- a/kie-aries-blueprint/src/test/java/org/kie/aries/blueprint/tests/KieBlueprintBasicTest.java
+++ b/kie-aries-blueprint/src/test/java/org/kie/aries/blueprint/tests/KieBlueprintBasicTest.java
@@ -36,7 +36,6 @@ import java.util.List;
 
 import static org.junit.Assert.*;
 
-@Ignore("Add when org.apache.aries.blueprint.noosgi 1.0.1 is released")
 public class KieBlueprintBasicTest {
 
     static BlueprintContainerImpl container = null;

--- a/kie-aries-blueprint/src/test/java/org/kie/aries/blueprint/tests/KieBlueprintCommandsTest.java
+++ b/kie-aries-blueprint/src/test/java/org/kie/aries/blueprint/tests/KieBlueprintCommandsTest.java
@@ -32,8 +32,6 @@ import org.kie.aries.blueprint.beans.Person;
 
 import static org.junit.Assert.*;
 
-@Ignore("Add when org.apache.aries.blueprint.noosgi 1.0.1 is released")
-
 public class KieBlueprintCommandsTest {
 
     static BlueprintContainerImpl container = null;

--- a/kie-aries-blueprint/src/test/java/org/kie/aries/blueprint/tests/KieBlueprintEnvironmentTest.java
+++ b/kie-aries-blueprint/src/test/java/org/kie/aries/blueprint/tests/KieBlueprintEnvironmentTest.java
@@ -40,7 +40,6 @@ import java.util.List;
 
 import static org.junit.Assert.*;
 
-@Ignore("Add when org.apache.aries.blueprint.noosgi 1.0.1 is released")
 public class KieBlueprintEnvironmentTest {
 
     static BlueprintContainerImpl container = null;

--- a/kie-aries-blueprint/src/test/java/org/kie/aries/blueprint/tests/KieBlueprintGAVTest.java
+++ b/kie-aries-blueprint/src/test/java/org/kie/aries/blueprint/tests/KieBlueprintGAVTest.java
@@ -36,7 +36,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-@Ignore
+@Ignore("kie:kbase-ref and kie:ksession-ref not (yet or anymore) supported. ")
 public class KieBlueprintGAVTest {
 
     static BlueprintContainerImpl container = null;

--- a/kie-aries-blueprint/src/test/java/org/kie/aries/blueprint/tests/KieBlueprintKModuleBasicTest.java
+++ b/kie-aries-blueprint/src/test/java/org/kie/aries/blueprint/tests/KieBlueprintKModuleBasicTest.java
@@ -36,7 +36,6 @@ import java.util.List;
 
 import static org.junit.Assert.*;
 
-@Ignore("Add when org.apache.aries.blueprint.noosgi 1.0.1 is released")
 public class KieBlueprintKModuleBasicTest {
 
     static BlueprintContainerImpl container = null;

--- a/kie-aries-blueprint/src/test/java/org/kie/aries/blueprint/tests/KieBlueprintListenerTest.java
+++ b/kie-aries-blueprint/src/test/java/org/kie/aries/blueprint/tests/KieBlueprintListenerTest.java
@@ -39,7 +39,6 @@ import java.util.List;
 
 import static org.junit.Assert.*;
 
-@Ignore("Add when org.apache.aries.blueprint.noosgi 1.0.1 is released")
 public class KieBlueprintListenerTest {
 
     static BlueprintContainerImpl container = null;

--- a/kie-aries-blueprint/src/test/java/org/kie/aries/blueprint/tests/KieBlueprintLoggerTest.java
+++ b/kie-aries-blueprint/src/test/java/org/kie/aries/blueprint/tests/KieBlueprintLoggerTest.java
@@ -37,7 +37,6 @@ import java.util.List;
 
 import static org.junit.Assert.*;
 
-@Ignore("Add when org.apache.aries.blueprint.noosgi 1.0.1 is released")
 public class KieBlueprintLoggerTest {
 
     static BlueprintContainerImpl container = null;


### PR DESCRIPTION
@mariofusco please take a look

Many thanks to @winklerm for the fixes around the BundleContext mocking.