### PR TITLE
JBPM-5083 - JMS Kie server startup test

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/pom.xml
@@ -115,7 +115,13 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
-    
+
+    <!-- Cargo dependencies -->
+    <dependency>
+     <groupId>org.codehaus.cargo</groupId>
+     <artifactId>cargo-core-uberjar</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.kie.server</groupId>
       <artifactId>kie-server</artifactId>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/category/RemotelyControlled.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/category/RemotelyControlled.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.integrationtests.category;
+
+public interface RemotelyControlled {
+}

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/config/TestConfig.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/config/TestConfig.java
@@ -49,6 +49,7 @@ public class TestConfig {
      */
     private static Integer CONTROLLER_ALLOCATED_PORT;
     private static final StringTestParameter PROVIDED_HTTP_URL = new StringTestParameter("kie.server.base.http.url");
+    private static final StringTestParameter PROVIDED_CONTEXT = new StringTestParameter("kie.server.context");
     private static final StringTestParameter PROVIDED_CONTROLLER_HTTP_URL = new StringTestParameter("kie.server.controller.base.http.url");
 
     private static final StringTestParameter USERNAME = new StringTestParameter("username", "yoda");
@@ -61,6 +62,12 @@ public class TestConfig {
     private static final StringTestParameter RESPONSE_QUEUE_JNDI = new StringTestParameter("kie.server.jndi.response.queue", "jms/queue/KIE.SERVER.RESPONSE");
 
     private static final StringTestParameter KJARS_BUILD_SETTINGS_XML = new StringTestParameter("kie.server.testing.kjars.build.settings.xml");
+
+    private static final StringTestParameter CONTAINER_ID = new StringTestParameter("cargo.container.id");
+    private static final StringTestParameter CONTAINER_PORT = new StringTestParameter("cargo.servlet.port");
+    private static final StringTestParameter KIE_SERVER_WAR_PATH = new StringTestParameter("kie.server.war.path");
+
+    private static final StringTestParameter WEBLOGIC_HOME = new StringTestParameter("weblogic.home");
 
     /**
      * Get kie-server URL for HTTP services - like REST.
@@ -277,6 +284,48 @@ public class TestConfig {
      */
     public static String getKjarsBuildSettingsXml() {
         return TestConfig.KJARS_BUILD_SETTINGS_XML.getParameterValue();
+    }
+
+    /**
+     * @return Cargo container ID.
+     */
+    public static String getContainerId() {
+        return TestConfig.CONTAINER_ID.getParameterValue();
+    }
+
+    /**
+     * @return Kie server context value.
+     */
+    public static String getKieServerContext() {
+        return TestConfig.PROVIDED_CONTEXT.getParameterValue();
+    }
+
+    /**
+     * @return Path to Kie server WAR file.
+     */
+    public static String getKieServerWarPath() {
+        return TestConfig.KIE_SERVER_WAR_PATH.getParameterValue();
+    }
+
+    /**
+     * @return Servlet port to container.
+     */
+    public static String getContainerPort() {
+        return TestConfig.CONTAINER_PORT.getParameterValue();
+    }
+
+    /**
+     * @return Servlet port to container.
+     */
+    public static String getWebLogicHome() {
+        return TestConfig.WEBLOGIC_HOME.getParameterValue();
+    }
+
+    /**
+     * @return Servlet port to container.
+     */
+    public static boolean isWebLogicHomeProvided() {
+        return TestConfig.WEBLOGIC_HOME.isParameterConfigured();
     }
 
     // Used for printing all configuration values at the beginning of first test run.

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/control/ContainerRemoteController.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/control/ContainerRemoteController.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.integrationtests.control;
+
+import org.codehaus.cargo.container.Container;
+import org.codehaus.cargo.container.ContainerType;
+import org.codehaus.cargo.container.RemoteContainer;
+import org.codehaus.cargo.container.configuration.Configuration;
+import org.codehaus.cargo.container.configuration.ConfigurationType;
+import org.codehaus.cargo.container.deployable.DeployableType;
+import org.codehaus.cargo.container.deployable.WAR;
+import org.codehaus.cargo.container.deployer.Deployer;
+import org.codehaus.cargo.container.property.ServletPropertySet;
+import org.codehaus.cargo.container.weblogic.WebLogicPropertySet;
+import org.codehaus.cargo.generic.DefaultContainerFactory;
+import org.codehaus.cargo.generic.configuration.DefaultConfigurationFactory;
+import org.codehaus.cargo.generic.deployable.DefaultDeployableFactory;
+import org.codehaus.cargo.generic.deployer.DefaultDeployerFactory;
+import org.kie.server.integrationtests.config.TestConfig;
+
+public class ContainerRemoteController {
+
+    private Configuration configuration;
+    private Container container;
+    private Deployer deployer;
+
+    public ContainerRemoteController(String cargoContainerId, String containerPort) {
+        configuration = new DefaultConfigurationFactory().createConfiguration(
+                cargoContainerId, ContainerType.REMOTE, ConfigurationType.RUNTIME);
+        container = (RemoteContainer) new DefaultContainerFactory().createContainer(
+                cargoContainerId, ContainerType.REMOTE, configuration);
+        deployer = new DefaultDeployerFactory().createDeployer(container);
+
+        configuration.setProperty(ServletPropertySet.PORT, containerPort);
+        // WLS remote configuration
+        if (TestConfig.isWebLogicHomeProvided()) {
+            String wlserverHome = TestConfig.getWebLogicHome().matches(".*/wlserver") ?
+                    TestConfig.getWebLogicHome() : TestConfig.getWebLogicHome() + "/wlserver";
+            configuration.setProperty(WebLogicPropertySet.LOCAL_WEBLOGIC_HOME, wlserverHome);
+        }
+    }
+
+    public void undeployWarFile(String context, String warFilePath) {
+        WAR deployable = (WAR) new DefaultDeployableFactory().createDeployable(container.getId(), warFilePath, DeployableType.WAR);
+        deployable.setContext(context);
+        deployer.undeploy(deployable);
+    }
+
+    public void deployWarFile(String context, String warFilePath) {
+        WAR deployable = (WAR) new DefaultDeployableFactory().createDeployable(container.getId(), warFilePath, DeployableType.WAR);
+        deployable.setContext(context);
+        deployer.deploy(deployable);
+    }
+}

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
@@ -201,6 +201,11 @@
           <configuration>
             <systemPropertyVariables>
               <!-- Values are supplied by specific profiles -->
+              <cargo.container.id>${cargo.container.id}</cargo.container.id>
+              <cargo.servlet.port>${container.port}</cargo.servlet.port>
+              <kie.server.context>${kie.server.context}</kie.server.context>
+              <kie.server.war.path>${org.kie.server:kie-server:war:ee7}</kie.server.war.path>
+              <weblogic.home>${weblogic.home}</weblogic.home>
               <kie.server.remoting.url>${kie.server.remoting.url}</kie.server.remoting.url>
               <kie.server.base.http.url>${kie.server.base.http.url}</kie.server.base.http.url>
               <kie.server.context.factory>${kie.server.context.factory}</kie.server.context.factory>
@@ -251,6 +256,19 @@
             </systemProperties>
           </container>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>set-properties-for-dependencies</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>properties</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/jms/JmsQueueIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/jms/JmsQueueIntegrationTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.integrationtests.jbpm.jms;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runners.Parameterized;
+import org.kie.server.api.marshalling.MarshallingFormat;
+import org.kie.server.api.model.KieContainerResource;
+import org.kie.server.api.model.ReleaseId;
+import org.kie.server.api.model.instance.ProcessInstance;
+import org.kie.server.client.KieServicesClient;
+import org.kie.server.client.KieServicesConfiguration;
+import org.kie.server.client.KieServicesFactory;
+import org.kie.server.client.ProcessServicesClient;
+import org.kie.server.integrationtests.category.JMSOnly;
+import org.kie.server.integrationtests.category.RemotelyControlled;
+import org.kie.server.integrationtests.config.TestConfig;
+import org.kie.server.integrationtests.control.ContainerRemoteController;
+import org.kie.server.integrationtests.jbpm.JbpmKieServerBaseIntegrationTest;
+
+@Category({JMSOnly.class, RemotelyControlled.class})
+public class JmsQueueIntegrationTest extends JbpmKieServerBaseIntegrationTest {
+
+    private static final ReleaseId RELEASE_ID = new ReleaseId("org.kie.server.testing", "definition-project", "1.0.0.Final");
+    private static final String CONTAINER_ID = "definition-project";
+
+    private static ContainerRemoteController containerRemoteController;
+
+    @Parameterized.Parameters(name = "{index}: {0} {1}")
+    public static Collection<Object[]> data() {
+        KieServicesConfiguration jmsConfiguration = createKieServicesJmsConfiguration();
+
+        Collection<Object[]> parameterData = new ArrayList<Object[]>(Arrays.asList(new Object[][]
+                        {
+                                {MarshallingFormat.JAXB, jmsConfiguration}
+                        }
+        ));
+
+        return parameterData;
+    }
+
+    @BeforeClass
+    public static void buildAndDeployArtifacts() {
+        buildAndDeployCommonMavenParent();
+        buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project").getFile());
+
+        containerRemoteController = new ContainerRemoteController(TestConfig.getContainerId(), TestConfig.getContainerPort());
+    }
+
+    @Test
+    public void testStartProcessFromJmsAfterApplicationStart() throws Exception {
+        assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, RELEASE_ID)));
+
+        // Custom client with reduced timeout
+        KieServicesConfiguration customConfig = configuration.clone();
+        customConfig.setTimeout(3000);
+        KieServicesClient customClient = KieServicesFactory.newKieServicesClient(customConfig);
+        ProcessServicesClient customProcessClient = customClient.getServicesClient(ProcessServicesClient.class);
+
+        containerRemoteController.undeployWarFile(TestConfig.getKieServerContext(), TestConfig.getKieServerWarPath());
+
+        try {
+            customProcessClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK);
+            fail("Should throw exception about Kie server being unavailable.");
+        } catch (Exception e) {
+            // TODO uncomment to test JBPM-5098
+//            assertTrue(e instanceof KieServicesException);
+//            assertEquals("Response is empty", ((KieServicesException) e).getMessage());
+        } finally {
+            containerRemoteController.deployWarFile(TestConfig.getKieServerContext(), TestConfig.getKieServerWarPath());
+        }
+
+        // Process should be deployed.
+        List<ProcessInstance> processInstances = queryClient.findProcessInstances(0, 100);
+        assertEquals(1, processInstances.size());
+
+        ProcessInstance pi = processInstances.get(0);
+        assertEquals(org.kie.api.runtime.process.ProcessInstance.STATE_ACTIVE, pi.getState().intValue());
+
+        processClient.abortProcessInstance(CONTAINER_ID, pi.getId());
+    }
+}

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -24,6 +24,7 @@
          is not able to override the value of the property. The port number would then always be the same
          (the default one, unless changed from outside) -->
     <kie.server.context>kie-server-services</kie.server.context>
+    <cargo.container.id>valid-id-needs-to-be-specified-in-appropriate-container-profile</cargo.container.id>
     <kie.server.controller.context>kie-server-controller-services</kie.server.controller.context>
     <kie.server.classifier>ee7</kie.server.classifier>
     <kie.server.base.http.url>http://${container.hostname}:${container.port}/${kie.server.context}/services/rest/server</kie.server.base.http.url>
@@ -86,6 +87,11 @@
         <artifactId>kie-server-integ-tests-all</artifactId>
         <version>${version.org.kie}</version>
       </dependency>
+      <dependency>
+        <groupId>org.codehaus.cargo</groupId>
+        <artifactId>cargo-core-uberjar</artifactId>
+        <version>1.4.19</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -97,6 +103,7 @@
           <artifactId>cargo-maven2-plugin</artifactId>
           <configuration>
             <container>
+              <containerId>${cargo.container.id}</containerId>
               <systemProperties>
                 <kie.maven.settings.custom>${project.build.testOutputDirectory}/kie-server-testing-server-custom-settings.xml</kie.maven.settings.custom>
                 <!-- Fixes issue when Tomcat hangs during deployment due to insufficient amount of entropy.
@@ -205,6 +212,7 @@
       <properties>
         <org.kie.server.persistence.ds>java:comp/env/jdbc/jbpm</org.kie.server.persistence.ds>
         <kie.server.classifier>webc</kie.server.classifier>
+        <cargo.container.id>tomcat8x</cargo.container.id>
       </properties>
       <build>
         <pluginManagement>
@@ -214,7 +222,6 @@
               <artifactId>cargo-maven2-plugin</artifactId>
               <configuration>
                 <container>
-                  <containerId>tomcat8x</containerId>
                   <type>installed</type>
                   <artifactInstaller>
                     <groupId>org.apache.tomcat</groupId>
@@ -271,7 +278,7 @@
             <plugin>
               <artifactId>maven-failsafe-plugin</artifactId>
               <configuration>
-                <excludedGroups>org.kie.server.integrationtests.category.JMSOnly,org.kie.server.integrationtests.category.Email</excludedGroups>
+                <excludedGroups>org.kie.server.integrationtests.category.JMSOnly,org.kie.server.integrationtests.category.Email,org.kie.server.integrationtests.category.RemotelyControlled</excludedGroups>
               </configuration>
             </plugin>
           </plugins>
@@ -315,6 +322,7 @@
       <properties>
         <kie.server.remoting.url>http-remoting://${container.hostname}:${container.port}</kie.server.remoting.url>
         <org.kie.server.persistence.ds>java:jboss/datasources/ExampleDS</org.kie.server.persistence.ds>
+        <cargo.container.id>wildfly10x</cargo.container.id>
       </properties>
       <build>
         <pluginManagement>
@@ -324,7 +332,6 @@
               <artifactId>cargo-maven2-plugin</artifactId>
               <configuration>
                 <container>
-                  <containerId>wildfly10x</containerId>
                   <type>installed</type>
                   <artifactInstaller>
                     <groupId>org.wildfly</groupId>
@@ -445,6 +452,11 @@
             <artifactId>jaxb-impl</artifactId>
             <version>${version.com.sun.xml.bind}</version>
           </dependency>
+          <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-controller-client</artifactId>
+            <version>8.2.1.Final</version>
+          </dependency>
         </dependencies>
       </dependencyManagement>
       <dependencies>
@@ -454,6 +466,11 @@
           <type>pom</type>
           <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>org.wildfly</groupId>
+          <artifactId>wildfly-controller-client</artifactId>
+          <scope>test</scope>
+        </dependency>
       </dependencies>
     </profile>
     <profile>
@@ -461,6 +478,8 @@
       <properties>
         <kie.server.remoting.url>http-remoting://${container.hostname}:${container.port}</kie.server.remoting.url>
         <org.kie.server.persistence.ds>java:jboss/datasources/ExampleDS</org.kie.server.persistence.ds>
+        <!-- eap7 is basically wildfly10; until there is a EAP 7 specific containerId, 'wildfly10x' should work just fine -->
+        <cargo.container.id>wildfly10x</cargo.container.id>
       </properties>
       <build>
         <pluginManagement>
@@ -470,8 +489,6 @@
               <artifactId>cargo-maven2-plugin</artifactId>
               <configuration>
                 <container>
-                  <!-- eap7 is basically wildfly10; until there is a EAP 7 specific containerId, 'wildfly10x' should work just fine -->
-                  <containerId>wildfly10x</containerId>
                   <type>installed</type>
                   <zipUrlInstaller>
                     <url>${eap7.download.url}</url>
@@ -612,6 +629,7 @@
         <kie.server.context>kie-server-${project.version}-${kie.server.classifier}</kie.server.context>
         <kie.server.controller.context>kie-server-controller-${project.version}-${kie.server.classifier}</kie.server.controller.context>
         <org.kie.server.persistence.ds>jdbc/jbpm</org.kie.server.persistence.ds>
+        <cargo.container.id>weblogic122x</cargo.container.id>
       </properties>
       <build>
         <pluginManagement>
@@ -621,7 +639,6 @@
               <artifactId>cargo-maven2-plugin</artifactId>
               <configuration>
                 <container>
-                  <containerId>weblogic122x</containerId>
                   <type>installed</type>
                   <home>${weblogic.home}/wlserver</home>
                   <systemProperties>
@@ -731,6 +748,7 @@
         <kie.server.connection.factory>jms/cf/KIE.SERVER.REQUEST</kie.server.connection.factory>
         <org.kie.server.persistence.ds>jdbc/jbpm</org.kie.server.persistence.ds>
         <kie.server.classifier>ee6</kie.server.classifier>
+        <cargo.container.id>websphere85x</cargo.container.id>
       </properties>
       <build>
         <pluginManagement>
@@ -740,7 +758,6 @@
               <artifactId>cargo-maven2-plugin</artifactId>
               <configuration>
                 <container>
-                  <containerId>websphere85x</containerId>
                   <type>installed</type>
                   <home>${websphere.home}</home>
                   <timeout>240000</timeout>
@@ -830,7 +847,7 @@
                   <additionalClasspathElement>${websphere.home}/runtimes/com.ibm.ws.sib.client.thin.jms_8.5.0.jar</additionalClasspathElement>
                   <additionalClasspathElement>${websphere.home}/runtimes/com.ibm.ws.orb_8.5.0.jar</additionalClasspathElement>
                 </additionalClasspathElements>
-                <excludedGroups>org.kie.server.integrationtests.category.Email</excludedGroups>
+                <excludedGroups>org.kie.server.integrationtests.category.Email,org.kie.server.integrationtests.category.RemotelyControlled</excludedGroups>
               </configuration>
             </plugin>
           </plugins>


### PR DESCRIPTION
@mswiderski Reproducer for JBPM-5083 and JBPM-5098

Maybe cargo-core-uberjar artifact should be moved elsewhere, to have its version managed and synchronized with Cargo maven plugin. Will check what and how.

Test works for Wildfly10 and WebLogic 12.2.
Cargo WebSphere implementation is still missing remote deployer - skipping test for WebSphere temporary.