### PR TITLE
[6.4.x] [DROOLS-1060] osgi: upgrade Apache POI from 3.11_1 to 3.13_2

### DIFF
--- a/drools-osgi/drools-karaf-features/pom.xml
+++ b/drools-osgi/drools-karaf-features/pom.xml
@@ -65,7 +65,7 @@
     <karaf.servicemix.version.com.thoughtworks.xmlpull>1.1.4c_7</karaf.servicemix.version.com.thoughtworks.xmlpull>
     <karaf.servicemix.version.javax.xml.bind.jaxb>2.2.0</karaf.servicemix.version.javax.xml.bind.jaxb>
     <karaf.servicemix.version.org.antlr>3.5_1</karaf.servicemix.version.org.antlr>
-    <karaf.servicemix.version.org.apache.poi>3.11_1</karaf.servicemix.version.org.apache.poi>
+    <karaf.servicemix.version.org.apache.poi>3.13_2</karaf.servicemix.version.org.apache.poi>
     <!-- Santurio and xmlresolver needed by POI 3.11+ -->
     <karaf.version.org.apache.santurio>2.0.6</karaf.version.org.apache.santurio>
     <karaf.servicemix.version.xmlresolver>1.2_5</karaf.servicemix.version.xmlresolver>


### PR DESCRIPTION
 * this is just to synp up with non-osgi world which uses
   version 3.13 for quite some time now