### PR TITLE
Revert "[BZ-1322171] drools-osgi: upgrade XStream bundle from 1.4.7_1…

### DIFF
--- a/drools-osgi/drools-karaf-features/pom.xml
+++ b/drools-osgi/drools-karaf-features/pom.xml
@@ -61,7 +61,7 @@
     <!-- Overwrites with a servicemix version -->
     <karaf.servicemix.version.com.google.protobuf>2.4.1_1</karaf.servicemix.version.com.google.protobuf>
     <karaf.servicemix.version.com.sun.xml.bind.jaxb>2.2.11_1</karaf.servicemix.version.com.sun.xml.bind.jaxb>
-    <karaf.servicemix.version.com.thoughtworks.xstream>1.4.9_1</karaf.servicemix.version.com.thoughtworks.xstream>
+    <karaf.servicemix.version.com.thoughtworks.xstream>1.4.7_1</karaf.servicemix.version.com.thoughtworks.xstream>
     <karaf.servicemix.version.com.thoughtworks.xmlpull>1.1.4c_7</karaf.servicemix.version.com.thoughtworks.xmlpull>
     <karaf.servicemix.version.javax.xml.bind.jaxb>2.2.0</karaf.servicemix.version.javax.xml.bind.jaxb>
     <karaf.servicemix.version.org.antlr>3.5_1</karaf.servicemix.version.org.antlr>


### PR DESCRIPTION
… to 1.4.9_1 (#471)"

This reverts commit 9a2f00b632942dfe673fff458243c55c417fef96.