### PR TITLE
squid:S1155 - Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/jbpm-simulation/src/main/java/org/jbpm/simulation/converter/JSONPathFormatConverter.java
+++ b/jbpm-simulation/src/main/java/org/jbpm/simulation/converter/JSONPathFormatConverter.java
@@ -30,7 +30,7 @@ public class JSONPathFormatConverter implements PathFormatConverter<JSONObject> 
         JSONObject parent = new JSONObject();
         JSONObject paths = new JSONObject();
         try {
-            if(completePaths != null && completePaths.size() > 0) {
+            if(completePaths != null && !completePaths.isEmpty()) {
                 for(PathContext pc : completePaths) {
                     paths.put(pc.getPathId(), getPathFlowElementsAsString(pc.getPathElements()));
                 }
@@ -45,7 +45,7 @@ public class JSONPathFormatConverter implements PathFormatConverter<JSONObject> 
     
     private String getPathFlowElementsAsString(Set<FlowElement> flowElements) {
         String ret = "";
-        if(flowElements != null && flowElements.size() > 0) {
+        if(flowElements != null && !flowElements.isEmpty()) {
             for(FlowElement fe : flowElements) {
                 ret += fe.getId();
                 ret += "|";

--- a/jbpm-simulation/src/main/java/org/jbpm/simulation/converter/SimulationFilterPathFormatConverter.java
+++ b/jbpm-simulation/src/main/java/org/jbpm/simulation/converter/SimulationFilterPathFormatConverter.java
@@ -92,7 +92,7 @@ public class SimulationFilterPathFormatConverter implements
                   simPath.addBoundaryEventId(fe.getId());  
                 } else if (fe instanceof CatchEvent) {
                     CatchEvent act = (CatchEvent) fe;
-                    if(act.getIncoming() == null || act.getIncoming().size() == 0 && !isParentEventSubprocess(fe)) {
+                    if(act.getIncoming() == null || act.getIncoming().isEmpty() && !isParentEventSubprocess(fe)) {
                         String ref = processEventDefinitions(((CatchEvent) fe).getEventDefinitions());
                         simPath.setSignalName(ref);
                     }

--- a/jbpm-simulation/src/main/java/org/jbpm/simulation/handler/ActivityElementHandler.java
+++ b/jbpm-simulation/src/main/java/org/jbpm/simulation/handler/ActivityElementHandler.java
@@ -30,14 +30,14 @@ public class ActivityElementHandler extends MainElementHandler {
 
     public boolean handle(FlowElement element, PathContextManager manager) {
         List<SequenceFlow> outgoing = new ArrayList<SequenceFlow>(getOutgoing(element));
-        if (outgoing.size() == 0) {
+        if (outgoing.isEmpty()) {
             return false;
         }
         
         PathContext context = manager.getContextFromStack();
         
         List<BoundaryEvent> bEvents = ((Activity) element).getBoundaryEventRefs();
-        if (bEvents != null && bEvents.size() > 0) {
+        if (bEvents != null && !bEvents.isEmpty()) {
             boolean cancelActivity = false;
             for (BoundaryEvent bEvent : bEvents) {
 

--- a/jbpm-simulation/src/main/java/org/jbpm/simulation/handler/AdHocSubProcessElementHandler.java
+++ b/jbpm-simulation/src/main/java/org/jbpm/simulation/handler/AdHocSubProcessElementHandler.java
@@ -33,7 +33,7 @@ public class AdHocSubProcessElementHandler extends MainElementHandler {
         
         for (FlowElement fElement : flowElements) {
             if (fElement instanceof Activity) {
-                if (((Activity) fElement).getIncoming().size() == 0) {
+                if (((Activity) fElement).getIncoming().isEmpty()) {
                     
                     manager.cloneGiven(manager.getContextFromStack());
                     boolean canBeFinsihed = manager.getContextFromStack().isCanBeFinished();

--- a/jbpm-simulation/src/main/java/org/jbpm/simulation/handler/DefaultElementHandler.java
+++ b/jbpm-simulation/src/main/java/org/jbpm/simulation/handler/DefaultElementHandler.java
@@ -25,7 +25,7 @@ public class DefaultElementHandler extends MainElementHandler {
 
     public boolean handle(FlowElement element, PathContextManager manager) {
         List<SequenceFlow> outgoing = getOutgoing(element);
-        if (outgoing.size() == 0) {
+        if (outgoing.isEmpty()) {
             return false;
         }
         for (SequenceFlow seqFlow : outgoing) {

--- a/jbpm-simulation/src/main/java/org/jbpm/simulation/handler/EventElementHandler.java
+++ b/jbpm-simulation/src/main/java/org/jbpm/simulation/handler/EventElementHandler.java
@@ -32,7 +32,7 @@ public class EventElementHandler extends MainElementHandler {
     public boolean handle(FlowElement element, PathContextManager manager) {
         List<EventDefinition> throwDefinitions = getEventDefinitions(element);
     
-        if (throwDefinitions != null && throwDefinitions.size() > 0) {
+        if (throwDefinitions != null && !throwDefinitions.isEmpty()) {
             for (EventDefinition def : throwDefinitions) {
                 String key = "";
                 if (def instanceof SignalEventDefinition) {

--- a/jbpm-simulation/src/main/java/org/jbpm/simulation/handler/ThrowEventElementHandler.java
+++ b/jbpm-simulation/src/main/java/org/jbpm/simulation/handler/ThrowEventElementHandler.java
@@ -40,7 +40,7 @@ public class ThrowEventElementHandler extends DefaultElementHandler {
     public boolean handle(FlowElement element, PathContextManager manager) {
         List<EventDefinition> throwDefinitions = getEventDefinitions(element);
     
-        if (throwDefinitions != null && throwDefinitions.size() > 0) {
+        if (throwDefinitions != null && !throwDefinitions.isEmpty()) {
             for (EventDefinition def : throwDefinitions) {
                 String key = "";
                 if (def instanceof SignalEventDefinition) {

--- a/jbpm-simulation/src/main/java/org/jbpm/simulation/impl/BPMN2PathFinderImpl.java
+++ b/jbpm-simulation/src/main/java/org/jbpm/simulation/impl/BPMN2PathFinderImpl.java
@@ -160,13 +160,13 @@ public class BPMN2PathFinderImpl implements PathFinder {
                 processEventDefinitions(fElement, eventDefinitions, catchingEvents);
             } else if((fElement instanceof Activity) && BPMN2Utils.isContainerAdHoc(container)) {
                 Activity act = (Activity) fElement;
-                if(act.getIncoming() == null || act.getIncoming().size() == 0) {
+                if(act.getIncoming() == null || act.getIncoming().isEmpty()) {
                     triggerElements.add(0, fElement);
                 }
             } else if (fElement instanceof IntermediateCatchEvent) {
                 
                 IntermediateCatchEvent act = (IntermediateCatchEvent) fElement;
-                if(act.getIncoming() == null || act.getIncoming().size() == 0) {
+                if(act.getIncoming() == null || act.getIncoming().isEmpty()) {
                     triggerElements.add(0, fElement);
                 } 
                 

--- a/jbpm-simulation/src/main/java/org/jbpm/simulation/impl/BPMN2SimulationDataProvider.java
+++ b/jbpm-simulation/src/main/java/org/jbpm/simulation/impl/BPMN2SimulationDataProvider.java
@@ -289,7 +289,7 @@ public class BPMN2SimulationDataProvider implements SimulationDataProvider {
                 List<EventDefinition> defs = boundaryEvent.getEventDefinitions();
                 String eventDef = "";
 
-                if (defs != null && defs.size() > 0) {
+                if (defs != null && !defs.isEmpty()) {
                     eventDef = getEventDefinitionAsString(defs.get(0));
                 }
 
@@ -299,7 +299,7 @@ public class BPMN2SimulationDataProvider implements SimulationDataProvider {
                 List<EventDefinition> defs = boundaryEvent.getEventDefinitions();
                 String eventDef = "";
 
-                if (defs != null && defs.size() > 0) {
+                if (defs != null && !defs.isEmpty()) {
                     eventDef = getEventDefinitionAsString(defs.get(0));
                 }
                 nodeProperties.put("node.type", "IntermediateCatchEvent:"+eventDef);
@@ -308,7 +308,7 @@ public class BPMN2SimulationDataProvider implements SimulationDataProvider {
                 List<EventDefinition> defs = boundaryEvent.getEventDefinitions();
                 String eventDef = "";
 
-                if (defs != null && defs.size() > 0) {
+                if (defs != null && !defs.isEmpty()) {
                     eventDef = getEventDefinitionAsString(defs.get(0));
                 }
                 nodeProperties.put("node.type", "IntermediateThrowEvent:"+eventDef);
@@ -317,7 +317,7 @@ public class BPMN2SimulationDataProvider implements SimulationDataProvider {
                 List<EventDefinition> defs = boundaryEvent.getEventDefinitions();
                 String eventDef = "";
 
-                if (defs != null && defs.size() > 0) {
+                if (defs != null && !defs.isEmpty()) {
                     eventDef = getEventDefinitionAsString(defs.get(0));
                 }
                 nodeProperties.put("node.type", "StartEvent:"+eventDef);
@@ -326,7 +326,7 @@ public class BPMN2SimulationDataProvider implements SimulationDataProvider {
                 List<EventDefinition> defs = boundaryEvent.getEventDefinitions();
                 String eventDef = "";
 
-                if (defs != null && defs.size() > 0) {
+                if (defs != null && !defs.isEmpty()) {
                     eventDef = getEventDefinitionAsString(defs.get(0));
                 }
                 nodeProperties.put("node.type", "EndEvent:"+eventDef);
@@ -346,16 +346,16 @@ public class BPMN2SimulationDataProvider implements SimulationDataProvider {
     }
     
     private Scenario getDefaultScenario(Definitions def) {
-    	if(def.getRelationships() != null && def.getRelationships().size() > 0) {
+    	if(def.getRelationships() != null && !def.getRelationships().isEmpty()) {
         	// current support for single relationship
         	Relationship relationship = def.getRelationships().get(0);
         	for(ExtensionAttributeValue extattrval : relationship.getExtensionValues()) {
                 FeatureMap extensionElements = extattrval.getValue();
                 @SuppressWarnings("unchecked")
                 List<BPSimDataType> bpsimExtension = (List<BPSimDataType>) extensionElements.get(BpsimPackage.Literals.DOCUMENT_ROOT__BP_SIM_DATA, true);
-                if(bpsimExtension != null && bpsimExtension.size() > 0) {
+                if(bpsimExtension != null && !bpsimExtension.isEmpty()) {
                     BPSimDataType bpmsim = bpsimExtension.get(0);
-                	if(bpmsim.getScenario() != null && bpmsim.getScenario().size() > 0) {
+                	if(bpmsim.getScenario() != null && !bpmsim.getScenario().isEmpty()) {
                 		return bpmsim.getScenario().get(0);
                 	}
                 }

--- a/kie-aries-blueprint/src/main/java/org/kie/aries/blueprint/factorybeans/KieSessionFactoryBeanHelper.java
+++ b/kie-aries-blueprint/src/main/java/org/kie/aries/blueprint/factorybeans/KieSessionFactoryBeanHelper.java
@@ -30,7 +30,7 @@ import java.util.List;
 public class KieSessionFactoryBeanHelper {
 
     protected static void addListeners(KieRuntimeEventManager kieRuntimeEventManager, List<KieListenerAdaptor> listeners){
-        if (listeners == null || listeners.size() == 0){
+        if (listeners == null || listeners.isEmpty()){
             //do nothing
             return;
         }
@@ -47,7 +47,7 @@ public class KieSessionFactoryBeanHelper {
     }
 
     protected static void attachLoggers(KieRuntimeEventManager ksession, List<KieLoggerAdaptor> loggerAdaptors) {
-        if (loggerAdaptors != null && loggerAdaptors.size() > 0) {
+        if (loggerAdaptors != null && !loggerAdaptors.isEmpty()) {
             KieServices ks = KieServices.Factory.get();
             KieLoggers loggers = ks.getLoggers();
             for (KieLoggerAdaptor adaptor : loggerAdaptors) {

--- a/kie-aries-blueprint/src/main/java/org/kie/aries/blueprint/namespace/KieObjectsInjector.java
+++ b/kie-aries-blueprint/src/main/java/org/kie/aries/blueprint/namespace/KieObjectsInjector.java
@@ -100,7 +100,7 @@ public class KieObjectsInjector implements BeanProcessor {
 
     public void afterPropertiesSet(){
         log.debug(" :: Starting Blueprint KieObjectsInjector for kmodule ("+contextId+") :: ");
-        if ( resources == null || resources.size() == 0) {
+        if ( resources == null || resources.isEmpty()) {
             configFileURL = getClass().getResource("/");
             if (configFileURL == null) {
                 createOsgiKieModule();

--- a/kie-remote/kie-remote-client/src/main/java/org/kie/remote/client/internal/command/AbstractRemoteCommandObject.java
+++ b/kie-remote/kie-remote-client/src/main/java/org/kie/remote/client/internal/command/AbstractRemoteCommandObject.java
@@ -450,7 +450,7 @@ public abstract class AbstractRemoteCommandObject {
 
         if( cmdResponse != null ) {
             List<JaxbCommandResponse<?>> responses = cmdResponse.getResponses();
-            if( responses.size() == 0 ) {
+            if( responses.isEmpty() ) {
                 return null;
             } else if( responses.size() == 1 ) {
                 // The type information *should* come from the Command class -- but it's a jaxb-gen class,

--- a/kie-remote/kie-remote-client/src/main/java/org/kie/remote/client/internal/command/InternalJmsCommandHelper.java
+++ b/kie-remote/kie-remote-client/src/main/java/org/kie/remote/client/internal/command/InternalJmsCommandHelper.java
@@ -215,7 +215,7 @@ public class InternalJmsCommandHelper {
                     version, VERSION);
         }
         List<JaxbCommandResponse<?>> responses = cmdResponse.getResponses();
-        if( responses.size() > 0 ) {
+        if( !responses.isEmpty() ) {
             JaxbCommandResponse<?> response = responses.get(0);
             if( response instanceof JaxbExceptionResponse ) {
                 JaxbExceptionResponse exceptionResponse = (JaxbExceptionResponse) response;
@@ -224,7 +224,7 @@ public class InternalJmsCommandHelper {
                 return (T) response.getResult();
             }
         } else {
-            assert responses.size() == 0: "There should only be 1 response, not " + responses.size() + ", returned by a command!";
+            assert responses.isEmpty() : "There should only be 1 response, not " + responses.size() + ", returned by a command!";
             return null;
         }
     }

--- a/kie-remote/kie-remote-jaxb/src/main/java/org/kie/services/client/serialization/jaxb/impl/audit/JaxbHistoryLogList.java
+++ b/kie-remote/kie-remote-jaxb/src/main/java/org/kie/services/client/serialization/jaxb/impl/audit/JaxbHistoryLogList.java
@@ -84,7 +84,7 @@ public class JaxbHistoryLogList implements JaxbCommandResponse<List<Object>>, Ja
     
     private void initialize( List<? extends Object> logList ) { 
         this.historyLogList = new ArrayList<AbstractJaxbHistoryObject>();
-        if( logList == null || logList.size() == 0 ) { 
+        if( logList == null || logList.isEmpty() ) {
             return;
         }
         for( Object logObj : logList ) { 

--- a/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/jaxb/DynamicJaxbContext.java
+++ b/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/jaxb/DynamicJaxbContext.java
@@ -267,7 +267,7 @@ public class DynamicJaxbContext extends JAXBContext {
         // while we have no guarantees that JAXBContext instances are thread-safe,
         // the REST framework using the JAXBContext instance is responsible for that thread-safety
         // since it is caching the JAXBContext in any case..
-        if( depClasses == null || depClasses.size() == 0 ) {
+        if( depClasses == null || depClasses.isEmpty() ) {
             JAXBContext defaultJaxbContext = contextsCache.get(DEFAULT_JAXB_CONTEXT_ID);
             contextsCache.put(deploymentId, defaultJaxbContext);
             return;

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerAssert.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerAssert.java
@@ -45,7 +45,7 @@ public class KieServerAssert {
 
     public static void assertNullOrEmpty(String errorMessage, Collection<?> result ) {
         if (result != null) {
-            assertTrue(errorMessage, result.size() == 0);
+            assertTrue(errorMessage, result.isEmpty());
         }
     }
 

--- a/kie-spring/src/main/java/org/kie/spring/factorybeans/EnvironmentDefFactoryBean.java
+++ b/kie-spring/src/main/java/org/kie/spring/factorybeans/EnvironmentDefFactoryBean.java
@@ -187,7 +187,7 @@ public class EnvironmentDefFactoryBean implements
             environment.set(EnvironmentName.CALENDARS, calendars);
         }
 
-        if (objectMarshallersOrder != null && objectMarshallersOrder.size() > 0) {
+        if (objectMarshallersOrder != null && !objectMarshallersOrder.isEmpty()) {
             List<ObjectMarshallingStrategy> strategies = getStrategies();
             environment.set(EnvironmentName.OBJECT_MARSHALLING_STRATEGIES, strategies.toArray(new ObjectMarshallingStrategy[]{}));
         }

--- a/kie-spring/src/main/java/org/kie/spring/factorybeans/KSessionFactoryBean.java
+++ b/kie-spring/src/main/java/org/kie/spring/factorybeans/KSessionFactoryBean.java
@@ -244,7 +244,7 @@ public class KSessionFactoryBean
     }
 
     public void attachLoggers(KieRuntimeEventManager ksession) {
-        if (loggerAdaptors != null && loggerAdaptors.size() > 0) {
+        if (loggerAdaptors != null && !loggerAdaptors.isEmpty()) {
             KieServices ks = KieServices.Factory.get();
             KieLoggers loggers = ks.getLoggers();
             for (LoggerAdaptor adaptor : loggerAdaptors) {

--- a/kie-spring/src/main/java/org/kie/spring/namespace/KBaseDefinitionParser.java
+++ b/kie-spring/src/main/java/org/kie/spring/namespace/KBaseDefinitionParser.java
@@ -61,7 +61,7 @@ public class KBaseDefinitionParser extends AbstractBeanDefinitionParser {
 
         element.setAttribute("name", id);
         List<Element> ksessionElements = DomUtils.getChildElementsByTagName(element, "ksession");
-        if (ksessionElements != null && ksessionElements.size() > 0) {
+        if (ksessionElements != null && !ksessionElements.isEmpty()) {
             for (Element kbaseElement : ksessionElements){
                 BeanDefinitionHolder obj = (BeanDefinitionHolder) parserContext.getDelegate().parsePropertySubElement(kbaseElement, null);
                 obj.getBeanDefinition().getPropertyValues().addPropertyValue("kBaseName", id);

--- a/kie-spring/src/main/java/org/kie/spring/namespace/KModuleDefinitionParser.java
+++ b/kie-spring/src/main/java/org/kie/spring/namespace/KModuleDefinitionParser.java
@@ -48,7 +48,7 @@ public class KModuleDefinitionParser extends AbstractBeanDefinitionParser {
         factory.addPropertyValue(ATTRIBUTE_ID, id);
         List<Element> kbaseElements = DomUtils.getChildElementsByTagName(element, "kbase");
         AbstractBeanDefinition beanDefinition = factory.getBeanDefinition();
-        if (kbaseElements != null && kbaseElements.size() > 0) {
+        if (kbaseElements != null && !kbaseElements.isEmpty()) {
             for (Element kbaseElement : kbaseElements){
                 kbaseElement.setAttribute("id", kbaseElement.getAttribute("name"));
                 BeanDefinitionHolder obj = (BeanDefinitionHolder) parserContext.getDelegate().parsePropertySubElement(kbaseElement, null, null);

--- a/kie-spring/src/main/java/org/kie/spring/namespace/LoggerUtil.java
+++ b/kie-spring/src/main/java/org/kie/spring/namespace/LoggerUtil.java
@@ -45,7 +45,7 @@ public class LoggerUtil {
             parserContext.getDelegate().parsePropertySubElement(consoleLoggerElement, null, null);
             loggerAdaptors.add(new RuntimeBeanReference(id));
         }
-        if (loggerAdaptors.size() > 0) {
+        if (!loggerAdaptors.isEmpty()) {
             factory.addPropertyValue("knowledgeRuntimeLoggers", loggerAdaptors);
         }
     }

--- a/kie-spring/src/main/java/org/kie/spring/persistence/HumanTaskSpringTransactionManager.java
+++ b/kie-spring/src/main/java/org/kie/spring/persistence/HumanTaskSpringTransactionManager.java
@@ -93,7 +93,7 @@ public class HumanTaskSpringTransactionManager implements TransactionManager {
             TransactionStatus transaction = null;
             boolean commitNewTransaction = false;
             try {
-                if (currentTransaction.size() == 0) {
+                if (currentTransaction.isEmpty()) {
                     transaction = ptm.getTransaction(td);
                     currentTransaction.push(transaction);
                     commitNewTransaction = true;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
George Kankava