### PR TITLE
DROOLS-1224 - Not able to update kie-server container version using R…

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/CommandScript.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/CommandScript.java
@@ -52,6 +52,7 @@ public class CommandScript implements Serializable {
             @XmlElement(name = "update-release-id", type = UpdateReleaseIdCommand.class),
             @XmlElement(name = "call-container", type = CallContainerCommand.class),
             @XmlElement(name = "descriptor-command", type = DescriptorCommand.class),
+            @XmlElement(name = "get-server-state", type = GetServerStateCommand.class),
 
             // TODO can this be added somewhere else? if not here JAXRS cannot deserialize content
             @XmlElement(name = "kie-server-config", type = KieServerConfig.class),

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/GetServerStateCommand.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/GetServerStateCommand.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.api.commands;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import org.kie.server.api.model.KieServerCommand;
+
+@XmlRootElement(name="get-server-state")
+@XStreamAlias( "get-server-state" )
+@XmlAccessorType(XmlAccessType.NONE)
+public class GetServerStateCommand implements KieServerCommand {
+    private static final long serialVersionUID = -1803374525440231478L;
+
+    public GetServerStateCommand() {
+        super();
+    }
+    
+}

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/jaxb/JaxbMarshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/jaxb/JaxbMarshaller.java
@@ -51,6 +51,7 @@ import org.kie.server.api.commands.DisposeContainerCommand;
 import org.kie.server.api.commands.GetContainerInfoCommand;
 import org.kie.server.api.commands.GetScannerInfoCommand;
 import org.kie.server.api.commands.GetServerInfoCommand;
+import org.kie.server.api.commands.GetServerStateCommand;
 import org.kie.server.api.commands.ListContainersCommand;
 import org.kie.server.api.commands.UpdateReleaseIdCommand;
 import org.kie.server.api.commands.UpdateScannerCommand;
@@ -65,6 +66,7 @@ import org.kie.server.api.model.KieContainerStatus;
 import org.kie.server.api.model.KieServerConfig;
 import org.kie.server.api.model.KieServerConfigItem;
 import org.kie.server.api.model.KieServerInfo;
+import org.kie.server.api.model.KieServerStateInfo;
 import org.kie.server.api.model.Message;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
@@ -129,6 +131,7 @@ public class JaxbMarshaller implements Marshaller {
                 UpdateScannerCommand.class,
                 UpdateReleaseIdCommand.class,
                 DescriptorCommand.class,
+                GetServerStateCommand.class,
 
                 KieContainerResource.class,
                 KieContainerResourceList.class,
@@ -137,6 +140,7 @@ public class JaxbMarshaller implements Marshaller {
                 ReleaseId.class,
                 ServiceResponse.class,
                 ServiceResponsesList.class,
+                KieServerStateInfo.class,
 
                 BatchExecutionCommandImpl.class,
                 ExecutionResultImpl.class,

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/KieServerStateInfo.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/KieServerStateInfo.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.api.model;
+
+import java.util.HashSet;
+import java.util.Set;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlRootElement(name="kie-server-state-info")
+@XStreamAlias( "kie-server-state-info" )
+public class KieServerStateInfo {
+
+    @XmlElement(name="controller")
+    private Set<String> controllers = new HashSet<String>();
+
+    @XmlElement(name="config")
+    private KieServerConfig configuration;
+
+    @XmlElement(name="containers")
+    private Set<KieContainerResource> containers = new HashSet<KieContainerResource>();
+
+    public KieServerStateInfo() {
+
+    }
+
+    public KieServerStateInfo(Set<String> controllers, KieServerConfig configuration, Set<KieContainerResource> containers) {
+        this.controllers = controllers;
+        this.configuration = configuration;
+        this.containers = containers;
+    }
+
+    public Set<String> getControllers() {
+        return controllers;
+    }
+
+    public void setControllers(Set<String> controllers) {
+        this.controllers = controllers;
+    }
+
+    public KieServerConfig getConfiguration() {
+        return configuration;
+    }
+
+    public void setConfiguration(KieServerConfig configuration) {
+        this.configuration = configuration;
+    }
+
+    public Set<KieContainerResource> getContainers() {
+        return containers;
+    }
+
+    public void setContainers(Set<KieContainerResource> containers) {
+        this.containers = containers;
+    }
+}

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/ServiceResponse.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/ServiceResponse.java
@@ -85,6 +85,7 @@ public class ServiceResponse<T> {
             @XmlElement(name = "kie-containers", type = KieContainerResourceList.class),
             @XmlElement(name = "kie-scanner", type = KieScannerResource.class),
             @XmlElement(name = "release-id", type = ReleaseId.class),
+            @XmlElement(name = "kie-server-state-info", type = KieServerStateInfo.class),
             // definition model
             @XmlElement(name = "process-associated-entities", type = AssociatedEntitiesDefinition.class),
             @XmlElement(name = "process-definition", type = ProcessDefinition.class),

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/KieServicesClient.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/KieServicesClient.java
@@ -22,6 +22,7 @@ import org.kie.server.api.model.KieContainerResourceList;
 import org.kie.server.api.model.KieScannerResource;
 import org.kie.server.api.model.KieServerConfig;
 import org.kie.server.api.model.KieServerInfo;
+import org.kie.server.api.model.KieServerStateInfo;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.api.model.ServiceResponsesList;
@@ -47,6 +48,8 @@ public interface KieServicesClient {
     ServiceResponse<KieScannerResource> updateScanner(String id, KieScannerResource resource);
 
     ServiceResponse<ReleaseId> updateReleaseId(String id, ReleaseId releaseId);
+
+    ServiceResponse<KieServerStateInfo> getServerState();
 
 
     // for backward compatibility reason

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/KieServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/KieServicesClientImpl.java
@@ -30,6 +30,7 @@ import org.kie.server.api.commands.DisposeContainerCommand;
 import org.kie.server.api.commands.GetContainerInfoCommand;
 import org.kie.server.api.commands.GetScannerInfoCommand;
 import org.kie.server.api.commands.GetServerInfoCommand;
+import org.kie.server.api.commands.GetServerStateCommand;
 import org.kie.server.api.commands.ListContainersCommand;
 import org.kie.server.api.commands.UpdateReleaseIdCommand;
 import org.kie.server.api.commands.UpdateScannerCommand;
@@ -38,6 +39,7 @@ import org.kie.server.api.model.KieContainerResourceList;
 import org.kie.server.api.model.KieScannerResource;
 import org.kie.server.api.model.KieServerCommand;
 import org.kie.server.api.model.KieServerInfo;
+import org.kie.server.api.model.KieServerStateInfo;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.api.model.ServiceResponsesList;
@@ -219,6 +221,16 @@ public class KieServicesClientImpl extends AbstractKieServicesClientImpl impleme
         } else {
             CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand) new UpdateReleaseIdCommand( id, releaseId ) ) );
             return (ServiceResponse<ReleaseId>) executeJmsCommand( script, null, null, id ).getResponses().get( 0 );
+        }
+    }
+
+    @Override
+    public ServiceResponse<KieServerStateInfo> getServerState() {
+        if( config.isRest() ) {
+            return makeHttpGetRequestAndCreateServiceResponse(loadBalancer.getUrl() + "/state", KieServerStateInfo.class);
+        } else {
+            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand) new GetServerStateCommand() ) );
+            return (ServiceResponse<KieServerStateInfo>) executeJmsCommand( script).getResponses().get( 0 );
         }
     }
 

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/main/java/org/kie/server/remote/rest/common/resource/KieServerRestImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/main/java/org/kie/server/remote/rest/common/resource/KieServerRestImpl.java
@@ -154,6 +154,11 @@ public class KieServerRestImpl {
         return createCorrectVariant(server.updateContainerReleaseId(id, releaseId), headers, conversationIdHeader);
     }
 
-
+    @GET
+    @Path("state")
+    @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    public Response getServerState(@Context HttpHeaders headers) {
+        return createCorrectVariant(server.getServerState(), headers);
+    }
 
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieContainerCommandServiceImpl.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieContainerCommandServiceImpl.java
@@ -35,6 +35,7 @@ import org.kie.server.api.commands.DisposeContainerCommand;
 import org.kie.server.api.commands.GetContainerInfoCommand;
 import org.kie.server.api.commands.GetScannerInfoCommand;
 import org.kie.server.api.commands.GetServerInfoCommand;
+import org.kie.server.api.commands.GetServerStateCommand;
 import org.kie.server.api.commands.ListContainersCommand;
 import org.kie.server.api.commands.UpdateReleaseIdCommand;
 import org.kie.server.api.commands.UpdateScannerCommand;
@@ -153,6 +154,8 @@ public class KieContainerCommandServiceImpl implements KieContainerCommandServic
                     responses.add(this.kieServer.updateScanner(((UpdateScannerCommand) command).getContainerId(), ((UpdateScannerCommand) command).getScanner()));
                 } else if (command instanceof UpdateReleaseIdCommand) {
                     responses.add(this.kieServer.updateContainerReleaseId(((UpdateReleaseIdCommand) command).getContainerId(), ((UpdateReleaseIdCommand) command).getReleaseId()));
+                } else if (command instanceof GetServerStateCommand) {
+                    responses.add(this.kieServer.getServerState());
                 }
             }
         }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/KieServerContainerCRUDIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/KieServerContainerCRUDIntegrationTest.java
@@ -16,6 +16,7 @@
 package org.kie.server.integrationtests.common;
 
 import java.util.List;
+import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -24,6 +25,7 @@ import org.junit.experimental.categories.Category;
 import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.KieContainerResourceList;
 import org.kie.server.api.model.KieContainerStatus;
+import org.kie.server.api.model.KieServerStateInfo;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.integrationtests.category.Smoke;
@@ -153,6 +155,33 @@ public class KieServerContainerCRUDIntegrationTest extends RestJmsSharedBaseInte
         ServiceResponse<Void> disposeReply = client.disposeContainer("update-releaseId");
         Assert.assertEquals(ServiceResponse.ResponseType.SUCCESS, disposeReply.getType());
 
+    }
+
+    @Test
+    public void testUpdateReleaseIdForExistingContainerAndCheckServerState() throws Exception {
+        client.createContainer("update-releaseId", new KieContainerResource("update-releaseId", releaseId1));
+
+        ServiceResponse<ReleaseId> reply = client.updateReleaseId("update-releaseId", releaseId2);
+        Assert.assertEquals(ServiceResponse.ResponseType.SUCCESS, reply.getType());
+        Assert.assertEquals(releaseId2, reply.getResult());
+
+        ServiceResponse<KieServerStateInfo> currentServerStateReply = client.getServerState();
+        Assert.assertEquals(ServiceResponse.ResponseType.SUCCESS, currentServerStateReply.getType());
+
+        KieServerStateInfo currentServerState = currentServerStateReply.getResult();
+        Assert.assertNotNull(currentServerState);
+
+        Set<KieContainerResource> containers = currentServerState.getContainers();
+        Assert.assertEquals(1, containers.size());
+
+        KieContainerResource container = containers.iterator().next();
+        Assert.assertNotNull(container);
+
+        Assert.assertEquals(releaseId2, container.getReleaseId());
+        Assert.assertEquals(releaseId2, container.getResolvedReleaseId());
+
+        ServiceResponse<Void> disposeReply = client.disposeContainer("update-releaseId");
+        Assert.assertEquals(ServiceResponse.ResponseType.SUCCESS, disposeReply.getType());
     }
 
     private void assertContainsContainer(List<KieContainerResource> containers, String expectedContainerId) {


### PR DESCRIPTION
…EAT API

@etirelli do you mind taking a look?

In addition to the fix of the upgrade of container I added new endpoint that allows to get the current state of the server - like the one stored in xml. I believe it makes sense to be able to easily get the current state (especially for unmanaged but for managed could be good as well used for verification). And that was the only way I could test it :) 