### PR TITLE
kie-server-tests: use BOM for kjar dependencies

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/definition-project/src/main/resources/call-evaluation.bpmn2
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/definition-project/src/main/resources/call-evaluation.bpmn2
@@ -53,6 +53,7 @@
           <bpmn2:dataInputRefs>_D05A98B9-118F-4A15-8D83-2B386F7E97C3_GroupIdInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_D05A98B9-118F-4A15-8D83-2B386F7E97C3_SkippableInputX</bpmn2:dataInputRefs>
         </bpmn2:inputSet>
+        <bpmn2:outputSet/>
       </bpmn2:ioSpecification>
       <bpmn2:dataInputAssociation id="_EK2FXvMuEeSoD-9HcIhmjA">
         <bpmn2:targetRef>_D05A98B9-118F-4A15-8D83-2B386F7E97C3_GroupIdInputX</bpmn2:targetRef>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/definition-project/src/main/resources/customtask.bpmn
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/definition-project/src/main/resources/customtask.bpmn
@@ -9,7 +9,8 @@
              xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
              xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
              xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
-             xmlns:tns="http://www.jboss.org/drools">
+             xmlns:tns="http://www.jboss.org/drools"
+             targetNamespace="http://www.omg.org/bpmn20">
 
   <itemDefinition id="_idItem" structureRef="String" />
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/definition-project/src/main/resources/signal-start.bpmn2
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/definition-project/src/main/resources/signal-start.bpmn2
@@ -25,9 +25,6 @@
         <sourceRef>_1_Output</sourceRef>
         <targetRef>x</targetRef>
       </dataOutputAssociation>
-      <outputSet>
-        <dataOutputRefs>_1_Output</dataOutputRefs>
-      </outputSet>
       <signalEventDefinition signalRef="start-process" />
     </startEvent>
     <scriptTask id="_2" name="Hello" >

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/pom.xml
@@ -15,19 +15,16 @@
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-core</artifactId>
-      <version>${version.org.kie}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-persistence-xstream</artifactId>
-      <version>${version.org.kie}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.codehaus.jackson</groupId>
       <artifactId>jackson-core-asl</artifactId>
-      <version>${version.org.codehaus.jackson}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
@@ -14,6 +14,18 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-platform-bom</artifactId>
+        <version>${version.org.kie}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <build>
     <pluginManagement>
       <plugins>


### PR DESCRIPTION
@psiroky What do you think, is it good to use this platform BOM or I should rather use several specific BOMs for drools/jbpm/optaplanner...