### PR TITLE
[6.3.x] JBPM-5191 - Task properties doesn't include values - only data types

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/ProcessDefinitionIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/ProcessDefinitionIntegrationTest.java
@@ -226,10 +226,10 @@ public class ProcessDefinitionIntegrationTest extends JbpmKieServerBaseIntegrati
 
         assertNotNull(task);
         assertEquals("Evaluate items", task.getName());
-        assertNull(task.getComment());
-        assertNull(task.getCreatedBy());
+        assertEquals("", task.getComment());
+        assertEquals("", task.getCreatedBy());
         assertEquals(0, task.getPriority().intValue());
-        assertEquals(false, task.isSkippable());
+        assertEquals(true, task.isSkippable());
 
         // assert associated entities - users and groups
         String[] evaluateItemsEntities = task.getAssociatedEntities();


### PR DESCRIPTION
test alignment for https://github.com/droolsjbpm/jbpm/pull/499