### PR TITLE
Scores should automatically marshall correctly with XStream - 

### DIFF
--- a/kie-server-parent/kie-server-api/pom.xml
+++ b/kie-server-parent/kie-server-api/pom.xml
@@ -38,6 +38,14 @@
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-persistence-xstream</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-persistence-jaxb</artifactId>
+    </dependency>
 
     <!-- json -->
     <dependency>

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/jaxb/JaxbMarshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/jaxb/JaxbMarshaller.java
@@ -81,6 +81,7 @@ import org.kie.server.api.model.type.JaxbDate;
 import org.kie.server.api.model.type.JaxbList;
 import org.kie.server.api.model.type.JaxbMap;
 import org.optaplanner.core.api.domain.solution.Solution;
+import org.optaplanner.core.api.score.AbstractScore;
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.score.buildin.bendable.BendableScore;
 import org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore;
@@ -95,6 +96,22 @@ import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore;
 import org.optaplanner.core.api.score.buildin.simpledouble.SimpleDoubleScore;
 import org.optaplanner.core.api.score.buildin.simplelong.SimpleLongScore;
+import org.optaplanner.persistence.jaxb.api.score.buildin.bendable.BendableScoreJaxbXmlAdapter;
+import org.optaplanner.persistence.jaxb.api.score.buildin.bendablelong.BendableLongScoreJaxbXmlAdapter;
+import org.optaplanner.persistence.jaxb.api.score.buildin.hardsoft.HardSoftScoreJaxbXmlAdapter;
+import org.optaplanner.persistence.xstream.api.score.buildin.bendable.BendableScoreXStreamConverter;
+import org.optaplanner.persistence.xstream.api.score.buildin.bendablebigdecimal.BendableBigDecimalScoreXStreamConverter;
+import org.optaplanner.persistence.xstream.api.score.buildin.bendablelong.BendableLongScoreXStreamConverter;
+import org.optaplanner.persistence.xstream.api.score.buildin.hardmediumsoft.HardMediumSoftScoreXStreamConverter;
+import org.optaplanner.persistence.xstream.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScoreXStreamConverter;
+import org.optaplanner.persistence.xstream.api.score.buildin.hardsoft.HardSoftScoreXStreamConverter;
+import org.optaplanner.persistence.xstream.api.score.buildin.hardsoftbigdecimal.HardSoftBigDecimalScoreXStreamConverter;
+import org.optaplanner.persistence.xstream.api.score.buildin.hardsoftdouble.HardSoftDoubleScoreXStreamConverter;
+import org.optaplanner.persistence.xstream.api.score.buildin.hardsoftlong.HardSoftLongScoreXStreamConverter;
+import org.optaplanner.persistence.xstream.api.score.buildin.simple.SimpleScoreXStreamConverter;
+import org.optaplanner.persistence.xstream.api.score.buildin.simplebigdecimal.SimpleBigDecimalScoreXStreamConverter;
+import org.optaplanner.persistence.xstream.api.score.buildin.simpledouble.SimpleDoubleScoreXStreamConverter;
+import org.optaplanner.persistence.xstream.api.score.buildin.simplelong.SimpleLongScoreXStreamConverter;
 
 public class JaxbMarshaller implements Marshaller {
     public static final Class<?>[] KIE_SERVER_JAXB_CLASSES;
@@ -197,7 +214,10 @@ public class JaxbMarshaller implements Marshaller {
                 // OptaPlanner
                 SolverInstance.class,
                 SolverInstanceList.class,
-                // TODO We should build and use optaplanner-persistence-jaxb in a future version
+                Message.class,
+
+                // TODO Needed to not fail SolverInstance.score but it probably corrupts the score...
+                // See https://issues.jboss.org/browse/PLANNER-604
                 SimpleScore.class,
                 SimpleLongScore.class,
                 SimpleDoubleScore.class,
@@ -211,7 +231,6 @@ public class JaxbMarshaller implements Marshaller {
                 BendableScore.class,
                 BendableLongScore.class,
                 BendableBigDecimalScore.class,
-                Message.class,
 
                 // Optaplanner commands
                 CreateSolverCommand.class,

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/xstream/XStreamMarshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/xstream/XStreamMarshaller.java
@@ -41,6 +41,19 @@ import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.api.model.ServiceResponsesList;
 import org.kie.server.api.model.instance.SolverInstance;
+import org.optaplanner.persistence.xstream.api.score.buildin.bendable.BendableScoreXStreamConverter;
+import org.optaplanner.persistence.xstream.api.score.buildin.bendablebigdecimal.BendableBigDecimalScoreXStreamConverter;
+import org.optaplanner.persistence.xstream.api.score.buildin.bendablelong.BendableLongScoreXStreamConverter;
+import org.optaplanner.persistence.xstream.api.score.buildin.hardmediumsoft.HardMediumSoftScoreXStreamConverter;
+import org.optaplanner.persistence.xstream.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScoreXStreamConverter;
+import org.optaplanner.persistence.xstream.api.score.buildin.hardsoft.HardSoftScoreXStreamConverter;
+import org.optaplanner.persistence.xstream.api.score.buildin.hardsoftbigdecimal.HardSoftBigDecimalScoreXStreamConverter;
+import org.optaplanner.persistence.xstream.api.score.buildin.hardsoftdouble.HardSoftDoubleScoreXStreamConverter;
+import org.optaplanner.persistence.xstream.api.score.buildin.hardsoftlong.HardSoftLongScoreXStreamConverter;
+import org.optaplanner.persistence.xstream.api.score.buildin.simple.SimpleScoreXStreamConverter;
+import org.optaplanner.persistence.xstream.api.score.buildin.simplebigdecimal.SimpleBigDecimalScoreXStreamConverter;
+import org.optaplanner.persistence.xstream.api.score.buildin.simpledouble.SimpleDoubleScoreXStreamConverter;
+import org.optaplanner.persistence.xstream.api.score.buildin.simplelong.SimpleLongScoreXStreamConverter;
 
 public class XStreamMarshaller
         implements Marshaller {
@@ -52,6 +65,20 @@ public class XStreamMarshaller
         this.classLoader = classLoader;
         this.xstream = XStreamXML.newXStreamMarshaller( new XStream(  ) );
         this.xstream.setClassLoader( classLoader );
+
+        this.xstream.registerConverter(new BendableScoreXStreamConverter());
+        this.xstream.registerConverter(new BendableLongScoreXStreamConverter());
+        this.xstream.registerConverter(new BendableBigDecimalScoreXStreamConverter());
+        this.xstream.registerConverter(new HardMediumSoftScoreXStreamConverter());
+        this.xstream.registerConverter(new HardMediumSoftLongScoreXStreamConverter());
+        this.xstream.registerConverter(new HardSoftScoreXStreamConverter());
+        this.xstream.registerConverter(new HardSoftLongScoreXStreamConverter());
+        this.xstream.registerConverter(new HardSoftDoubleScoreXStreamConverter());
+        this.xstream.registerConverter(new HardSoftBigDecimalScoreXStreamConverter());
+        this.xstream.registerConverter(new SimpleScoreXStreamConverter());
+        this.xstream.registerConverter(new SimpleLongScoreXStreamConverter());
+        this.xstream.registerConverter(new SimpleDoubleScoreXStreamConverter());
+        this.xstream.registerConverter(new SimpleBigDecimalScoreXStreamConverter());
 
         this.xstream.processAnnotations( CommandScript.class );
         this.xstream.processAnnotations( CallContainerCommand.class );
@@ -79,7 +106,6 @@ public class XStreamMarshaller
         this.xstream.processAnnotations( GetSolversCommand.class );
         this.xstream.processAnnotations( GetSolverStateCommand.class );
         this.xstream.processAnnotations( UpdateSolverStateCommand.class );
-
 
         if (classes != null) {
             for (Class<?> clazz : classes) {

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/instance/SolverInstance.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/instance/SolverInstance.java
@@ -36,6 +36,7 @@ public class SolverInstance {
 
     @XmlElement(name = "score")
     @XStreamAlias("score")
+    // TODO https://issues.jboss.org/browse/PLANNER-604 this might be corrupted during marshalling and it's not tested
     @XmlJavaTypeAdapter(JaxbUnknownAdapter.class)
     private Score score;
 

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/package-info.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/package-info.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@XmlJavaTypeAdapters({
+    @XmlJavaTypeAdapter(type = BendableScore.class, value = BendableScoreJaxbXmlAdapter.class),
+    @XmlJavaTypeAdapter(type = BendableLongScore.class, value = BendableLongScoreJaxbXmlAdapter.class),
+    @XmlJavaTypeAdapter(type = HardMediumSoftScore.class, value = HardMediumSoftScoreJaxbXmlAdapter.class),
+    @XmlJavaTypeAdapter(type = HardMediumSoftLongScore.class, value = HardMediumSoftLongScoreJaxbXmlAdapter.class),
+    @XmlJavaTypeAdapter(type = HardSoftScore.class, value = HardSoftScoreJaxbXmlAdapter.class),
+    @XmlJavaTypeAdapter(type = HardSoftLongScore.class, value = HardSoftLongScoreJaxbXmlAdapter.class),
+    @XmlJavaTypeAdapter(type = HardSoftDoubleScore.class, value = HardSoftDoubleScoreJaxbXmlAdapter.class),
+    @XmlJavaTypeAdapter(type = HardSoftBigDecimalScore.class, value = HardSoftBigDecimalScoreJaxbXmlAdapter.class),
+    @XmlJavaTypeAdapter(type = SimpleScore.class, value = SimpleScoreJaxbXmlAdapter.class),
+    @XmlJavaTypeAdapter(type = SimpleLongScore.class, value = SimpleLongScoreJaxbXmlAdapter.class),
+    @XmlJavaTypeAdapter(type = SimpleDoubleScore.class, value = SimpleDoubleScoreJaxbXmlAdapter.class),
+    @XmlJavaTypeAdapter(type = SimpleBigDecimalScore.class, value = SimpleBigDecimalScoreJaxbXmlAdapter.class)
+})
+package org.kie.server.api;
+
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapters;
+
+import org.optaplanner.core.api.score.buildin.bendable.BendableScore;
+import org.optaplanner.core.api.score.buildin.bendablelong.BendableLongScore;
+import org.optaplanner.core.api.score.buildin.hardmediumsoft.HardMediumSoftScore;
+import org.optaplanner.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScore;
+import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
+import org.optaplanner.core.api.score.buildin.hardsoftbigdecimal.HardSoftBigDecimalScore;
+import org.optaplanner.core.api.score.buildin.hardsoftdouble.HardSoftDoubleScore;
+import org.optaplanner.core.api.score.buildin.hardsoftlong.HardSoftLongScore;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore;
+import org.optaplanner.core.api.score.buildin.simpledouble.SimpleDoubleScore;
+import org.optaplanner.core.api.score.buildin.simplelong.SimpleLongScore;
+import org.optaplanner.persistence.jaxb.api.score.buildin.bendable.BendableScoreJaxbXmlAdapter;
+import org.optaplanner.persistence.jaxb.api.score.buildin.bendablelong.BendableLongScoreJaxbXmlAdapter;
+import org.optaplanner.persistence.jaxb.api.score.buildin.hardmediumsoft.HardMediumSoftScoreJaxbXmlAdapter;
+import org.optaplanner.persistence.jaxb.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScoreJaxbXmlAdapter;
+import org.optaplanner.persistence.jaxb.api.score.buildin.hardsoft.HardSoftScoreJaxbXmlAdapter;
+import org.optaplanner.persistence.jaxb.api.score.buildin.hardsoftbigdecimal.HardSoftBigDecimalScoreJaxbXmlAdapter;
+import org.optaplanner.persistence.jaxb.api.score.buildin.hardsoftdouble.HardSoftDoubleScoreJaxbXmlAdapter;
+import org.optaplanner.persistence.jaxb.api.score.buildin.hardsoftlong.HardSoftLongScoreJaxbXmlAdapter;
+import org.optaplanner.persistence.jaxb.api.score.buildin.simple.SimpleScoreJaxbXmlAdapter;
+import org.optaplanner.persistence.jaxb.api.score.buildin.simplebigdecimal.SimpleBigDecimalScoreJaxbXmlAdapter;
+import org.optaplanner.persistence.jaxb.api.score.buildin.simpledouble.SimpleDoubleScoreJaxbXmlAdapter;
+import org.optaplanner.persistence.jaxb.api.score.buildin.simplelong.SimpleLongScoreJaxbXmlAdapter;


### PR DESCRIPTION
With JAXB this is impossible, but we add the package-info anyway so it works for our kie-server-api classes at least.

This PR also points out a TODO related PLANNER-604 that were already there (and aren't being fixed now), but at least it brings that TODO away from hiding.