### PR TITLE
kie-server-tests: custom client-deployment-settings.xml

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/config/TestConfig.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/config/TestConfig.java
@@ -62,6 +62,7 @@ public class TestConfig {
     private static final StringTestParameter RESPONSE_QUEUE_JNDI = new StringTestParameter("kie.server.jndi.response.queue", "jms/queue/KIE.SERVER.RESPONSE");
 
     private static final StringTestParameter KJARS_BUILD_SETTINGS_XML = new StringTestParameter("kie.server.testing.kjars.build.settings.xml");
+    private static final StringTestParameter KIE_CLIENT_DEPLOYMENT_SETTINGS = new StringTestParameter("kie.server.client.deployment.settings.xml");
 
     private static final StringTestParameter CONTAINER_ID = new StringTestParameter("cargo.container.id");
     private static final StringTestParameter CONTAINER_PORT = new StringTestParameter("cargo.servlet.port");
@@ -326,6 +327,13 @@ public class TestConfig {
      */
     public static boolean isWebLogicHomeProvided() {
         return TestConfig.WEBLOGIC_HOME.isParameterConfigured();
+    }
+
+    /**
+     * @return location of custom kie-server-testing-client-deployment-settings.xml
+     */
+    public static String getKieClientDeploymentSettings() {
+        return TestConfig.KIE_CLIENT_DEPLOYMENT_SETTINGS.getParameterValue();
     }
 
     // Used for printing all configuration values at the beginning of first test run.

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerBaseIntegrationTest.java
@@ -119,9 +119,13 @@ public abstract class KieServerBaseIntegrationTest {
 
     private static void setupCustomSettingsXml() {
         if (!TestConfig.isLocalServer()) {
-            String clientDeploymentSettingsXml = ClassLoader.class.getResource(
-                    "/kie-server-testing-client-deployment-settings.xml").getFile();
-            System.setProperty(KieServerConstants.CFG_KIE_MVN_SETTINGS, clientDeploymentSettingsXml);
+            String deploymentSettings = TestConfig.getKieClientDeploymentSettings();
+
+            if (deploymentSettings == null) {
+                deploymentSettings = ClassLoader.class.getResource("/kie-server-testing-client-deployment-settings.xml").getFile();
+            }
+
+            System.setProperty(KieServerConstants.CFG_KIE_MVN_SETTINGS, deploymentSettings);
         }
     }
 


### PR DESCRIPTION
Allow external definition of kie-server-testing-client-deployment-settings.xml - for case when we need to use custom private repositories for kjar dependencies.

Side note: using 2 different approaches for creating kjars in tests(by MavenCLI and kie-ci) makes things complicated. I would like to remove one of them in future. What do you think, which one should stay? I think that kie-ci provides more flexibility, could be more useful to keep it.