### PR TITLE
kie-server: controller - empty KieServerInstanceList fix

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/model/KieServerInstanceList.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/model/KieServerInstanceList.java
@@ -15,6 +15,7 @@
 
 package org.kie.server.controller.api.model;
 
+import java.util.Collections;
 import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -31,6 +32,7 @@ public class KieServerInstanceList {
     private KieServerInstance[] KieServerInstances;
 
     public KieServerInstanceList() {
+        this(Collections.EMPTY_LIST);
     }
 
     public KieServerInstanceList(KieServerInstance[] KieServerInstances) {

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerIntegrationTest.java
@@ -193,7 +193,7 @@ public class KieControllerIntegrationTest extends KieControllerBaseTest {
     public void testEmptyListKieServerInstances() throws Exception {
         KieServerInstanceList instanceList = controllerClient.listKieServerInstances();
         assertNotNull(instanceList);
-        assertNullOrEmpty("Active kie server instance found!", instanceList.getKieServerInstances());
+        assertEquals("Active kie server instance found!", 0, instanceList.getKieServerInstances().length);
     }
 
     @Test


### PR DESCRIPTION
When is created `KieServerInstanceList` with no `KieServerInstance` and then try get all server instances by `getKieServerInstances()` then KieServerList created with Json marshalling return _empty array_ and  list created with Jaxb marshalling return _null_.
This is caused by content of response: Jaxb ( `<kie-server-instance-list/>` ), JSON (` "kie-server-instance" : [ ] `) so there are used different constructors.
Empty `KieServerInstances` in `KieServerInstanceList` should be empty and not null.