### PR TITLE
kie-remote-jaxb-gen: remove unused plugin config (thanks @baldimir)

### DIFF
--- a/kie-remote/kie-remote-jaxb-gen/pom.xml
+++ b/kie-remote/kie-remote-jaxb-gen/pom.xml
@@ -116,26 +116,6 @@
         </configuration>
       </plugin>
 
-      <!-- 0. add src/main/generated so that generated classes are added to jar -->
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>add-generated-sources</id>
-            <phase>inititalize</phase>
-            <goals>
-              <goal>add-source</goal>
-            </goals>
-            <configuration>
-              <sources>
-                <source>src/main/generated</source>
-              </sources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
       <!-- 1. unpack original sources of Command implementation java code -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
 * the plugin was bound to non-existing phase inititalize
   (typo, should be initialize). Because of that it was
   never executed and thus is not needed at all