### PR TITLE
[DROOLS-1129] consistent OSGi Bundle-SymbolicName for all jars

### DIFF
--- a/drools-osgi/drools-osgi-integration/pom.xml
+++ b/drools-osgi/drools-osgi-integration/pom.xml
@@ -14,6 +14,10 @@
 
   <name>Drools :: OSGi Integration</name>
 
+  <properties>
+    <osgi.Bundle-SymbolicName>org.drools.osgi.integration</osgi.Bundle-SymbolicName>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.drools</groupId>
@@ -98,7 +102,6 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <configuration>
           <instructions>
-            <Bundle-SymbolicName>org.drools.osgi.integration</Bundle-SymbolicName>
             <Fragment-Host>org.drools.compiler;bundle-version="[7,8)"</Fragment-Host>
             <Export-Package>org.drools.osgi.*</Export-Package>
             <Import-Package>

--- a/kie-aries-blueprint/pom.xml
+++ b/kie-aries-blueprint/pom.xml
@@ -17,6 +17,10 @@
   <description>Drools and jBPM integration for Aries Blueprint</description>
   <packaging>bundle</packaging>
 
+  <properties>
+    <osgi.Bundle-SymbolicName>org.kie.aries.blueprint</osgi.Bundle-SymbolicName>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -160,7 +164,6 @@
         <configuration>
           <instructions>
             <_removeheaders>Ignore-Package</_removeheaders>
-            <Bundle-SymbolicName>org.kie.aries.blueprint</Bundle-SymbolicName>
             <Bundle-Name>Kie Aries Blueprint</Bundle-Name>
             <Import-Package>
               !org.kie.aries.blueprint*,

--- a/kie-remote/kie-remote-client/pom.xml
+++ b/kie-remote/kie-remote-client/pom.xml
@@ -13,6 +13,7 @@
   <packaging>bundle</packaging><!-- bundle = jar + OSGi metadata -->
 
   <properties>
+    <osgi.Bundle-SymbolicName>org.kie.remote.client</osgi.Bundle-SymbolicName>
     <maven.jdbc.url>jdbc:h2:file:test;MVCC=true</maven.jdbc.url>
   </properties>
   
@@ -257,7 +258,6 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <configuration>
           <instructions>
-            <Bundle-SymbolicName>org.kie.remote.client</Bundle-SymbolicName>
             <Export-Package>
               org.kie.remote.client.api.*,
               org.kie.remote.client.jaxb.*,

--- a/kie-remote/kie-remote-common/pom.xml
+++ b/kie-remote/kie-remote-common/pom.xml
@@ -12,6 +12,10 @@
   <name>KIE Remote Services :: Common</name>
   <packaging>bundle</packaging>
 
+  <properties>
+    <osgi.Bundle-SymbolicName>org.kie.remote.common</osgi.Bundle-SymbolicName>
+  </properties>
+
   <dependencies>
     <!-- REST -->
     <dependency>
@@ -51,7 +55,6 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <configuration>
           <instructions>
-            <Bundle-SymbolicName>org.kie.remote.common</Bundle-SymbolicName>
             <Export-Package>
               org.kie.remote.common.rest.*
             </Export-Package>

--- a/kie-server-parent/kie-server-api/pom.xml
+++ b/kie-server-parent/kie-server-api/pom.xml
@@ -13,6 +13,10 @@
   <name>KIE :: Execution Server :: API</name>
   <description>KIE Execution Server API</description>
 
+  <properties>
+    <osgi.Bundle-SymbolicName>org.kie.server.api</osgi.Bundle-SymbolicName>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -115,7 +119,6 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <configuration>
           <instructions>
-            <Bundle-SymbolicName>org.kie.server.api</Bundle-SymbolicName>
             <Export-Package>
               org.kie.server.api.*
             </Export-Package>

--- a/kie-server-parent/kie-server-remote/kie-server-client/pom.xml
+++ b/kie-server-parent/kie-server-remote/kie-server-client/pom.xml
@@ -13,6 +13,10 @@
   <name>KIE :: Execution Server :: Remote :: Client</name>
   <description>KIE Execution Server Client</description>
 
+  <properties>
+    <osgi.Bundle-SymbolicName>org.kie.server.client</osgi.Bundle-SymbolicName>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.kie</groupId>
@@ -103,7 +107,6 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <configuration>
           <instructions>
-            <Bundle-SymbolicName>org.kie.server.client</Bundle-SymbolicName>
             <Export-Package>
               org.kie.server.client.*
             </Export-Package>

--- a/kie-spring/pom.xml
+++ b/kie-spring/pom.xml
@@ -17,6 +17,10 @@
   <name>Kie :: Spring</name>
   <description>Drools and jBPM integration for Spring.</description>
 
+  <properties>
+    <osgi.Bundle-SymbolicName>org.kie.spring</osgi.Bundle-SymbolicName>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.jbpm</groupId>
@@ -240,7 +244,6 @@
         <configuration>
           <instructions>
             <_removeheaders>Ignore-Package</_removeheaders>
-            <Bundle-SymbolicName>org.kie.spring</Bundle-SymbolicName>
             <Bundle-Name>Kie Spring</Bundle-Name>
             <Import-Package>
               !org.kie.spring*,


### PR DESCRIPTION
Depends on:
https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/pull/183