### PR TITLE
squid:S1161 - '@Override' annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one

### DIFF
--- a/kie-infinispan/jbpm-infinispan-persistence/src/main/java/org/jbpm/persistence/processinstance/InfinispanProcessInstanceManager.java
+++ b/kie-infinispan/jbpm-infinispan-persistence/src/main/java/org/jbpm/persistence/processinstance/InfinispanProcessInstanceManager.java
@@ -64,6 +64,7 @@ public class InfinispanProcessInstanceManager
         this.kruntime = kruntime;
     }
 
+    @Override
     public void addProcessInstance(ProcessInstance processInstance, CorrelationKey correlationKey) {
         ProcessInstanceInfo processInstanceInfo = new ProcessInstanceInfo( processInstance, this.kruntime.getEnvironment() );
         ProcessPersistenceContext context 
@@ -82,7 +83,8 @@ public class InfinispanProcessInstanceManager
         }
         internalAddProcessInstance(processInstance);
     }
-    
+
+    @Override
     public void internalAddProcessInstance(ProcessInstance processInstance) {
         if( processInstances.putIfAbsent(processInstance.getId(), processInstance) != null ) { 
             throw new ConcurrentModificationException(
@@ -91,10 +93,12 @@ public class InfinispanProcessInstanceManager
         }
     }
 
+    @Override
     public ProcessInstance getProcessInstance(long id) {
         return getProcessInstance(id, false);
     }
 
+    @Override
     public ProcessInstance getProcessInstance(long id, boolean readOnly) {
         InternalRuntimeManager manager = (InternalRuntimeManager) kruntime.getEnvironment().get("RuntimeManager");
         if (manager != null) {
@@ -148,10 +152,12 @@ public class InfinispanProcessInstanceManager
         return processInstance;
     }
 
+    @Override
     public Collection<ProcessInstance> getProcessInstances() {
     	return Collections.unmodifiableCollection(processInstances.values());
     }
 
+    @Override
     public void removeProcessInstance(ProcessInstance processInstance) {
         ProcessPersistenceContext context = ((ProcessPersistenceContextManager) this.kruntime.getEnvironment().get( EnvironmentName.PERSISTENCE_CONTEXT_MANAGER )).getProcessPersistenceContext();
         ProcessInstanceInfo processInstanceInfo = context.findProcessInstanceInfo( processInstance.getId() );
@@ -162,16 +168,19 @@ public class InfinispanProcessInstanceManager
         internalRemoveProcessInstance(processInstance);
     }
 
+    @Override
     public void internalRemoveProcessInstance(ProcessInstance processInstance) {
         processInstances.remove( processInstance.getId() );
     }
-    
+
+    @Override
     public void clearProcessInstances() {
     	/*for (ProcessInstance processInstance: new ArrayList<ProcessInstance>(processInstances.values())) {
             ((ProcessInstanceImpl) processInstance).disconnect();
         }*/
     }
 
+    @Override
     public void clearProcessInstancesState() {
         try {
             // at this point only timers are considered as state that needs to be cleared

--- a/kie-infinispan/jbpm-infinispan-persistence/src/main/java/org/jbpm/persistence/processinstance/InfinispanProcessInstanceManagerFactory.java
+++ b/kie-infinispan/jbpm-infinispan-persistence/src/main/java/org/jbpm/persistence/processinstance/InfinispanProcessInstanceManagerFactory.java
@@ -21,6 +21,7 @@ import org.jbpm.process.instance.ProcessInstanceManagerFactory;
 
 public class InfinispanProcessInstanceManagerFactory implements ProcessInstanceManagerFactory {
 
+	@Override
 	public ProcessInstanceManager createProcessInstanceManager(InternalKnowledgeRuntime kruntime) {
 		InfinispanProcessInstanceManager result = new InfinispanProcessInstanceManager();
 		result.setKnowledgeRuntime(kruntime);

--- a/kie-infinispan/jbpm-infinispan-persistence/src/main/java/org/jbpm/persistence/processinstance/InfinispanSignalManager.java
+++ b/kie-infinispan/jbpm-infinispan-persistence/src/main/java/org/jbpm/persistence/processinstance/InfinispanSignalManager.java
@@ -29,7 +29,8 @@ public class InfinispanSignalManager extends DefaultSignalManager {
     public InfinispanSignalManager(InternalKnowledgeRuntime kruntime) {
         super(kruntime);
     }
-    
+
+    @Override
     public void signalEvent(String type,
                             Object event) {
         for ( long id : getProcessInstancesForEvent( type ) ) {

--- a/kie-infinispan/jbpm-infinispan-persistence/src/main/java/org/jbpm/persistence/processinstance/InfinispanSignalManagerFactory.java
+++ b/kie-infinispan/jbpm-infinispan-persistence/src/main/java/org/jbpm/persistence/processinstance/InfinispanSignalManagerFactory.java
@@ -21,6 +21,7 @@ import org.jbpm.process.instance.event.SignalManagerFactory;
 
 public class InfinispanSignalManagerFactory implements SignalManagerFactory {
 
+	@Override
 	public SignalManager createSignalManager(InternalKnowledgeRuntime kruntime) {
 		return new InfinispanSignalManager(kruntime);
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1161 - '@Override' annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava