### PR TITLE
kie-server-tests: run modules one at a time, even for parallel builds

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/pom.xml
@@ -184,6 +184,20 @@
       <type>war</type>
       <scope>test</scope>
     </dependency>
+
+    <!-- This is an artificial dependency to make sure the kie-server-tests modules are executed one at a time during
+         parallel build (otherwise the tests fail because of conflicting port binding) -->
+    <dependency>
+      <groupId>org.kie.server</groupId>
+      <artifactId>kie-server-integ-tests-optaplanner</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <build>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/pom.xml
@@ -125,6 +125,20 @@
       <type>war</type>
       <scope>test</scope>
     </dependency>
+
+    <!-- This is an artificial dependency to make sure the kie-server-tests modules are executed one at a time during
+         parallel build (otherwise the tests fail because of conflicting port binding) -->
+    <dependency>
+      <groupId>org.kie.server</groupId>
+      <artifactId>kie-server-integ-tests-all</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <build>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/pom.xml
@@ -159,6 +159,20 @@
       <type>war</type>
       <scope>test</scope>
     </dependency>
+
+    <!-- This is an artificial dependency to make sure the kie-server-tests modules are executed one at a time during
+         parallel build (otherwise the tests fail because of conflicting port binding) -->
+    <dependency>
+      <groupId>org.kie.server</groupId>
+      <artifactId>kie-server-integ-tests-common</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <build>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
@@ -170,6 +170,20 @@
       <artifactId>dashbuilder-dataset-api</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <!-- This is an artificial dependency to make sure the kie-server-tests modules are executed one at a time during
+         parallel build (otherwise the tests fail because of conflicting port binding) -->
+    <dependency>
+      <groupId>org.kie.server</groupId>
+      <artifactId>kie-server-integ-tests-drools</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <build>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/pom.xml
@@ -147,6 +147,20 @@
       <type>war</type>
       <scope>test</scope>
     </dependency>
+
+    <!-- This is an artificial dependency to make sure the kie-server-tests modules are executed one at a time during
+         parallel build (otherwise the tests fail because of conflicting port binding) -->
+    <dependency>
+      <groupId>org.kie.server</groupId>
+      <artifactId>kie-server-integ-tests-jbpm</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <build>

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -54,6 +54,41 @@
     <module>kie-server-integ-tests-controller</module>
   </modules>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.kie.server</groupId>
+        <artifactId>kie-server-integ-tests-common</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.server</groupId>
+        <artifactId>kie-server-integ-tests-drools</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.server</groupId>
+        <artifactId>kie-server-integ-tests-jbpm</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.server</groupId>
+        <artifactId>kie-server-integ-tests-optaplanner</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.server</groupId>
+        <artifactId>kie-server-integ-tests-controller</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.server</groupId>
+        <artifactId>kie-server-integ-tests-all</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <build>
     <pluginManagement>
       <plugins>


### PR DESCRIPTION
@sutaakar, @mswiderski please take a look. This is basically hack/workaround to make sure the test modules are not executed in parallel. Ultimately we could fix this by configuring cargo to use random available ports instead of the defaults. But that will take some time to get properly done. This is I think a good workaround for now.