### PR TITLE
kie-server: test improvements and stabilization

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/rest/FormServiceRestOnlyIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/rest/FormServiceRestOnlyIntegrationTest.java
@@ -176,8 +176,12 @@ public class FormServiceRestOnlyIntegrationTest extends RestOnlyBaseIntegrationT
 
             clientRequest = newRequest(build(TestConfig.getKieServerHttpUrl(), PROCESS_URI + "/" + ABORT_PROCESS_INST_DEL_URI, valuesMap)).header("Content-Type", getMediaType().toString());
             logger.info("[DELETE] " + clientRequest.getUri());
+
             response = clientRequest.delete();
-            Assert.assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
+            int noContentStatusCode = Response.Status.NO_CONTENT.getStatusCode();
+            int okStatusCode = Response.Status.OK.getStatusCode();
+            assertTrue("Wrong status code returned: " + response.getStatus(),
+                    response.getStatus() == noContentStatusCode || response.getStatus() == okStatusCode);
 
         } catch (Exception e) {
             throw new ClientResponseFailure(e, response);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/rest/ImageServiceRestOnlyIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/rest/ImageServiceRestOnlyIntegrationTest.java
@@ -156,8 +156,12 @@ public class ImageServiceRestOnlyIntegrationTest extends RestOnlyBaseIntegration
 
             clientRequest = newRequest(build(TestConfig.getKieServerHttpUrl(), PROCESS_URI + "/" + ABORT_PROCESS_INST_DEL_URI, valuesMap)).header("Content-Type", getMediaType().toString());
             logger.info("[DELETE] " + clientRequest.getUri());
+
             response = clientRequest.delete();
-            Assert.assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
+            int noContentStatusCode = Response.Status.NO_CONTENT.getStatusCode();
+            int okStatusCode = Response.Status.OK.getStatusCode();
+            assertTrue("Wrong status code returned: " + response.getStatus(),
+                    response.getStatus() == noContentStatusCode || response.getStatus() == okStatusCode);
 
         } catch (Exception e) {
             throw new ClientResponseFailure(e, response);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/JobServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/JobServiceIntegrationTest.java
@@ -21,7 +21,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -326,7 +326,7 @@ public class JobServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest 
         String businessKey = "testkey";
         String command = "org.jbpm.executor.commands.PrintOutCommand";
 
-        int currentNumberOfCancelled = jobServicesClient.getRequestsByBusinessKey(businessKey, 0, 100).size();
+        int currentNumberOfRequests = jobServicesClient.getRequestsByBusinessKey(businessKey, 0, 100).size();
 
         Map<String, Object> data = new HashMap<String, Object>();
         data.put("businessKey", businessKey);
@@ -345,14 +345,19 @@ public class JobServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest 
 
         List<RequestInfoInstance> result = jobServicesClient.getRequestsByBusinessKey(businessKey, 0, 100);
         assertNotNull(result);
-        assertEquals(1 + currentNumberOfCancelled, result.size());
+        assertEquals(1 + currentNumberOfRequests, result.size());
 
-        RequestInfoInstance jobRequest = result.get(result.size()-1);
-        assertNotNull(jobRequest);
-        assertEquals(jobId, jobRequest.getId());
-        assertEquals(businessKey, jobRequest.getBusinessKey());
-        assertEquals(STATUS.QUEUED.toString(), jobRequest.getStatus());
-        assertEquals(command, jobRequest.getCommandName());
+        List<RequestInfoInstance> queuedJobs = result.stream().
+                filter(n -> n.getStatus().equals(STATUS.QUEUED.name())).collect(Collectors.toList());
+
+        assertNotNull(queuedJobs);
+        assertEquals(1, queuedJobs.size());
+
+        RequestInfoInstance queuedJob = queuedJobs.get(0);
+        assertEquals(jobId, queuedJob.getId());
+        assertEquals(businessKey, queuedJob.getBusinessKey());
+        assertEquals(STATUS.QUEUED.toString(), queuedJob.getStatus());
+        assertEquals(command, queuedJob.getCommandName());
 
         jobServicesClient.cancelRequest(jobId);
     }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/QueryDataServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/QueryDataServiceIntegrationTest.java
@@ -63,7 +63,7 @@ public class QueryDataServiceIntegrationTest extends JbpmKieServerBaseIntegratio
     protected void additionalConfiguration(KieServicesConfiguration configuration) throws Exception {
         super.additionalConfiguration(configuration);
         // Having timeout issues due to kjar dependencies -> raised timeout.
-        configuration.setTimeout(120000);
+        configuration.setTimeout(300000);
     }
 
     @Test

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/rest/JbpmRestIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/rest/JbpmRestIntegrationTest.java
@@ -103,8 +103,13 @@ public class JbpmRestIntegrationTest extends RestOnlyBaseIntegrationTest {
             valuesMap.put(PROCESS_INST_ID, response.getEntity(JaxbLong.class).unwrap());
             clientRequest = newRequest(build(TestConfig.getKieServerHttpUrl(), PROCESS_URI + "/" + ABORT_PROCESS_INST_DEL_URI, valuesMap)).header("Content-Type", getMediaType().toString());
             logger.info( "[DELETE] " + clientRequest.getUri());
+
             response = clientRequest.delete();
-            Assert.assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
+            int noContentStatusCode = Response.Status.NO_CONTENT.getStatusCode();
+            int okStatusCode = Response.Status.OK.getStatusCode();
+            assertTrue("Wrong status code returned: " + response.getStatus(),
+                    response.getStatus() == noContentStatusCode || response.getStatus() == okStatusCode);
+
             response.releaseConnection();
         } catch (Exception e) {
             throw new ClientResponseFailure(e, response);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/OptaplannerKieServerBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/OptaplannerKieServerBaseIntegrationTest.java
@@ -49,7 +49,7 @@ public abstract class OptaplannerKieServerBaseIntegrationTest
     @Override
     protected void additionalConfiguration(KieServicesConfiguration configuration) throws Exception {
         super.additionalConfiguration(configuration);
-        configuration.setTimeout(30000);
+        configuration.setTimeout(60000);
     }
 
     protected Object valueOf(Object object, String fieldName) {


### PR DESCRIPTION
- raised timeout for QueryDataServiceIntegrationTest and OptaPlanner integration tests, current ones were low for case when is used slower repo(improvement idea - separate API to reduce to reduce dependency tree complexity and size)
- updated JobServiceIntegrationTest - to remove dependency on job order returned by Kie server
- updated ProcessServiceIntegrationTest - to remove dependency on job order returned by Kie server, also some DBs round timestamp so test became unreliable for them

- response code changes in REST tests - some containers like WebLogic 12.1.3 use jersey 1.x. In such case response code for DELETE requests from Kie server is 200 instead of 204. It seems to be caused by setting of response entity for these requests, see http://stackoverflow.com/questions/31655486/jersey-nocontent-response-returns-200-instead-of-204 .
Is this something what should be fixed? Or it can be acceptable behavior.