### PR TITLE
DROOLS-1128 - Concurrent call fails when creating container

### DIFF
--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/main/java/org/kie/server/remote/rest/common/util/RestUtils.java
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/main/java/org/kie/server/remote/rest/common/util/RestUtils.java
@@ -25,6 +25,7 @@ import org.kie.remote.common.rest.RestEasy960Util;
 import org.kie.server.api.ConversationId;
 import org.kie.server.api.KieServerConstants;
 import org.kie.server.api.KieServerEnvironment;
+import org.kie.server.api.model.KieContainerStatus;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.remote.rest.common.Header;
 import org.kie.server.services.api.KieServerRegistry;
@@ -150,7 +151,7 @@ public class RestUtils {
         }
 
         KieContainerInstanceImpl container = registry.getContainer(containerId);
-        if (container != null) {
+        if (container != null && KieContainerStatus.STARTED.equals(container.getStatus())) {
             ReleaseId releaseId = container.getResource().getResolvedReleaseId();
             if (releaseId == null) {
                 releaseId = container.getResource().getReleaseId();

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/test/java/org/kie/server/remote/rest/common/util/RestUtilsTest.java
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/test/java/org/kie/server/remote/rest/common/util/RestUtilsTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.remote.rest.common.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.ws.rs.core.HttpHeaders;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.server.api.KieServerConstants;
+import org.kie.server.api.KieServerEnvironment;
+import org.kie.server.api.model.KieContainerStatus;
+import org.kie.server.api.model.ReleaseId;
+import org.kie.server.remote.rest.common.Header;
+import org.kie.server.services.api.KieServerRegistry;
+import org.kie.server.services.impl.KieContainerInstanceImpl;
+import org.mockito.Mockito;
+
+public class RestUtilsTest {
+
+    private static final String CONTAINER_ID = "my-container";
+
+    private KieServerRegistry registry;
+    private HttpHeaders headers;
+
+    @Before
+    public void setup() {
+        registry = Mockito.mock(KieServerRegistry.class);
+        headers = Mockito.mock(HttpHeaders.class);
+    }
+
+    @Test
+    public void buildConversationIdHeaderWithPresentHeader() {
+        String conversationId = "my-conversation-id";
+
+        List<String> requestHeaders = new ArrayList<String>();
+        requestHeaders.add(conversationId);
+        when(headers.getRequestHeader(KieServerConstants.KIE_CONVERSATION_ID_TYPE_HEADER)).thenReturn(requestHeaders);
+
+        Header conversationIdHeader = RestUtils.buildConversationIdHeader(CONTAINER_ID, registry, headers);
+
+        assertEquals(KieServerConstants.KIE_CONVERSATION_ID_TYPE_HEADER, conversationIdHeader.getName());
+        assertEquals(conversationId, conversationIdHeader.getValue());
+    }
+
+    @Test
+    public void buildConversationIdHeaderWithoutContainer() {
+        Header conversationIdHeader = RestUtils.buildConversationIdHeader(CONTAINER_ID, registry, headers);
+        assertNull(conversationIdHeader);
+    }
+
+    @Test
+    public void buildConversationIdHeaderNullContainer() {
+        Header conversationIdHeader = RestUtils.buildConversationIdHeader(null, registry, headers);
+        assertNull(conversationIdHeader);
+    }
+
+    @Test
+    public void buildConversationIdHeaderRunningContainer() {
+        String kieServerId = "KieServerId";
+        KieServerEnvironment.setServerId(kieServerId);
+
+        String groupId = "org.kie";
+        String artifactId = "testArtifact";
+        String version = "1.0";
+        ReleaseId releaseId = new ReleaseId(groupId, artifactId, version);
+        KieContainerInstanceImpl containerInstanceImpl = new KieContainerInstanceImpl(CONTAINER_ID, KieContainerStatus.STARTED);
+        containerInstanceImpl.getResource().setReleaseId(releaseId);
+        when(registry.getContainer(CONTAINER_ID)).thenReturn(containerInstanceImpl);
+
+        Header conversationIdHeader = RestUtils.buildConversationIdHeader(CONTAINER_ID, registry, headers);
+
+        assertEquals(KieServerConstants.KIE_CONVERSATION_ID_TYPE_HEADER, conversationIdHeader.getName());
+        assertNotNull(conversationIdHeader.getValue());
+        assertTrue(conversationIdHeader.getValue().contains(groupId));
+        assertTrue(conversationIdHeader.getValue().contains(artifactId));
+        assertTrue(conversationIdHeader.getValue().contains(version));
+        assertTrue(conversationIdHeader.getValue().contains(CONTAINER_ID));
+        assertTrue(conversationIdHeader.getValue().contains(kieServerId));
+    }
+
+    @Test
+    public void buildConversationIdHeaderCreatingContainer() {
+        String kieServerId = "KieServerId";
+        KieServerEnvironment.setServerId(kieServerId);
+
+        KieContainerInstanceImpl containerInstanceImpl = new KieContainerInstanceImpl(CONTAINER_ID, KieContainerStatus.CREATING);
+        when(registry.getContainer(CONTAINER_ID)).thenReturn(containerInstanceImpl);
+
+        Header conversationIdHeader = RestUtils.buildConversationIdHeader(CONTAINER_ID, registry, headers);
+
+        assertNull(conversationIdHeader);
+    }
+}

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/KieServerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/KieServerIntegrationTest.java
@@ -15,9 +15,19 @@
 
 package org.kie.server.integrationtests.common;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.kie.api.command.BatchExecutionCommand;
+import org.kie.api.command.Command;
+import org.kie.api.runtime.ExecutionResults;
 import org.kie.server.api.KieServerEnvironment;
 import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.KieScannerResource;
@@ -31,6 +41,8 @@ import org.kie.server.integrationtests.shared.RestJmsSharedBaseIntegrationTest;
 public class KieServerIntegrationTest extends RestJmsSharedBaseIntegrationTest {
     private static ReleaseId releaseId1 = new ReleaseId("foo.bar", "baz", "2.1.0.GA");
     private static ReleaseId releaseId2 = new ReleaseId("foo.bar", "baz", "2.1.1.GA");
+
+    private static final String CONTAINER_ID = "kie1";
 
     @BeforeClass
     public static void initialize() throws Exception {
@@ -53,41 +65,41 @@ public class KieServerIntegrationTest extends RestJmsSharedBaseIntegrationTest {
 
     @Test
     public void testScanner() throws Exception {
-        client.createContainer("kie1", new KieContainerResource("kie1", releaseId1));
-        ServiceResponse<KieContainerResource> reply = client.getContainerInfo("kie1");
+        client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId1));
+        ServiceResponse<KieContainerResource> reply = client.getContainerInfo(CONTAINER_ID);
         Assert.assertEquals(ServiceResponse.ResponseType.SUCCESS, reply.getType());
         
-        ServiceResponse<KieScannerResource> si = client.getScannerInfo("kie1");
+        ServiceResponse<KieScannerResource> si = client.getScannerInfo(CONTAINER_ID);
         Assert.assertEquals( ResponseType.SUCCESS, si.getType() );
         KieScannerResource info = si.getResult();
         Assert.assertEquals( KieScannerStatus.DISPOSED, info.getStatus() );
         
-        si = client.updateScanner("kie1", new KieScannerResource(KieScannerStatus.STARTED, 10000l));
+        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.STARTED, 10000l));
         Assert.assertEquals( si.getMsg(), ResponseType.SUCCESS, si.getType() );
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.STARTED, info.getStatus() );
         
-        si = client.getScannerInfo("kie1");
+        si = client.getScannerInfo(CONTAINER_ID);
         Assert.assertEquals( si.getMsg(), ResponseType.SUCCESS, si.getType() );
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.STARTED, info.getStatus() );
         
-        si = client.updateScanner("kie1", new KieScannerResource(KieScannerStatus.STOPPED, 10000l));
+        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.STOPPED, 10000l));
         Assert.assertEquals( si.getMsg(), ResponseType.SUCCESS, si.getType() );
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.STOPPED, info.getStatus() );
         
-        si = client.getScannerInfo("kie1");
+        si = client.getScannerInfo(CONTAINER_ID);
         Assert.assertEquals( si.getMsg(), ResponseType.SUCCESS, si.getType() );
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.STOPPED, info.getStatus() );
         
-        si = client.updateScanner("kie1", new KieScannerResource(KieScannerStatus.DISPOSED, 10000l));
+        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.DISPOSED, 10000l));
         Assert.assertEquals( si.getMsg(), ResponseType.SUCCESS, si.getType() );
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.DISPOSED, info.getStatus() );
         
-        si = client.getScannerInfo("kie1");
+        si = client.getScannerInfo(CONTAINER_ID);
         Assert.assertEquals( si.getMsg(), ResponseType.SUCCESS, si.getType() );
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.DISPOSED, info.getStatus() );
@@ -95,31 +107,31 @@ public class KieServerIntegrationTest extends RestJmsSharedBaseIntegrationTest {
 
     @Test
     public void testScannerScanNow() throws Exception {
-        client.createContainer("kie1", new KieContainerResource("kie1", releaseId1));
-        ServiceResponse<KieContainerResource> reply = client.getContainerInfo("kie1");
+        client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId1));
+        ServiceResponse<KieContainerResource> reply = client.getContainerInfo(CONTAINER_ID);
         Assert.assertEquals(ServiceResponse.ResponseType.SUCCESS, reply.getType());
 
-        ServiceResponse<KieScannerResource> si = client.getScannerInfo("kie1");
+        ServiceResponse<KieScannerResource> si = client.getScannerInfo(CONTAINER_ID);
         Assert.assertEquals( ResponseType.SUCCESS, si.getType() );
         KieScannerResource info = si.getResult();
         Assert.assertEquals( KieScannerStatus.DISPOSED, info.getStatus() );
 
-        si = client.updateScanner("kie1", new KieScannerResource(KieScannerStatus.SCANNING, 0l));
+        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.SCANNING, 0l));
         Assert.assertEquals( si.getMsg(), ResponseType.SUCCESS, si.getType() );
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.STOPPED, info.getStatus() );
 
-        si = client.getScannerInfo("kie1");
+        si = client.getScannerInfo(CONTAINER_ID);
         Assert.assertEquals( si.getMsg(), ResponseType.SUCCESS, si.getType() );
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.STOPPED, info.getStatus() );
 
-        si = client.updateScanner("kie1", new KieScannerResource(KieScannerStatus.DISPOSED, 10000l));
+        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.DISPOSED, 10000l));
         Assert.assertEquals( si.getMsg(), ResponseType.SUCCESS, si.getType() );
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.DISPOSED, info.getStatus() );
 
-        si = client.getScannerInfo("kie1");
+        si = client.getScannerInfo(CONTAINER_ID);
         Assert.assertEquals( si.getMsg(), ResponseType.SUCCESS, si.getType() );
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.DISPOSED, info.getStatus() );
@@ -127,36 +139,54 @@ public class KieServerIntegrationTest extends RestJmsSharedBaseIntegrationTest {
 
     @Test
     public void testScannerStatusOnContainerInfo() throws Exception {
-        client.createContainer("kie1", new KieContainerResource("kie1", releaseId1));
-        ServiceResponse<KieContainerResource> reply = client.getContainerInfo("kie1");
+        client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId1));
+        ServiceResponse<KieContainerResource> reply = client.getContainerInfo(CONTAINER_ID);
         Assert.assertEquals(ServiceResponse.ResponseType.SUCCESS, reply.getType());
 
         KieContainerResource kci = reply.getResult();
         Assert.assertEquals( KieScannerStatus.DISPOSED, kci.getScanner().getStatus() );
 
-        ServiceResponse<KieScannerResource> si = client.updateScanner("kie1", new KieScannerResource(KieScannerStatus.STARTED, 10000l));
+        ServiceResponse<KieScannerResource> si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.STARTED, 10000l));
         Assert.assertEquals( si.getMsg(), ResponseType.SUCCESS, si.getType() );
         KieScannerResource info = si.getResult();
         Assert.assertEquals( KieScannerStatus.STARTED, info.getStatus() );
 
-        kci = client.getContainerInfo( "kie1" ).getResult();
+        kci = client.getContainerInfo( CONTAINER_ID ).getResult();
         Assert.assertEquals( KieScannerStatus.STARTED, kci.getScanner().getStatus() );
         Assert.assertEquals( 10000, kci.getScanner().getPollInterval().longValue() );
 
-        si = client.updateScanner("kie1", new KieScannerResource(KieScannerStatus.STOPPED, 10000l));
+        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.STOPPED, 10000l));
         Assert.assertEquals( si.getMsg(), ResponseType.SUCCESS, si.getType() );
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.STOPPED, info.getStatus() );
 
-        kci = client.getContainerInfo( "kie1" ).getResult();
+        kci = client.getContainerInfo( CONTAINER_ID ).getResult();
         Assert.assertEquals( KieScannerStatus.STOPPED, kci.getScanner().getStatus() );
 
-        si = client.updateScanner("kie1", new KieScannerResource(KieScannerStatus.DISPOSED, 10000l));
+        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.DISPOSED, 10000l));
         Assert.assertEquals( si.getMsg(), ResponseType.SUCCESS, si.getType() );
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.DISPOSED, info.getStatus() );
 
-        kci = client.getContainerInfo( "kie1" ).getResult();
+        kci = client.getContainerInfo( CONTAINER_ID ).getResult();
         Assert.assertEquals( KieScannerStatus.DISPOSED, kci.getScanner().getStatus() );
+    }
+
+    @Test
+    public void testConversationIdHandling() throws Exception {
+        client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId1));
+        String conversationId = client.getConversationId();
+        assertNotNull(conversationId);
+
+        client.getContainerInfo(CONTAINER_ID);
+        String afterNextCallConversationId = client.getConversationId();
+        assertEquals(conversationId, afterNextCallConversationId);
+
+        // complete conversation to start with new one
+        client.completeConversation();
+
+        client.getContainerInfo(CONTAINER_ID);
+        afterNextCallConversationId = client.getConversationId();
+        assertNotEquals(conversationId, afterNextCallConversationId);
     }
 }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/KieServerDroolsIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/KieServerDroolsIntegrationTest.java
@@ -164,9 +164,6 @@ public class KieServerDroolsIntegrationTest extends DroolsKieServerBaseIntegrati
         String conversationId = client.getConversationId();
         assertNotNull(conversationId);
 
-        String afterNextCallConversationId = client.getConversationId();
-        assertEquals(conversationId, afterNextCallConversationId);
-
         Object message = createInstance(MESSAGE_CLASS_NAME);
         setValue(message, MESSAGE_TEXT_FIELD, MESSAGE_REQUEST);
 
@@ -176,16 +173,13 @@ public class KieServerDroolsIntegrationTest extends DroolsKieServerBaseIntegrati
         commands.add(commandsFactory.newInsert(message, MESSAGE_OUT_IDENTIFIER));
         commands.add(commandsFactory.newFireAllRules());
 
-        // complete conversation to start with new one
-        client.completeConversation();
-
         ServiceResponse<ExecutionResults> reply = ruleClient.executeCommandsWithResults(CONTAINER_ID, batchExecution);
         Assert.assertEquals(ServiceResponse.ResponseType.SUCCESS, reply.getType());
         ExecutionResults results = reply.getResult();
         Object value = results.getValue(MESSAGE_OUT_IDENTIFIER);
         Assert.assertEquals(MESSAGE_RESPONSE, valueOf(value, MESSAGE_TEXT_FIELD));
 
-        afterNextCallConversationId = client.getConversationId();
-        assertNotEquals(conversationId, afterNextCallConversationId);
+        String afterNextCallConversationId = client.getConversationId();
+        assertEquals(conversationId, afterNextCallConversationId);
     }
 }


### PR DESCRIPTION
Also refactored conversation Id integration tests: moved conversation Id check to separated test method in common module.