### PR TITLE
[6.4.x] DROOLS-1114 - Add ConversationId http header/jms property to allow dy…

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/ConversationId.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/ConversationId.java
@@ -34,6 +34,9 @@ import org.kie.server.api.model.ReleaseId;
  */
 public class ConversationId {
 
+    private static final String WRAP = "'";
+    private static final String SPLIT_PATTERN = WRAP + ":" + WRAP;
+
     private String kieServerId;
     private String containerId;
     private ReleaseId releaseId;
@@ -60,15 +63,18 @@ public class ConversationId {
         try {
             String conversationId = URLDecoder.decode(conversationIdString, "UTF-8");
 
-            String[] conversationIdElements = conversationId.split(":");
-            if (conversationIdElements.length != 6) {
+            String[] conversationIdElements = conversationId.split(SPLIT_PATTERN);
+            if (conversationIdElements.length != 4) {
                 throw new IllegalArgumentException("Non-parsable conversationId '" + conversationIdString + "'");
             }
 
-            String kieServerId = conversationIdElements[0];
+            String kieServerId = conversationIdElements[0].replaceAll("'", "");
             String containerId = conversationIdElements[1];
-            ReleaseId releaseId = new ReleaseId(conversationIdElements[2], conversationIdElements[3], conversationIdElements[4]);
-            String uniqueString = conversationIdElements[5];
+
+            String[] releaseIdElements = conversationIdElements[2].split(":");
+
+            ReleaseId releaseId = new ReleaseId(releaseIdElements[0], releaseIdElements[1], releaseIdElements[2]);
+            String uniqueString = conversationIdElements[3].replaceAll("'", "");;
 
             return new ConversationId(kieServerId, containerId, releaseId, uniqueString);
         } catch (UnsupportedEncodingException e) {
@@ -95,13 +101,16 @@ public class ConversationId {
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();
-        builder.append(kieServerId)
-        .append(":")
+        builder
+        .append(WRAP)
+        .append(kieServerId)
+        .append(WRAP + ":" + WRAP)
         .append(containerId)
-        .append(":")
+        .append(WRAP + ":" + WRAP)
         .append(releaseId.toExternalForm())
-        .append(":")
-        .append(uniqueString);
+        .append(WRAP + ":" + WRAP)
+        .append(uniqueString)
+        .append(WRAP);
 
         try {
             return URLEncoder.encode(builder.toString(), "UTF-8");

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/test/java/org/kie/server/client/ConversationIdTest.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/test/java/org/kie/server/client/ConversationIdTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.client;
+
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+
+import org.junit.Test;
+import org.kie.server.api.ConversationId;
+import org.kie.server.api.model.ReleaseId;
+
+import static org.junit.Assert.*;
+
+public class ConversationIdTest {
+
+    @Test
+    public void testParseConversationIdFromString() throws Exception {
+         String conversationId = "'kie-server-id':'my-container':'org.kie:kjar:1.0':'12345abcdef'";
+
+        ConversationId instance = ConversationId.fromString(conversationId);
+        assertNotNull(instance);
+
+        assertEquals("kie-server-id", instance.getKieServerId());
+        assertEquals("my-container", instance.getContainerId());
+        assertEquals("org.kie:kjar:1.0", instance.getReleaseId().toExternalForm());
+        assertEquals("12345abcdef", instance.getUniqueString());
+
+        String conversationIdUrlEncoded = URLEncoder.encode(conversationId, "UTF-8");
+        assertEquals(conversationIdUrlEncoded, instance.toString());
+    }
+
+    @Test
+    public void testParseConversationId() {
+        ConversationId instance = ConversationId.from("kie-server-id", "my-container", new ReleaseId("org.kie", "kjar", "1.0"));
+        assertNotNull(instance);
+
+        assertEquals("kie-server-id", instance.getKieServerId());
+        assertEquals("my-container", instance.getContainerId());
+        assertEquals("org.kie:kjar:1.0", instance.getReleaseId().toExternalForm());
+
+    }
+
+    @Test
+    public void testParseConversationIdWithColonInName() {
+        ConversationId instance = ConversationId.from("kie:server:id", "my:container", new ReleaseId("org.kie", "kjar", "1.0"));
+        assertNotNull(instance);
+
+        assertEquals("kie:server:id", instance.getKieServerId());
+        assertEquals("my:container", instance.getContainerId());
+        assertEquals("org.kie:kjar:1.0", instance.getReleaseId().toExternalForm());
+
+    }
+
+    @Test
+    public void testParseConversationRoundTripping() throws Exception {
+        String conversationId = "'kie-server-id':'my-container':'org.kie:kjar:1.0':'12345abcdef'";
+
+        ConversationId instance = ConversationId.fromString(conversationId);
+        assertNotNull(instance);
+
+        assertEquals("kie-server-id", instance.getKieServerId());
+        assertEquals("my-container", instance.getContainerId());
+        assertEquals("org.kie:kjar:1.0", instance.getReleaseId().toExternalForm());
+        assertEquals("12345abcdef", instance.getUniqueString());
+
+        // check the incoming toString
+        String conversationIdUrlEncoded = URLEncoder.encode(conversationId, "UTF-8");
+        assertEquals(conversationIdUrlEncoded, instance.toString());
+
+        // url decode it and check with raw conversationId
+        assertEquals(conversationId, URLDecoder.decode(instance.toString(), "UTF-8"));
+
+        // now build ConversationId from url encoded string
+        instance = ConversationId.fromString(instance.toString());
+        assertNotNull(instance);
+
+        assertEquals("kie-server-id", instance.getKieServerId());
+        assertEquals("my-container", instance.getContainerId());
+        assertEquals("org.kie:kjar:1.0", instance.getReleaseId().toExternalForm());
+        assertEquals("12345abcdef", instance.getUniqueString());
+    }
+}


### PR DESCRIPTION
…namic routing of requests - changed conversationId format

(cherry picked from commit e8d59b9c521957630af2f2fad1bf9ddfd661692f)

@etirelli @manstis here is a change in the conversationId format to have its parts included in '' so it can use separation character (:) in the name as well. wdyt?