### PR TITLE
kie-server-tests: align WildFly client to bom

### DIFF
--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -454,11 +454,6 @@
             <artifactId>jaxb-impl</artifactId>
             <version>${version.com.sun.xml.bind}</version>
           </dependency>
-          <dependency>
-            <groupId>org.wildfly</groupId>
-            <artifactId>wildfly-controller-client</artifactId>
-            <version>8.2.1.Final</version>
-          </dependency>
         </dependencies>
       </dependencyManagement>
       <dependencies>
@@ -469,7 +464,7 @@
           <scope>test</scope>
         </dependency>
         <dependency>
-          <groupId>org.wildfly</groupId>
+          <groupId>org.wildfly.core</groupId>
           <artifactId>wildfly-controller-client</artifactId>
           <scope>test</scope>
         </dependency>
@@ -617,6 +612,11 @@
           <groupId>org.wildfly</groupId>
           <artifactId>wildfly-jms-client-bom</artifactId>
           <type>pom</type>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.wildfly.core</groupId>
+          <artifactId>wildfly-controller-client</artifactId>
           <scope>test</scope>
         </dependency>
       </dependencies>


### PR DESCRIPTION
wildfly-controller-client is needed by Cargo, used in JmsQueueIntegrationTest.
Updated group Id and aligned to use version defined in WildFly bom.