### PR TITLE
make a RemoteKieServerOperation class protected instead of public

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/KieServerInstanceManager.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/KieServerInstanceManager.java
@@ -313,7 +313,7 @@ public class KieServerInstanceManager {
     protected String getToken() {
         return System.getProperty(KieServerConstants.CFG_KIE_TOKEN);
     }
-    private class RemoteKieServerOperation<T> {
+    protected class RemoteKieServerOperation<T> {
 
         public T doOperation(KieServicesClient client, Container container) {
 


### PR DESCRIPTION
@porcelli @etirelli @csadilek see the change ... I might be stupid and don't understand this but how it can work on one wildfly version and not the other....????