### PR TITLE
PLANNER-560 The score of the bestSolution is set before it is (fully)…

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-optaplanner/src/main/java/org/kie/server/services/optaplanner/SolverServiceBase.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-optaplanner/src/main/java/org/kie/server/services/optaplanner/SolverServiceBase.java
@@ -150,7 +150,7 @@ public class SolverServiceBase {
             SolverInstanceContext sic = solvers.get( SolverInstance.getSolverInstanceKey( containerId, solverId ) );
             if( sic != null ) {
                 updateSolverInstance( sic );
-                sic.getInstance().setBestSolution((Solution)  sic.getSolver().getBestSolution() );
+                sic.getInstance().setBestSolution((Solution) sic.getSolver().getBestSolution() );
                 return new ServiceResponse<SolverInstance>(ServiceResponse.ResponseType.SUCCESS,
                                                            "Best computed solution for '" + solverId + "' successfully retrieved from container '" + containerId + "'",
                                                             sic.getInstance() );


### PR DESCRIPTION
… initialized, but from Solver.getBestSolution() it's not detectable that it's not yet initialized

Note: this doesn't fix the JAXB issue yet with marshalling the score, but it should fix the random failures of the testGetBestSolution() unit test.