### PR TITLE
[6.4.x] JBPM-5022 - enable kie server REST services only after all containers…

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
@@ -143,7 +143,7 @@ public class KieServerImpl {
                                                                                         containerManager,
                                                                                         this), "KieServer-ControllerConnect");
             connectToControllerThread.start();
-            if (Boolean.parseBoolean(currentState.getConfiguration().getConfigItemValue(KieServerConstants.CFG_SYNC_DEPLOYMENT, "true"))) {
+            if (Boolean.parseBoolean(currentState.getConfiguration().getConfigItemValue(KieServerConstants.CFG_SYNC_DEPLOYMENT, "false"))) {
                 logger.info("Containers were requested to be deployed synchronously, holding application start...");
                 try {
                     connectToControllerThread.join();


### PR DESCRIPTION
… have been loaded / processed on startup - use async deploy mode by default to allow running workbench and kie server on single app server

(cherry picked from commit 9676ab6559c6d91c244f88f6bdf9d2890224f269)