### PR TITLE
Jetty + CXF related fixes after upgrade to IP BOM 7.0.0.CR3

### DIFF
--- a/kie-remote/kie-remote-client/pom.xml
+++ b/kie-remote/kie-remote-client/pom.xml
@@ -16,7 +16,7 @@
     <osgi.Bundle-SymbolicName>org.kie.remote.client</osgi.Bundle-SymbolicName>
     <maven.jdbc.url>jdbc:h2:file:test;MVCC=true</maven.jdbc.url>
   </properties>
-  
+
   <dependencies>
     <dependency>
       <groupId>org.codehaus.jackson</groupId>
@@ -77,7 +77,7 @@
     <!--  webservices: cxf -->
    <dependency>
       <groupId>org.apache.cxf</groupId>
-      <artifactId>cxf-api</artifactId>
+      <artifactId>cxf-core</artifactId>
    </dependency> 
    <dependency>
       <groupId>org.apache.cxf</groupId>

--- a/kie-remote/kie-remote-common/pom.xml
+++ b/kie-remote/kie-remote-common/pom.xml
@@ -43,7 +43,13 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-servlets</artifactId>
+      <artifactId>jetty-proxy</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
     

--- a/kie-remote/kie-remote-common/src/test/java/org/kie/remote/common/rest/KieRemoteHttpRequestTest.java
+++ b/kie-remote/kie-remote-common/src/test/java/org/kie/remote/common/rest/KieRemoteHttpRequestTest.java
@@ -596,11 +596,7 @@ public class KieRemoteHttpRequestTest extends ServerTestCase {
             public void handle( Request request, HttpServletResponse response ) {
                 String auth = request.getHeader("Authorization");
                 auth = auth.substring(auth.indexOf(' ') + 1);
-                try {
-                    auth = B64Code.decode(auth, CHARSET_UTF8);
-                } catch( UnsupportedEncodingException e ) {
-                    throw new RuntimeException(e);
-                }
+                auth = B64Code.decode(auth, CHARSET_UTF8);
                 int colon = auth.indexOf(':');
                 user.set(auth.substring(0, colon));
                 password.set(auth.substring(colon + 1));
@@ -859,7 +855,7 @@ public class KieRemoteHttpRequestTest extends ServerTestCase {
             }
         };
         Map<String, List<String>> headers = newRequest(url).get().response().headers();
-        assertEquals(headers.size(), 5);
+        assertEquals(headers.size(), 6);
         assertEquals(headers.get("a").size(), 2);
         assertTrue(headers.get("b").get(0).equals("b"));
     }
@@ -885,7 +881,7 @@ public class KieRemoteHttpRequestTest extends ServerTestCase {
         KieRemoteHttpRequest request = newRequest(url).header("h1", 5).header("h2", (Number) null);
         assertEquals(HTTP_OK, request.get().response().code());
         assertEquals("5", h1.get());
-        assertEquals("", h2.get());
+        assertEquals(null, h2.get());
     }
 
     /**

--- a/kie-remote/kie-remote-common/src/test/resources/logback-test.xml
+++ b/kie-remote/kie-remote-common/src/test/resources/logback-test.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <!-- %l lowers performance -->
+      <!--<pattern>%d [%t] %-5p %l%n  %m%n</pattern>-->
+      <pattern>%d [%t] %-5p %m%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.kie" level="info"/>
+  <logger name="org.drools" level="info"/>
+  <logger name="org.jbpm" level="info"/>
+
+  <root level="warn">
+    <appender-ref ref="consoleAppender" />
+  </root>
+
+</configuration>


### PR DESCRIPTION
 * Jetty was upgraded from 8.x to 9.x and those two
   versions are not 100% compatible.

Depends on https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/pull/201

@mrietveld could ouy please take a look?