### PR TITLE
BZ-1326806 - Serialization problems on websphere as a result of BZ-1310739

### DIFF
--- a/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/jaxb/DynamicJaxbContext.java
+++ b/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/jaxb/DynamicJaxbContext.java
@@ -93,7 +93,7 @@ public class DynamicJaxbContext extends JAXBContext {
      * create a {@link Marshaller}, {@link Unmarshaller} or {@link Validator} instance.
      * @return The {@link JAXBContext} created or retrieved from cache for the request.
      */
-    private JAXBContext getRequestContext() {
+    JAXBContext getRequestContext() {
         JAXBContext requestJaxbContext = requestJaxbContextLocal.get();
         if( requestJaxbContext == null ) {
             logger.error("No JAXB context could be found for request, using default!");
@@ -156,15 +156,6 @@ public class DynamicJaxbContext extends JAXBContext {
         } catch (JAXBException e) {
             throw new IllegalStateException( "Unable to create new " + JAXBContext.class.getSimpleName() + " instance.", e);
         }
-    }
-
-    public JAXBContext getDeploymentJaxbContext(String deploymentId) {
-        JAXBContext jaxbContext = contextsCache.get(deploymentId);
-        if( jaxbContext == null ) {
-            logger.debug("No JAXBContext available for deployment '" + deploymentId + "', using default JAXBContext instance.");
-            jaxbContext = contextsCache.get(DEFAULT_JAXB_CONTEXT_ID);
-        }
-        return jaxbContext;
     }
 
     @Override


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1326806

For the reviewer: both this pr and https://github.com/droolsjbpm/kie-wb-distributions/pull/268 are necessary for this. 

The `org.apache.wink.jaxbcontextcache` property (set to `off`) makes sure that JAXB contexts are not cached (otherwise, changes in the deployment would not be "caught" and user-defined serialized class instances _incorrectly_ de/serialized). 

This change makes sure that the (apache wink/websphere) JAX-RS implementation framework gets a real `JAXBContext` instance: it looks like the openwebbeans CDI implementation that websphere uses simply interferes too much for us to use the `DynamicJaxbContext` as the `JAXBContext` instance. 

Lastly, given that the `DynamicJaxbContext` is already caching `JAXBContext` instances, there should be no significant performance penalty by turning off the apache wink `JAXBContext` caching. 