### PR TITLE
squid:ModifiersOrderCheck - Modifiers should be declared in the correct order

### DIFF
--- a/drools-benchmark/src/main/java/org/drools/benchmark/model/waltz/Edge.java
+++ b/drools-benchmark/src/main/java/org/drools/benchmark/model/waltz/Edge.java
@@ -27,13 +27,13 @@ public class Edge {
 
     private boolean            plotted;
 
-    final public static String NIL   = "empty";
+    public static final String NIL   = "empty";
 
-    final public static String B     = "B";
+    public static final String B     = "B";
 
-    final public static String PLUS  = "+";
+    public static final String PLUS  = "+";
 
-    final public static String MINUS = "-";
+    public static final String MINUS = "-";
 
     public Edge() {
 

--- a/drools-benchmark/src/main/java/org/drools/benchmark/model/waltz/Stage.java
+++ b/drools-benchmark/src/main/java/org/drools/benchmark/model/waltz/Stage.java
@@ -27,21 +27,21 @@ public class Stage
     Externalizable {
     private static final long serialVersionUID      = 510l;
 
-    final public static int   START                 = 0;
+    public static final int   START                 = 0;
 
-    final public static int   DUPLICATE             = 1;
+    public static final int   DUPLICATE             = 1;
 
-    final public static int   DETECT_JUNCTIONS      = 2;
+    public static final int   DETECT_JUNCTIONS      = 2;
 
-    final public static int   FIND_INITIAL_BOUNDARY = 3;
+    public static final int   FIND_INITIAL_BOUNDARY = 3;
 
-    final public static int   FIND_SECOND_BOUNDARY  = 4;
+    public static final int   FIND_SECOND_BOUNDARY  = 4;
 
-    final public static int   LABELING              = 5;
+    public static final int   LABELING              = 5;
 
-    final public static int   PLOT_REMAINING_EDGES  = 9;
+    public static final int   PLOT_REMAINING_EDGES  = 9;
 
-    final public static int   DONE                  = 10;
+    public static final int   DONE                  = 10;
 
     private int               value;
 

--- a/kie-infinispan/jbpm-infinispan-persistence/src/main/java/org/jbpm/persistence/processinstance/InfinispanProcessInstanceManager.java
+++ b/kie-infinispan/jbpm-infinispan-persistence/src/main/java/org/jbpm/persistence/processinstance/InfinispanProcessInstanceManager.java
@@ -57,7 +57,7 @@ public class InfinispanProcessInstanceManager
     // In a scenario in which 1000's of processes are running daily,
     //   lazy initialization is more costly than eager initialization
     // Added volatile so that if something happens, we can figure out what
-    private volatile transient ConcurrentHashMap<Long, ProcessInstance> processInstances = new ConcurrentHashMap<Long, ProcessInstance>();
+    private transient volatile ConcurrentHashMap<Long, ProcessInstance> processInstances = new ConcurrentHashMap<Long, ProcessInstance>();
 
     
     public void setKnowledgeRuntime(InternalKnowledgeRuntime kruntime) {

--- a/kie-performance-kit/src/main/java/org/kie/perf/metrics/ThreadStatesGaugeSet.java
+++ b/kie-performance-kit/src/main/java/org/kie/perf/metrics/ThreadStatesGaugeSet.java
@@ -19,7 +19,7 @@ import com.codahale.metrics.jvm.ThreadDeadlockDetector;
 public class ThreadStatesGaugeSet implements MetricSet {
 
     // do not compute stack traces.
-    private final static int STACK_TRACE_DEPTH = 0;
+    private static final int STACK_TRACE_DEPTH = 0;
 
     private Class<?> scenario;
 

--- a/kie-remote/kie-remote-client/src/main/java/org/kie/remote/client/api/RemoteRuntimeEngineFactory.java
+++ b/kie-remote/kie-remote-client/src/main/java/org/kie/remote/client/api/RemoteRuntimeEngineFactory.java
@@ -68,7 +68,7 @@ public abstract class RemoteRuntimeEngineFactory {
      * @return a new (remote client) {@link RuntimeEngine} instance.
      * @see {@link RemoteRuntimeEngineBuilder#buildRuntimeEngine()}
      */
-    abstract public RuntimeEngine newRuntimeEngine();
+     public abstract RuntimeEngine newRuntimeEngine();
     
     /**
      * Retrieves the (remote) {@link InitialContext} from the JBoss AS server instance in order 

--- a/kie-remote/kie-remote-client/src/main/java/org/kie/remote/client/internal/RemoteCommandWebserviceClientBuilderImpl.java
+++ b/kie-remote/kie-remote-client/src/main/java/org/kie/remote/client/internal/RemoteCommandWebserviceClientBuilderImpl.java
@@ -59,8 +59,8 @@ import org.kie.services.shared.ServicesVersion;
  */
 class RemoteCommandWebserviceClientBuilderImpl extends RemoteWebserviceClientBuilderImpl<CommandWebService> {
 
-    private final static String commandServiceNamespace = "http://services.remote.kie.org/" + ServicesVersion.VERSION + "/command";
-    private final static QName commandServiceQName = new QName(commandServiceNamespace, "CommandServiceBasicAuth");
+    private static final String commandServiceNamespace = "http://services.remote.kie.org/" + ServicesVersion.VERSION + "/command";
+    private static final QName commandServiceQName = new QName(commandServiceNamespace, "CommandServiceBasicAuth");
 
     @Override
     public CommandWebService buildBasicAuthClient() {

--- a/kie-remote/kie-remote-client/src/main/java/org/kie/remote/client/jaxb/JaxbWrapper.java
+++ b/kie-remote/kie-remote-client/src/main/java/org/kie/remote/client/jaxb/JaxbWrapper.java
@@ -98,7 +98,7 @@ abstract class JaxbWrapper {
     /**
      * Represents a {@link Task} instance
      */
-    final static class JaxbTaskWrapper extends JaxbWrapper implements InternalTask {
+     static final class JaxbTaskWrapper extends JaxbWrapper implements InternalTask {
     
         private final org.kie.remote.jaxb.gen.Task task;
     
@@ -276,7 +276,7 @@ abstract class JaxbWrapper {
     /**
      * Represents a {@link TaskData} instance
      */
-    final static class JaxbTaskDataWrapper extends JaxbWrapper implements TaskData {
+    static final class JaxbTaskDataWrapper extends JaxbWrapper implements TaskData {
     
         private final org.kie.remote.jaxb.gen.TaskData taskData;
     
@@ -416,7 +416,7 @@ abstract class JaxbWrapper {
         
     }
 
-    final static class JaxbAttachmentWrapper extends JaxbWrapper implements Attachment {
+    static final class JaxbAttachmentWrapper extends JaxbWrapper implements Attachment {
     
         private final org.kie.remote.jaxb.gen.Attachment attachment;
         
@@ -461,7 +461,7 @@ abstract class JaxbWrapper {
         }
     }
 
-    final static class JaxbCommentWrapper extends JaxbWrapper implements Comment {
+    static final class JaxbCommentWrapper extends JaxbWrapper implements Comment {
     
         private final org.kie.remote.jaxb.gen.Comment comment;
     
@@ -491,7 +491,7 @@ abstract class JaxbWrapper {
         }
     }
 
-    final static class JaxbContentWrapper extends JaxbWrapper implements Content {
+    static final class JaxbContentWrapper extends JaxbWrapper implements Content {
 
         private final org.kie.remote.jaxb.gen.Content content;
 
@@ -512,7 +512,7 @@ abstract class JaxbWrapper {
        
     }
 
-    final static class JaxbI18NTextWrapper extends JaxbWrapper implements I18NText {
+    static final class JaxbI18NTextWrapper extends JaxbWrapper implements I18NText {
     
         private final org.kie.remote.jaxb.gen.I18NText i18nText;
     
@@ -537,7 +537,7 @@ abstract class JaxbWrapper {
         }
     }
 
-    final static class JaxbPeopleAssignmentsWrapper extends JaxbWrapper implements InternalPeopleAssignments {
+    static final class JaxbPeopleAssignmentsWrapper extends JaxbWrapper implements InternalPeopleAssignments {
     
         private final org.kie.remote.jaxb.gen.PeopleAssignments peopleAssignments;
     
@@ -610,7 +610,7 @@ abstract class JaxbWrapper {
     /**
      * Represents a {@link Group} instance
      */
-    final static class GroupWrapper extends JaxbWrapper implements Group {
+    static final class GroupWrapper extends JaxbWrapper implements Group {
         
         private final String id;
         public GroupWrapper(String id) {
@@ -627,7 +627,7 @@ abstract class JaxbWrapper {
     /**
      * Represents a {@link User} instance
      */
-    final static class UserWrapper extends JaxbWrapper implements User {
+    static final class UserWrapper extends JaxbWrapper implements User {
         
         private final String id;
         public UserWrapper(String id) {

--- a/kie-remote/kie-remote-common/src/main/java/org/kie/remote/common/rest/Base64Util.java
+++ b/kie-remote/kie-remote-common/src/main/java/org/kie/remote/common/rest/Base64Util.java
@@ -34,13 +34,13 @@ import java.io.UnsupportedEncodingException;
 public class Base64Util {
 
     /** The equals sign (=) as a byte. */
-    private final static byte EQUALS_SIGN = (byte) '=';
+    private static final byte EQUALS_SIGN = (byte) '=';
 
     /** Preferred encoding. */
-    private final static String PREFERRED_ENCODING = "US-ASCII";
+    private static final String PREFERRED_ENCODING = "US-ASCII";
 
     /** The 64 valid Base64 values. */
-    private final static byte[] _STANDARD_ALPHABET = { (byte) 'A', (byte) 'B', (byte) 'C', (byte) 'D', (byte) 'E', (byte) 'F',
+    private static final byte[] _STANDARD_ALPHABET = { (byte) 'A', (byte) 'B', (byte) 'C', (byte) 'D', (byte) 'E', (byte) 'F',
             (byte) 'G', (byte) 'H', (byte) 'I', (byte) 'J', (byte) 'K', (byte) 'L', (byte) 'M', (byte) 'N', (byte) 'O',
             (byte) 'P', (byte) 'Q', (byte) 'R', (byte) 'S', (byte) 'T', (byte) 'U', (byte) 'V', (byte) 'W', (byte) 'X',
             (byte) 'Y', (byte) 'Z', (byte) 'a', (byte) 'b', (byte) 'c', (byte) 'd', (byte) 'e', (byte) 'f', (byte) 'g',

--- a/kie-remote/kie-remote-common/src/main/java/org/kie/remote/common/rest/KieRemoteHttpRequest.java
+++ b/kie-remote/kie-remote-common/src/main/java/org/kie/remote/common/rest/KieRemoteHttpRequest.java
@@ -289,7 +289,7 @@ public class KieRemoteHttpRequest {
      *
      * @param <V>
      */
-    private static abstract class Operation<V> implements Callable<V> {
+    private abstract static class Operation<V> implements Callable<V> {
 
         /**
          * Run operation
@@ -335,7 +335,7 @@ public class KieRemoteHttpRequest {
      *
      * @param <V>
      */
-    private static abstract class CloseOperation<V> extends Operation<V> {
+    private abstract static class CloseOperation<V> extends Operation<V> {
 
         private final Closeable closeable;
 
@@ -373,7 +373,7 @@ public class KieRemoteHttpRequest {
      *
      * @param <V>
      */
-    private static abstract class FlushOperation<V> extends Operation<V> {
+    private abstract static class FlushOperation<V> extends Operation<V> {
 
         private final Flushable flushable;
 

--- a/kie-remote/kie-remote-jaxb/src/main/java/org/kie/services/client/serialization/JaxbSerializationProvider.java
+++ b/kie-remote/kie-remote-jaxb/src/main/java/org/kie/services/client/serialization/JaxbSerializationProvider.java
@@ -186,14 +186,14 @@ public abstract class JaxbSerializationProvider implements SerializationProvider
 
     // Other fields, methods, etc -------------------------------------------------------------------------------------------------
 
-    public final static int JMS_SERIALIZATION_TYPE = 0;
+    public static final int JMS_SERIALIZATION_TYPE = 0;
 
     @Override
     public int getSerializationType() {
        return JMS_SERIALIZATION_TYPE;
     }
 
-    public final static String EXECUTE_DEPLOYMENT_ID_HEADER = "Kie-Deployment-Id";
+    public static final String EXECUTE_DEPLOYMENT_ID_HEADER = "Kie-Deployment-Id";
 
     private boolean prettyPrint = false;
 

--- a/kie-remote/kie-remote-jaxb/src/main/java/org/kie/services/client/serialization/JsonSerializationProvider.java
+++ b/kie-remote/kie-remote-jaxb/src/main/java/org/kie/services/client/serialization/JsonSerializationProvider.java
@@ -23,7 +23,7 @@ import org.codehaus.jackson.map.ObjectMapper;
 
 public class JsonSerializationProvider implements SerializationProvider {
 
-    public final static int JMS_SERIALIZATION_TYPE = 1;
+    public static final int JMS_SERIALIZATION_TYPE = 1;
 
     private ObjectMapper mapper = new ObjectMapper();
    

--- a/kie-remote/kie-remote-jaxb/src/main/java/org/kie/services/client/serialization/jaxb/impl/runtime/JaxbCorrelationKeyFactory.java
+++ b/kie-remote/kie-remote-jaxb/src/main/java/org/kie/services/client/serialization/jaxb/impl/runtime/JaxbCorrelationKeyFactory.java
@@ -7,7 +7,7 @@ import org.kie.internal.process.CorrelationKeyFactory;
 
 public class JaxbCorrelationKeyFactory implements CorrelationKeyFactory {
 
-    private final static JaxbCorrelationKeyFactory _instance = new JaxbCorrelationKeyFactory();
+    private static final JaxbCorrelationKeyFactory _instance = new JaxbCorrelationKeyFactory();
    
     private JaxbCorrelationKeyFactory() { 
        // private constructor 

--- a/kie-remote/kie-remote-jaxb/src/main/java/org/kie/services/shared/ServicesVersion.java
+++ b/kie-remote/kie-remote-jaxb/src/main/java/org/kie/services/shared/ServicesVersion.java
@@ -18,6 +18,6 @@ package org.kie.services.shared;
 public class ServicesVersion {
 
     // Do not modify this: this is automatically incremented by the maven replacer plugin
-    public final static String VERSION = "7.0.0.1";
+    public static final String VERSION = "7.0.0.1";
     
 }

--- a/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/ResourceBase.java
+++ b/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/ResourceBase.java
@@ -282,9 +282,9 @@ public class ResourceBase {
         }
     }
 
-    private final static int MAX_LENGTH_INT = 9;
-    private final static int MAX_LENGTH_LONG = 18;
-    private final static int MAX_LENGTH_FLOAT = 10;
+    private static final int MAX_LENGTH_INT = 9;
+    private static final int MAX_LENGTH_LONG = 18;
+    private static final int MAX_LENGTH_FLOAT = 10;
 
     public static String BOOLEAN_REGEX ="^(true|false)";
     public static String LONG_INTEGER_REGEX ="^\\d+[li]?$";

--- a/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/jaxb/DynamicJaxbContext.java
+++ b/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/jaxb/DynamicJaxbContext.java
@@ -295,9 +295,9 @@ public class DynamicJaxbContext extends JAXBContext {
         }
     }
 
-    private final static String SMART_JAXB_CONTEXT_INIT_PROPERTY_NAME = "org.kie.remote.jaxb.smart.init";
-    private final static boolean smartJaxbContextInitialization;
-    private final static String EXPECTED_JAXB_CONTEXT_IMPL_CLASS = "com.sun.xml.bind.v2.runtime.JAXBContextImpl";
+    private static final String SMART_JAXB_CONTEXT_INIT_PROPERTY_NAME = "org.kie.remote.jaxb.smart.init";
+    private static final boolean smartJaxbContextInitialization;
+    private static final String EXPECTED_JAXB_CONTEXT_IMPL_CLASS = "com.sun.xml.bind.v2.runtime.JAXBContextImpl";
 
     // only use smart initialization if we're using the (default) JAXB RI
     static {

--- a/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/query/RemoteServicesAuditQueryCriteriaUtil.java
+++ b/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/query/RemoteServicesAuditQueryCriteriaUtil.java
@@ -26,7 +26,7 @@ public class RemoteServicesAuditQueryCriteriaUtil extends AuditQueryCriteriaUtil
 
     // Query Field Info -----------------------------------------------------------------------------------------------------------
 
-    public final static Map<Class, Map<String, Attribute>> criteriaAttributes
+    public static final Map<Class, Map<String, Attribute>> criteriaAttributes
         = RemoteServicesQueryData.criteriaAttributes;
 
     @Override

--- a/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/query/RemoteServicesQueryData.java
+++ b/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/query/RemoteServicesQueryData.java
@@ -24,7 +24,7 @@ public abstract class RemoteServicesQueryData {
 
     // Query Field Info -----------------------------------------------------------------------------------------------------------
 
-    final static Map<Class, Map<String, Attribute>> criteriaAttributes
+    static final Map<Class, Map<String, Attribute>> criteriaAttributes
         = new ConcurrentHashMap<Class, Map<String, Attribute>>();
     private static final AtomicBoolean criteriaAttributesInitialized = new AtomicBoolean(false);
 
@@ -124,12 +124,12 @@ public abstract class RemoteServicesQueryData {
         return true;
     }
 
-    public final static Set<String> procInstLogNeededCriterias = new CopyOnWriteArraySet<String>();
-    public final static Set<String> varInstLogNeededCriterias = new CopyOnWriteArraySet<String>();
-    public final static Set<String> taskNeededCriterias = new CopyOnWriteArraySet<String>();
+    public static final Set<String> procInstLogNeededCriterias = new CopyOnWriteArraySet<String>();
+    public static final Set<String> varInstLogNeededCriterias = new CopyOnWriteArraySet<String>();
+    public static final Set<String> taskNeededCriterias = new CopyOnWriteArraySet<String>();
 
-    public final static Set<String> taskSpecificCriterias = new CopyOnWriteArraySet<String>();
-    public final static Set<String> varInstLogSpecificCriterias = new CopyOnWriteArraySet<String>();
+    public static final Set<String> taskSpecificCriterias = new CopyOnWriteArraySet<String>();
+    public static final Set<String> varInstLogSpecificCriterias = new CopyOnWriteArraySet<String>();
 
     static {
 

--- a/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/query/RemoteServicesTaskQueryCriteriaUtil.java
+++ b/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/query/RemoteServicesTaskQueryCriteriaUtil.java
@@ -27,7 +27,7 @@ public class RemoteServicesTaskQueryCriteriaUtil extends TaskSummaryQueryCriteri
 
     // Query Field Info -----------------------------------------------------------------------------------------------------------
 
-    public final static Map<Class, Map<String, Attribute>> criteriaAttributes
+    public static final Map<Class, Map<String, Attribute>> criteriaAttributes
         = RemoteServicesQueryData.criteriaAttributes;
 
     @Override

--- a/kie-remote/kie-remote-ws/kie-remote-ws-impl/src/main/java/org/kie/services/remote/ws/deployment/DeploymentWebServiceImpl.java
+++ b/kie-remote/kie-remote-ws/kie-remote-ws-impl/src/main/java/org/kie/services/remote/ws/deployment/DeploymentWebServiceImpl.java
@@ -52,7 +52,7 @@ import org.kie.services.shared.ServicesVersion;
         targetNamespace = DeploymentWebServiceImpl.NAMESPACE)
 public class DeploymentWebServiceImpl extends ResourceBase implements DeploymentWebService {
 
-    final static String NAMESPACE = "http://services.remote.kie.org/" + ServicesVersion.VERSION + "/command";
+    static final String NAMESPACE = "http://services.remote.kie.org/" + ServicesVersion.VERSION + "/command";
 
     @Inject 
     private DeployResourceBase deployBase;

--- a/kie-remote/kie-remote-ws/kie-remote-ws-impl/src/main/java/org/kie/services/remote/ws/history/HistoryWebServiceImpl.java
+++ b/kie-remote/kie-remote-ws/kie-remote-ws-impl/src/main/java/org/kie/services/remote/ws/history/HistoryWebServiceImpl.java
@@ -40,7 +40,7 @@ import org.kie.services.shared.ServicesVersion;
         targetNamespace = HistoryWebServiceImpl.NAMESPACE)
 public class HistoryWebServiceImpl extends ResourceBase implements HistoryWebService {
 
-    final static String NAMESPACE = "http://services.remote.kie.org/" + ServicesVersion.VERSION + "/command";
+    static final String NAMESPACE = "http://services.remote.kie.org/" + ServicesVersion.VERSION + "/command";
 
     @Override
     public ProcessInstanceLogResponse findProcessInstanceLogs( HistoryInstanceLogRequest request ) throws HistoryWebServiceException {

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/KieServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/KieServicesClientImpl.java
@@ -292,7 +292,7 @@ public class KieServicesClientImpl extends AbstractKieServicesClientImpl impleme
     }
 
 
-    private synchronized static List<KieServicesClientBuilder> loadClientBuilders() {
+    private static synchronized List<KieServicesClientBuilder> loadClientBuilders() {
         List<KieServicesClientBuilder> builders = new ArrayList<KieServicesClientBuilder>();
         for (KieServicesClientBuilder builder : clientBuilders) {
             builders.add(builder);

--- a/kie-server-parent/kie-server-remote/kie-server-jms/src/main/java/org/kie/server/jms/KieServerMDB.java
+++ b/kie-server-parent/kie-server-remote/kie-server-jms/src/main/java/org/kie/server/jms/KieServerMDB.java
@@ -68,7 +68,7 @@ import static org.kie.server.api.jms.JMSConstants.*;
 public class KieServerMDB
         implements MessageListener {
 
-    private final static Logger logger = LoggerFactory.getLogger( KieServerMDB.class );
+    private static final Logger logger = LoggerFactory.getLogger( KieServerMDB.class );
 
     // Constants / properties
     private              String RESPONSE_QUEUE_NAME          = null;

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/config/TestConfig.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/config/TestConfig.java
@@ -365,7 +365,7 @@ public class TestConfig {
         }
     }
 
-    private static abstract class TestParameter<T> {
+    private abstract static class TestParameter<T> {
 
         private String key;
         private T defaultValue;

--- a/kie-spring/src/main/java/org/kie/spring/annotations/AnnotationsPostProcessor.java
+++ b/kie-spring/src/main/java/org/kie/spring/annotations/AnnotationsPostProcessor.java
@@ -55,7 +55,7 @@ class AnnotationsPostProcessor implements InstantiationAwareBeanPostProcessor,
 
     public static final String KIE_ANNOTATIONS_ARE_NOT_SUPPORTED_ON_STATIC_METHODS = "Kie Annotations are not supported on static methods";
     public static final String INJECTION_OF_KIE_DEPENDENCIES_FAILED = "Injection of kie dependencies failed";
-    private transient final Map<Class<?>, InjectionMetadata> injectionMetadataCache = new ConcurrentHashMap<Class<?>, InjectionMetadata>();
+    private final transient Map<Class<?>, InjectionMetadata> injectionMetadataCache = new ConcurrentHashMap<Class<?>, InjectionMetadata>();
     private int order = Ordered.LOWEST_PRECEDENCE - 4;
     private transient ListableBeanFactory beanFactory;
     private ReleaseId releaseId;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:ModifiersOrderCheck - Modifiers should be declared in the correct order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:ModifiersOrderCheck
Please let me know if you have any questions.
George Kankava