### PR TITLE
BZ-1326805 - Serialization problems on websphere as a result of BZ-1299549

### DIFF
--- a/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/jaxb/DynamicJaxbContext.java
+++ b/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/jaxb/DynamicJaxbContext.java
@@ -125,6 +125,10 @@ public class DynamicJaxbContext extends JAXBContext {
 
     // JAXBContext methods --------------------------------------------------------------------------------------------------------
 
+    JAXBContext getRequestContext() {
+        return requestJaxbContext.get();
+    }
+
     /*
      * (non-Javadoc)
      * @see javax.xml.bind.JAXBContext#createUnmarshaller()
@@ -167,8 +171,6 @@ public class DynamicJaxbContext extends JAXBContext {
 
     // Deployment jaxbContext management and creation logic -----------------------------------------------------------------------
 
-
-
     @Override
     public boolean equals( Object obj ) {
         if( obj instanceof DynamicJaxbContext ) {
@@ -176,6 +178,5 @@ public class DynamicJaxbContext extends JAXBContext {
         }
         return false;
     }
-
 
 }

--- a/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/jaxb/DynamicJaxbContextManager.java
+++ b/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/jaxb/DynamicJaxbContextManager.java
@@ -39,6 +39,25 @@ public class DynamicJaxbContextManager {
 
     private static final Logger logger = LoggerFactory.getLogger(DynamicJaxbContextManager.class);
 
+
+    private final static boolean onWebsphere;
+    private final static String WEBSPHERE_JAXB_CACHING_CLASS_NAME
+        = "org.apache.wink.common.internal.providers.entity.xml.AbstractJAXBProvider";
+
+    static {
+        // websphere stuff
+        boolean classFound = false;
+        try {
+            Class.forName(WEBSPHERE_JAXB_CACHING_CLASS_NAME);
+            classFound = true;
+        } catch (ClassNotFoundException e) {
+            // no-op
+        }
+        onWebsphere = classFound;
+    }
+
+    // LOGGING IF MULTIPLE INSTANCES ARE CREATED ----------------------------------------------------------------------------------
+
     private static AtomicInteger instanceCreated = new AtomicInteger(0);
 
     public DynamicJaxbContextManager() {
@@ -204,6 +223,10 @@ public class DynamicJaxbContextManager {
     }
 
     public JAXBContext getJaxbContext() {
-        return _jaxbContextInstance;
+        if (onWebsphere ) {
+            return _jaxbContextInstance.getRequestContext();
+        } else {
+            return _jaxbContextInstance;
+        }
     }
 }


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1326805

For the reviewer: both this pr and https://github.com/droolsjbpm/kie-wb-distributions/pull/268 are necessary for this. 

The `org.apache.wink.jaxbcontextcache` property (set to `off`) makes sure that JAXB contexts are not cached (otherwise, changes in the deployment would not be "caught" and user-defined serialized class instances _incorrectly_ de/serialized). 

This change makes sure that the (apache wink/websphere) JAX-RS implementation framework gets a real `JAXBContext` instance: it looks like the openwebbeans CDI implementation that websphere uses simply interferes too much for us to use the `DynamicJaxbContext` as the `JAXBContext` instance. 

Lastly, given that the `DynamicJaxbContext` is already caching `JAXBContext` instances, there should be no significant performance penalty by turning off the apache wink `JAXBContext` caching. 