### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/droolsjbpm-integration-examples/src/main/java/org/drools/examples/broker/misc/BrokerUtils.java
+++ b/droolsjbpm-integration-examples/src/main/java/org/drools/examples/broker/misc/BrokerUtils.java
@@ -23,7 +23,9 @@ import org.drools.examples.broker.model.Action;
 
 public class BrokerUtils {
     private static final Random rand = new Random(System.currentTimeMillis());
-    
+
+    private BrokerUtils() {}
+
     public static String percent( double number ) {
         return new DecimalFormat( "0.00%" ).format( number );
     }

--- a/jbpm-simulation/src/main/java/org/jbpm/simulation/util/BPMN2Utils.java
+++ b/jbpm-simulation/src/main/java/org/jbpm/simulation/util/BPMN2Utils.java
@@ -39,6 +39,8 @@ import org.jboss.drools.impl.DroolsPackageImpl;
 
 public class BPMN2Utils {
 
+    private BPMN2Utils() {}
+
     public static Definitions getDefinitions(InputStream is) {
         DroolsPackageImpl.init();
         BpsimPackageImpl.init();

--- a/jbpm-simulation/src/main/java/org/jbpm/simulation/util/SimulationUtils.java
+++ b/jbpm-simulation/src/main/java/org/jbpm/simulation/util/SimulationUtils.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 
 public class SimulationUtils {
-	
+
 	public static final double HUNDRED = 100;
 	public static final  NumberFormat formatter = new DecimalFormat("#0.00");
 	
@@ -38,6 +38,8 @@ public class SimulationUtils {
 	    timeUnitMapping.put("day", "days");
 	    timeUnitMapping.put("year", "years");
 	}
+
+	private SimulationUtils() {}
 
 	public static int asInt(Object value) {
 		if (value == null) {

--- a/jbpm-simulation/src/test/java/org/jbpm/simulation/helper/TestUtils.java
+++ b/jbpm-simulation/src/test/java/org/jbpm/simulation/helper/TestUtils.java
@@ -52,6 +52,8 @@ import org.kie.internal.runtime.StatefulKnowledgeSession;
 
 public class TestUtils {
 
+    private TestUtils() {}
+
     public static boolean matchExpected(List<PathContext> paths, List<String>... expectedIds) {
         
         for (PathContext context : paths) {

--- a/kie-aries-blueprint/src/main/java/org/kie/aries/blueprint/namespace/ExpressionUtils.java
+++ b/kie-aries-blueprint/src/main/java/org/kie/aries/blueprint/namespace/ExpressionUtils.java
@@ -20,6 +20,8 @@ import org.osgi.service.blueprint.container.ComponentDefinitionException;
 import java.io.File;
 
 public class ExpressionUtils {
+    private ExpressionUtils() {}
+
     public static String resolveExpressionInPath(String path){
         //#{ systemProperties['java.io.tmpdir'] }
         String[] pathComponents = path.split("/");

--- a/kie-infinispan/drools-infinispan-persistence/src/main/java/org/drools/persistence/util/StringUtils.java
+++ b/kie-infinispan/drools-infinispan-persistence/src/main/java/org/drools/persistence/util/StringUtils.java
@@ -30,6 +30,8 @@ import java.io.UnsupportedEncodingException;
  */
 public class StringUtils {
 
+    private StringUtils() {}
+
     /**
      * Encodes the given string into a sequence of bytes using the ISO-8859-1 charset, storing the result into a new
      * byte array.

--- a/kie-server-parent/kie-server-controller/kie-server-controller-rest/src/main/java/org/kie/server/controller/rest/ControllerUtils.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-rest/src/main/java/org/kie/server/controller/rest/ControllerUtils.java
@@ -53,6 +53,8 @@ public class ControllerUtils {
     private static Marshaller jsonMarshaller = MarshallerFactory.getMarshaller(getMinimalModelClasses(), MarshallingFormat.JSON, ControllerUtils.class.getClassLoader());
     private static Marshaller jaxbMarshaller = MarshallerFactory.getMarshaller(getModelClasses(), MarshallingFormat.JAXB, ControllerUtils.class.getClassLoader());
 
+    private ControllerUtils() {}
+
     public static Set<Class<?>> getModelClasses() {
         Set<Class<?>> modelClasses = new HashSet<Class<?>>();
 

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/main/java/org/kie/server/remote/rest/common/util/RestUtils.java
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/main/java/org/kie/server/remote/rest/common/util/RestUtils.java
@@ -36,7 +36,9 @@ import org.kie.server.services.impl.marshal.MarshallerHelper;
 public class RestUtils {
 
     private static MarshallerHelper marshallerHelper = new MarshallerHelper(null);
-    
+
+    private RestUtils() {}
+
     public static Response createCorrectVariant(Object responseObj, HttpHeaders headers, Header... customHeaders) {
         return createCorrectVariant(responseObj, headers, null, customHeaders);
     }

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/test/java/org/kie/server/remote/rest/common/util/RestUtilsTest.java
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/test/java/org/kie/server/remote/rest/common/util/RestUtilsTest.java
@@ -44,6 +44,8 @@ public class RestUtilsTest {
     private KieServerRegistry registry;
     private HttpHeaders headers;
 
+    private RestUtilsTest() {}
+
     @Before
     public void setup() {
         registry = Mockito.mock(KieServerRegistry.class);

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/ConvertUtils.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/ConvertUtils.java
@@ -45,6 +45,8 @@ import org.kie.server.api.model.instance.VariableInstanceList;
 
 public class ConvertUtils {
 
+    private ConvertUtils() {}
+
     public static ProcessInstanceList convertToProcessInstanceList(Collection<ProcessInstanceDesc> instances) {
         if (instances == null) {
             return new ProcessInstanceList(new org.kie.server.api.model.instance.ProcessInstance[0]);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava