### PR TITLE
[ENTESB-5152] add support for OSGi WAR bundles

### DIFF
--- a/drools-osgi/drools-osgi-integration/pom.xml
+++ b/drools-osgi/drools-osgi-integration/pom.xml
@@ -70,6 +70,21 @@
     </dependency>
 
     <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
 * so far we only supported jar-based bundles. WARs
   are, however, supported as well on Karaf/Fuse.
   The code is a hack basically. It tries to search
   search resources with WEB-INF/classes prefix to
   cover the WAR use case. For 7.x we should look
   into making this easier to undersntad, by e.g.
   having two (or more) different classes
   - OsgiJarKieModule and OsgiWarKieModule. They
   would then hide the implementation details
   of WEB-INF/classes, etc. Implementing this for
   6.x is a risk at this stage.

This is a forward port of #368. We need to come up with better approach, bot for now let's at least keep in sync with 6.4.x