### PR TITLE
[ENTESB-5168] create different features file for Fuse 6.3

### DIFF
--- a/drools-osgi/drools-karaf-features/pom.xml
+++ b/drools-osgi/drools-karaf-features/pom.xml
@@ -34,7 +34,9 @@
     <!-- used by jbpm-commons -->
     <karaf.version.org.jboss.spec.javax.security.jacc>1.0.0.Final</karaf.version.org.jboss.spec.javax.security.jacc>
     <karaf.version.org.jboss.spec.javax.interceptor>1.0.0.Final</karaf.version.org.jboss.spec.javax.interceptor>
+    <!-- Geronimo servlet-api bundle is needed by Fuse 6.2.x and javax-servlet by Fuse 6.3.x+ -->
     <karaf.version.org.apache.geronimo.specs.servlet>1.0</karaf.version.org.apache.geronimo.specs.servlet>
+    <karaf.version.javax.servlet>3.1.0</karaf.version.javax.servlet>
     <karaf.version.org.apache.geronimo.specs.jms>1.1.1</karaf.version.org.apache.geronimo.specs.jms>
     <karaf.version.org.apache.geronimo.specs.jpa>1.1</karaf.version.org.apache.geronimo.specs.jpa>
     <karaf.version.org.apache.geronimo.specs.jta>1.1.1</karaf.version.org.apache.geronimo.specs.jta>
@@ -99,6 +101,11 @@
         <groupId>org.apache.geronimo.specs</groupId>
         <artifactId>geronimo-servlet_3.0_spec</artifactId>
         <version>${karaf.version.org.apache.geronimo.specs.servlet}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.servlet</groupId>
+        <artifactId>javax.servlet-api</artifactId>
+        <version>${karaf.version.javax.servlet}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.geronimo.specs</groupId>
@@ -648,9 +655,21 @@
             <configuration>
               <artifacts>
                 <artifact>
+                  <file>${project.build.outputDirectory}/repository/features-core.xml</file>
+                  <type>xml</type>
+                  <classifier>features-core</classifier>
+                </artifact>
+                <!-- features.xml was not renamed to features-fuse-6_2.xml for backward compatibility reasons. All future
+                     files should have fuse version in the classifier -->
+                <artifact>
                   <file>${project.build.outputDirectory}/repository/features.xml</file>
                   <type>xml</type>
                   <classifier>features</classifier>
+                </artifact>
+                <artifact>
+                  <file>${project.build.outputDirectory}/repository/features-fuse-6_3.xml</file>
+                  <type>xml</type>
+                  <classifier>features-fuse-6_3</classifier>
                 </artifact>
               </artifacts>
             </configuration>

--- a/drools-osgi/drools-karaf-features/src/main/filtered-resources/repository/features-core.xml
+++ b/drools-osgi/drools-karaf-features/src/main/filtered-resources/repository/features-core.xml
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="karaf-features-core-droolsjbpm-${project.version}"
+          xmlns="http://karaf.apache.org/xmlns/features/v1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.0.0 http://karaf.apache.org/xmlns/features/v1.0.0">
+
+  <feature name="drools-common" version="${project.version}" description="Drools Commons">
+    <bundle>mvn:com.google.protobuf/protobuf-java/${karaf.version.com.google.protobuf}</bundle>
+    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.antlr/${karaf.servicemix.version.org.antlr}</bundle>
+    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/${karaf.servicemix.version.com.thoughtworks.xstream}</bundle>
+    <bundle start-level='10'>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxb-api-2.2/${karaf.servicemix.version.javax.xml.bind.jaxb}</bundle>
+    <bundle start-level='10'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-xjc/${karaf.servicemix.version.com.sun.xml.bind.jaxb}</bundle>
+    <bundle start-level='10'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-impl/${karaf.servicemix.version.com.sun.xml.bind.jaxb}</bundle>
+    <bundle>mvn:org.mvel/mvel2/${version.org.mvel}</bundle>
+    <bundle>wrap:mvn:org.eclipse.jdt.core.compiler/ecj/${karaf.version.org.eclipse.jdt.core.compiler}$Bundle-SymbolicName=Eclipse-JDT-Compiler&amp;Bundle-Version=${karaf.version.org.eclipse.jdt.core.compiler}</bundle>
+    <bundle>wrap:mvn:org.codehaus.janino/janino/${karaf.version.org.codehaus.janino}$Bundle-SymbolicName=Codehaus-Janino&amp;Bundle-Version=${karaf.version.org.codehaus.janino}</bundle>
+    <bundle>mvn:org.apache.geronimo.specs/geronimo-atinject_1.0_spec/${karaf.version.javax.inject}</bundle>
+    <bundle>wrap:mvn:javax.enterprise/cdi-api/${karaf.version.javax.enterprise.cdi}</bundle>
+    <bundle>mvn:commons-codec/commons-codec/${karaf.version.commons-codec}</bundle>
+  </feature>
+
+  <feature name="drools-module" version="${project.version}" description="Drools Core">
+    <feature version="${project.version}">drools-common</feature>
+    <feature version="${project.version}">kie</feature>
+    <bundle>mvn:org.drools/drools-core/${version.org.drools}</bundle>
+    <bundle>mvn:org.drools/drools-compiler/${version.org.drools}</bundle>
+    <bundle>mvn:org.drools/drools-osgi-integration/${version.org.drools}</bundle>
+  </feature>
+
+  <feature name="drools-templates" version="${project.version}" description="Drools Templates">
+    <bundle>mvn:org.drools/drools-templates/${version.org.drools}</bundle>
+  </feature>
+
+  <feature name="drools-decisiontable" description="Drools Decision Tables" version="${project.version}">
+    <feature version="${project.version}">drools-module</feature>
+    <feature version="${project.version}">drools-templates</feature>
+    <bundle>mvn:commons-codec/commons-codec/${karaf.version.commons-codec}</bundle>
+    <bundle>mvn:org.drools/drools-decisiontables/${version.org.drools}</bundle>
+    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.poi/${karaf.servicemix.version.org.apache.poi}</bundle>
+    <bundle>mvn:org.apache.santuario/xmlsec/${karaf.version.org.apache.santurio}</bundle>
+    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlresolver/${karaf.servicemix.version.xmlresolver}</bundle>
+  </feature>
+
+  <feature name="drools-jpa" version="${project.version}" description="Drools JPA">
+    <feature version="${project.version}">drools-module</feature>
+    <feature version="[3.1,4.0)">spring-orm</feature>
+    <feature version="[${karaf.version.org.apache.aries.jpa},2.0)">jpa</feature>
+    <bundle>mvn:org.drools/drools-persistence-jpa/${version.org.drools}</bundle>
+  </feature>
+
+  <feature name="kie" version="${project.version}" description="KIE API">
+    <bundle>mvn:org.kie/kie-api/${version.org.drools}</bundle>
+    <bundle>mvn:org.kie/kie-internal/${version.org.drools}</bundle>
+  </feature>
+
+  <feature name="kie-ci" version="${project.version}" description="KIE CI">
+    <bundle>mvn:org.kie/kie-ci-osgi/${version.org.drools}</bundle>
+  </feature>
+
+  <feature name="kie-spring" version="${project.version}" description="KIE Spring">
+    <feature version="${project.version}">kie</feature>
+    <feature version="${project.version}">drools-jpa</feature>
+    <feature version="${project.version}">jbpm</feature>
+    <feature version="${project.version}">jbpm-human-task</feature>
+    <feature version="[3.1,4.0)">spring</feature>
+    <bundle>mvn:org.springframework.osgi/spring-osgi-extender/${version.org.springframework.osgi}</bundle>
+    <bundle>mvn:org.springframework.osgi/spring-osgi-core/${version.org.springframework.osgi}</bundle>
+    <bundle>mvn:org.springframework.osgi/spring-osgi-io/${version.org.springframework.osgi}</bundle>
+    <bundle>mvn:org.kie/kie-spring/${version.org.drools}</bundle>
+  </feature>
+
+  <feature name="kie-aries-blueprint" version="${project.version}" description="KIE Aries Blueprint">
+    <feature version="${project.version}">kie</feature>
+    <feature version="${project.version}">drools-jpa</feature>
+    <feature version="${project.version}">jbpm</feature>
+    <feature version="${project.version}">jbpm-human-task</feature>
+    <bundle>mvn:org.kie/kie-aries-blueprint/${version.org.drools}</bundle>
+  </feature>
+
+  <feature name="jbpm-commons" version="${project.version}" description="jBPM Commons">
+    <!-- This feature is Fuse version specific, so it is defined differently in the features.xml and features-fuse-6_3.xml files -->
+    <feature version="${project.version}">servlet-api-drools</feature>
+    <bundle>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.scripting-api-1.0/${karaf.servicemix.version.scripting-api}</bundle>
+    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.quartz/${karaf.servicemix.version.org.quartz-scheduler}</bundle>
+    <bundle>mvn:org.jboss.spec.javax.security.jacc/jboss-jacc-api_1.5_spec/${karaf.version.org.jboss.spec.javax.security.jacc}</bundle>
+    <bundle>mvn:joda-time/joda-time/${karaf.version.joda-time}</bundle>
+    <bundle>mvn:org.jboss.spec.javax.interceptor/jboss-interceptors-api_1.2_spec/${karaf.version.org.jboss.spec.javax.interceptor}</bundle>
+    <bundle>mvn:org.apache.geronimo.specs/geronimo-jms_1.1_spec/${karaf.version.org.apache.geronimo.specs.jms}</bundle>
+    <bundle>mvn:org.apache.geronimo.specs/geronimo-jpa_2.0_spec/${karaf.version.org.apache.geronimo.specs.jpa}</bundle>
+    <bundle>mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/${karaf.version.org.apache.geronimo.specs.jta}</bundle>
+  </feature>
+
+  <feature name="jbpm-human-task" version="${project.version}" description="jBPM Human Task">
+    <bundle>mvn:org.codehaus.jackson/jackson-core-asl/${version.org.codehaus.jackson}</bundle>
+    <bundle>mvn:org.jbpm/jbpm-human-task-core/${version.org.jbpm}</bundle>
+    <bundle>mvn:org.jbpm/jbpm-human-task-workitems/${version.org.jbpm}</bundle>
+    <bundle>mvn:org.jbpm/jbpm-human-task-jpa/${version.org.jbpm}</bundle>
+    <bundle>mvn:org.jbpm/jbpm-human-task-audit/${version.org.jbpm}</bundle>
+  </feature>
+
+  <feature name="jbpm" version="${project.version}" description="jBPM Engine">
+    <feature version="${project.version}">drools-module</feature>
+    <feature version="${project.version}">drools-jpa</feature>
+    <feature version="${project.version}">jbpm-commons</feature>
+    <feature version="${project.version}">jbpm-human-task</feature>
+    <bundle>mvn:org.jbpm/jbpm-flow-builder/${version.org.jbpm}</bundle>
+    <bundle>mvn:org.jbpm/jbpm-flow/${version.org.jbpm}</bundle>
+    <bundle>mvn:org.jbpm/jbpm-bpmn2/${version.org.jbpm}</bundle>
+    <bundle>mvn:org.jbpm/jbpm-audit/${version.org.jbpm}</bundle>
+    <bundle>mvn:org.jbpm/jbpm-query-jpa/${version.org.jbpm}</bundle>
+    <bundle>mvn:org.jbpm/jbpm-runtime-manager/${version.org.jbpm}</bundle>
+    <bundle>mvn:org.jbpm/jbpm-persistence-jpa/${version.org.jbpm}</bundle>
+    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.javax.mail/1.4.1_5</bundle>
+  </feature>
+
+  <feature name="jbpm-workitems" version="${project.version}" description="jBPM Work Items">
+    <feature version="${project.version}">jbpm</feature>
+    <bundle>wrap:mvn:org.jbpm/jbpm-workitems/${version.org.jbpm}</bundle>
+  </feature>
+
+  <feature name="jbpm-executor" version="${project.version}" description="jBPM Executor">
+    <feature version="${project.version}">jbpm-workitems</feature>
+    <bundle>wrap:mvn:org.jbpm/jbpm-executor/${version.org.jbpm}$DynamicImport-Package=org.hibernate.*,javassist.*</bundle>
+  </feature>
+
+  <feature name="optaplanner-engine" version="${project.version}" description="OptaPlanner Engine">
+    <feature version="${project.version}">drools-module</feature>
+    <bundle>mvn:org.optaplanner/optaplanner-core/${version.org.optaplanner}</bundle>
+    <bundle>mvn:org.apache.commons/commons-lang3/${version.org.apache.commons.lang3}</bundle>
+    <bundle>mvn:org.apache.commons/commons-math3/${version.org.apache.commons.math3}</bundle>
+    <bundle>mvn:commons-io/commons-io/${version.commons-io}</bundle>
+    <bundle>mvn:com.google.guava/guava/${version.com.google.guava}</bundle>
+    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.reflections/${karaf.version.org.apache.servicemix.bundles.reflections}</bundle>
+  </feature>
+
+  <feature name="droolsjbpm-hibernate" version="${version.org.hibernate}" description="Hibernate 4.2.x JPA persistence engine support">
+    <details>Enable Hibernate 4.2.x as persistence engine.</details>
+    <feature>transaction</feature>
+    <feature>jpa</feature>
+    <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.antlr/${karaf.version.org.apache.servicemix.bundles.antlr}</bundle>
+    <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.ant/${karaf.version.org.apache.servicemix.bundles.ant}</bundle>
+    <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.dom4j/${karaf.version.org.apache.servicemix.bundles.dom4j}</bundle>
+    <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.serp/${karaf.version.org.apache.servicemix.bundles.serp}</bundle>
+    <bundle dependency="true">mvn:com.fasterxml/classmate/${karaf.version.com.fasterxml.classmate}</bundle>
+    <bundle dependency="true">mvn:org.javassist/javassist/${version.org.javassist}</bundle>
+    <bundle dependency="true">mvn:org.jboss.spec.javax.security.jacc/jboss-jacc-api_1.4_spec/${version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.4_spec}</bundle>
+    <bundle dependency="true">wrap:mvn:org.jboss/jandex/${karaf.version.org.jboss.jandex}</bundle>
+    <bundle dependency="true">mvn:javax.validation/validation-api/${karaf.version.javax.validation}</bundle>
+    <bundle dependency="true">mvn:org.jboss.logging/jboss-logging/${version.org.jboss.logging.jboss-logging}</bundle>
+    <bundle dependency="true">mvn:org.hibernate.common/hibernate-commons-annotations/${version.org.hibernate.commons.annotations}</bundle>
+    <bundle start-level="100">wrap:mvn:org.hibernate/hibernate-core/${version.org.hibernate}$overwrite=merge&amp;Import-Package=org.jbpm.services.task*,*</bundle>
+    <bundle start-level="100">wrap:mvn:org.hibernate/hibernate-entitymanager/${version.org.hibernate}$overwrite=merge&amp;DynamicImport-Package=*</bundle>
+    <bundle start-level="100">mvn:org.hibernate/hibernate-osgi/${version.org.hibernate}</bundle>
+  </feature>
+
+  <feature name="hibernate-validator" version="${version.org.hibernate.validator}" description="Hibernate Validator">
+    <bundle>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jsr303-api-1.1.0/${karaf.version.org.apache.servicemix.specs.jsr303-api}</bundle>
+    <bundle>mvn:org.jboss.logging/jboss-logging/${version.org.jboss.logging.jboss-logging}</bundle>
+    <bundle>mvn:org.hibernate/hibernate-validator/${version.org.hibernate.validator}</bundle>
+  </feature>
+
+  <feature name="jbpm-spring-persistent" version="${project.version}" description="jBPM Spring Persistence support">
+    <feature version="${project.version}">jbpm</feature>
+    <feature>spring-dm</feature>
+    <feature version="${project.version}">kie-spring</feature>
+    <feature>droolsjbpm-hibernate</feature>
+    <feature version="${h2.version}">h2</feature>
+  </feature>
+
+  <feature name="h2" version="${h2.version}" description="H2 database">
+    <bundle>mvn:com.h2database/h2/${h2.version}</bundle>
+    <bundle start-level="100">mvn:commons-dbcp/commons-dbcp/${version.commons-dbcp}</bundle>
+    <bundle start-level="100">mvn:commons-pool/commons-pool/${version.commons-pool}</bundle>
+  </feature>
+
+  <feature name="kie-server-client" version="${project.version}" description="KIE Server Client">
+    <feature version="${project.version}">drools-module</feature>
+    <feature version="${project.version}">optaplanner-engine</feature>
+    <bundle>mvn:org.kie.server/kie-server-api/${version.org.drools.droolsjbpm-integration}</bundle>
+    <bundle>mvn:org.kie.remote/kie-remote-common/${version.org.drools.droolsjbpm-integration}</bundle>
+    <bundle>mvn:org.kie.server/kie-server-client/${version.org.drools.droolsjbpm-integration}</bundle>
+    <bundle>wrap:mvn:org.jboss.resteasy/jaxrs-api/${version.org.jboss.resteasy}</bundle>
+    <bundle>mvn:org.apache.commons/commons-lang3/${version.org.apache.commons.lang3}</bundle>
+    <bundle>mvn:org.codehaus.jackson/jackson-core-asl/${version.org.codehaus.jackson}</bundle>
+    <bundle>mvn:org.codehaus.jackson/jackson-xc/${version.org.codehaus.jackson}</bundle>
+    <bundle>mvn:org.codehaus.jackson/jackson-mapper-asl/${version.org.codehaus.jackson}</bundle>
+    <bundle>mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/${karaf.version.org.apache.geronimo.specs.jta}</bundle>
+    <bundle>mvn:org.apache.geronimo.specs/geronimo-jms_1.1_spec/${karaf.version.org.apache.geronimo.specs.jms}</bundle>
+    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xpp3/${karaf.servicemix.version.com.thoughtworks.xmlpull}</bundle>
+  </feature>
+
+  <feature name="kie-remote-client" version="${project.version}" description="KIE Remote Client">
+    <feature version="${project.version}">drools-module</feature>
+    <feature version="${project.version}">optaplanner-engine</feature>
+    <bundle>mvn:org.kie.remote/kie-remote-client/${version.org.drools.droolsjbpm-integration}</bundle>
+    <bundle>mvn:org.kie.remote/kie-remote-common/${version.org.drools.droolsjbpm-integration}</bundle>
+    <bundle>wrap:mvn:org.kie.remote.ws/kie-remote-ws-common/${version.org.drools.droolsjbpm-integration}</bundle>
+    <bundle>wrap:mvn:org.kie.remote/kie-remote-jaxb/${version.org.drools.droolsjbpm-integration}</bundle>
+    <bundle>wrap:mvn:org.jboss.resteasy/jaxrs-api/${version.org.jboss.resteasy}</bundle>
+    <bundle>wrap:mvn:org.jsoup/jsoup/${version.org.jsoup}</bundle>
+    <bundle>mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/${karaf.version.org.apache.geronimo.specs.jta}</bundle>
+    <bundle>mvn:org.apache.geronimo.specs/geronimo-jms_1.1_spec/${karaf.version.org.apache.geronimo.specs.jms}</bundle>
+  </feature>
+
+</features>

--- a/drools-osgi/drools-karaf-features/src/main/filtered-resources/repository/features-fuse-6_3.xml
+++ b/drools-osgi/drools-karaf-features/src/main/filtered-resources/repository/features-fuse-6_3.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<features name="karaf-features-droolsjbpm-${project.version}"
+<features name="karaf-features-fuse-6_3-droolsjbpm-${project.version}"
           xmlns="http://karaf.apache.org/xmlns/features/v1.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.0.0 http://karaf.apache.org/xmlns/features/v1.0.0">
@@ -7,7 +7,7 @@
   <repository>mvn:org.drools/drools-karaf-features/${project.version}/xml/features-core</repository>
 
   <feature name="servlet-api-drools" version="${project.version}">
-    <bundle>mvn:org.apache.geronimo.specs/geronimo-servlet_3.0_spec/${karaf.version.org.apache.geronimo.specs.servlet}</bundle>
+    <bundle>mvn:javax.servlet/javax.servlet-api/${karaf.version.javax.servlet}</bundle>
   </feature>
 
 </features>


### PR DESCRIPTION
 * we need different servlet-api bundle for Fuse 6.2
   and Fuse 6.3. Separate feature files seem to be the
   only way to do so. From now on, the feature files
   should include the target Fuse version in the name.
   Keeping features.xml (for Fuse 6.2) because of
   backward compatibility