### PR TITLE
kie-server-tests: move container creation to @BeforeClass

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/DeploymentDescriptorIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/DeploymentDescriptorIntegrationTest.java
@@ -28,7 +28,6 @@ import org.kie.api.KieServices;
 import org.kie.api.command.BatchExecutionCommand;
 import org.kie.api.command.Command;
 import org.kie.api.runtime.ExecutionResults;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.integrationtests.shared.KieServerAssert;
@@ -53,6 +52,9 @@ public class DeploymentDescriptorIntegrationTest extends JbpmKieServerBaseIntegr
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/deployment-descriptor-project").getFile());
 
         kieContainer = KieServices.Factory.get().newKieContainer(releaseId);
+
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
     }
 
     @Override
@@ -62,8 +64,6 @@ public class DeploymentDescriptorIntegrationTest extends JbpmKieServerBaseIntegr
 
     @Test
     public void testGlobalVariableFromDeploymentDescriptor() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         List<Command<?>> commands = new ArrayList<Command<?>>();
         BatchExecutionCommand executionCommand = commandsFactory.newBatchExecution(commands, CONTAINER_ID);
 
@@ -84,8 +84,6 @@ public class DeploymentDescriptorIntegrationTest extends JbpmKieServerBaseIntegr
     public void testPerRequestRuntimeStrategy() throws Exception {
         String personOutIdentifier = "personOut";
         String personName = USER_YODA;
-
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
 
         List<Command<?>> commands = new ArrayList<Command<?>>();
         BatchExecutionCommand executionCommand = commandsFactory.newBatchExecution(commands, CONTAINER_ID);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/FormServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/FormServiceIntegrationTest.java
@@ -19,13 +19,11 @@ import java.util.List;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.instance.TaskSummary;
 import org.kie.server.client.KieServicesException;
 
 import static org.junit.Assert.*;
-import org.kie.server.integrationtests.shared.KieServerAssert;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 
 public class FormServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest {
@@ -43,13 +41,12 @@ public class FormServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
         KieServerDeployer.buildAndDeployCommonMavenParent();
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project").getFile());
 
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
     }
 
     @Test
     public void testGetProcessFormViaUIClientTest() throws Exception {
-        KieContainerResource resource = new KieContainerResource(CONTAINER_ID, releaseId);
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, resource));
-
         String result = uiServicesClient.getProcessForm(CONTAINER_ID, HIRING_PROCESS_ID, "en");
         logger.debug("Form content is '{}'", result);
         assertNotNull(result);
@@ -58,17 +55,11 @@ public class FormServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
 
     @Test(expected = KieServicesException.class)
     public void testGetProcessNotExistingFormViaUIClientTest() throws Exception {
-        KieContainerResource resource = new KieContainerResource(CONTAINER_ID, releaseId);
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, resource));
-
         uiServicesClient.getProcessForm(CONTAINER_ID, "not-existing", "en");
     }
 
     @Test
     public void testGetTaskFormViaUIClientTest() throws Exception {
-        KieContainerResource resource = new KieContainerResource(CONTAINER_ID, releaseId);
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, resource));
-
         long processInstanceId = processClient.startProcess(CONTAINER_ID, HIRING_PROCESS_ID);
         assertTrue(processInstanceId > 0);
         try {
@@ -89,17 +80,11 @@ public class FormServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
 
     @Test(expected = KieServicesException.class)
     public void testGetTaskNotExistingFormViaUIClientTest() throws Exception {
-        KieContainerResource resource = new KieContainerResource(CONTAINER_ID, releaseId);
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, resource));
-
         uiServicesClient.getTaskForm(CONTAINER_ID, 9999l, "en");
     }
 
     @Test
     public void testGetProcessFormInPackageViaUIClientTest() throws Exception {
-        KieContainerResource resource = new KieContainerResource(CONTAINER_ID, releaseId);
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, resource));
-
         String result = uiServicesClient.getProcessForm(CONTAINER_ID, HIRING_2_PROCESS_ID, "en");
         logger.debug("Form content is '{}'", result);
         assertNotNull(result);
@@ -108,9 +93,6 @@ public class FormServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
 
     @Test
     public void testGetTaskFormInPackageViaUIClientTest() throws Exception {
-        KieContainerResource resource = new KieContainerResource(CONTAINER_ID, releaseId);
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, resource));
-
         long processInstanceId = processClient.startProcess(CONTAINER_ID, HIRING_2_PROCESS_ID);
         assertTrue(processInstanceId > 0);
         try {

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/ImageServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/ImageServiceIntegrationTest.java
@@ -17,12 +17,10 @@ package org.kie.server.integrationtests.jbpm;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.client.KieServicesException;
 
 import static org.junit.Assert.*;
-import org.kie.server.integrationtests.shared.KieServerAssert;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 
 public class ImageServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest {
@@ -40,13 +38,12 @@ public class ImageServiceIntegrationTest extends JbpmKieServerBaseIntegrationTes
         KieServerDeployer.buildAndDeployCommonMavenParent();
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project").getFile());
 
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
     }
 
     @Test
     public void testGetProcessImageViaUIClientTest() throws Exception {
-        KieContainerResource resource = new KieContainerResource(CONTAINER_ID, releaseId);
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, resource));
-
         String result = uiServicesClient.getProcessImage(CONTAINER_ID, HIRING_PROCESS_ID);
         logger.debug("Image content is '{}'", result);
         assertNotNull(result);
@@ -55,17 +52,11 @@ public class ImageServiceIntegrationTest extends JbpmKieServerBaseIntegrationTes
 
     @Test(expected = KieServicesException.class)
     public void testGetProcessNotExistingImageViaUIClientTest() throws Exception {
-        KieContainerResource resource = new KieContainerResource(CONTAINER_ID, releaseId);
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, resource));
-
         uiServicesClient.getProcessImage(CONTAINER_ID, "not-existing");
     }
 
     @Test
     public void testGetProcessInstanceImageViaUIClientTest() throws Exception {
-        KieContainerResource resource = new KieContainerResource(CONTAINER_ID, releaseId);
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, resource));
-
         long processInstanceId = processClient.startProcess(CONTAINER_ID, HIRING_PROCESS_ID);
         assertTrue(processInstanceId > 0);
         try {
@@ -80,17 +71,11 @@ public class ImageServiceIntegrationTest extends JbpmKieServerBaseIntegrationTes
 
     @Test(expected = KieServicesException.class)
     public void testGetProcessInstanceNotExistingImageViaUIClientTest() throws Exception {
-        KieContainerResource resource = new KieContainerResource(CONTAINER_ID, releaseId);
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, resource));
-
         uiServicesClient.getProcessInstanceImage(CONTAINER_ID, 9999l);
     }
 
     @Test
     public void testGetProcessImageInPackageViaUIClientTest() throws Exception {
-        KieContainerResource resource = new KieContainerResource(CONTAINER_ID, releaseId);
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, resource));
-
         String result = uiServicesClient.getProcessImage(CONTAINER_ID, HIRING_2_PROCESS_ID);
         logger.debug("Image content is '{}'", result);
         assertNotNull(result);
@@ -99,9 +84,6 @@ public class ImageServiceIntegrationTest extends JbpmKieServerBaseIntegrationTes
 
     @Test
     public void testGetProcessInstanceImageInPackageViaUIClientTest() throws Exception {
-        KieContainerResource resource = new KieContainerResource(CONTAINER_ID, releaseId);
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, resource));
-
         long processInstanceId = processClient.startProcess(CONTAINER_ID, HIRING_2_PROCESS_ID);
         assertTrue(processInstanceId > 0);
         try {

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/JobServiceJmsIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/JobServiceJmsIntegrationTest.java
@@ -24,46 +24,25 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Assume;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.kie.api.KieServices;
 import org.kie.internal.executor.api.STATUS;
-import org.kie.server.api.model.KieContainerResource;
-import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.instance.JobRequestInstance;
 import org.kie.server.api.model.instance.RequestInfoInstance;
 import org.kie.server.integrationtests.category.JMSOnly;
 import org.kie.server.integrationtests.config.TestConfig;
-import org.kie.server.integrationtests.shared.KieServerAssert;
-import org.kie.server.integrationtests.shared.KieServerDeployer;
 import org.kie.server.integrationtests.shared.KieServerSynchronization;
 
 @Category(JMSOnly.class)
 public class JobServiceJmsIntegrationTest extends JbpmKieServerBaseIntegrationTest {
 
-    private static ReleaseId releaseId = new ReleaseId("org.kie.server.testing", "definition-project",
-            "1.0.0.Final");
-
     private static final long NUMBER_OF_JOBS = 10;
     private static final long MAXIMUM_PROCESSING_TIME = 20000;
-    private static final String CONTAINER_ID = "definition-project";
-
-    @BeforeClass
-    public static void buildAndDeployArtifacts() {
-
-        KieServerDeployer.buildAndDeployCommonMavenParent();
-        KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project").getFile());
-
-        kieContainer = KieServices.Factory.get().newKieContainer(releaseId);
-    }
 
     @Test
     public void testScheduleSeveralJobs() throws Exception {
         // Test is using JMS, isn't available for local execution.
         Assume.assumeFalse(TestConfig.isLocalServer());
-
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
 
         String businessKey = "test key";
         String command = "org.jbpm.executor.commands.PrintOutCommand";

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/PerProcessInstanceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/PerProcessInstanceIntegrationTest.java
@@ -29,7 +29,6 @@ import org.kie.api.KieServices;
 import org.kie.api.command.BatchExecutionCommand;
 import org.kie.api.command.Command;
 import org.kie.api.runtime.ExecutionResults;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.integrationtests.shared.KieServerAssert;
@@ -57,6 +56,9 @@ public class PerProcessInstanceIntegrationTest extends JbpmKieServerBaseIntegrat
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/per-process-instance-project").getFile());
 
         kieContainer = KieServices.Factory.get().newKieContainer(releaseId);
+
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
     }
 
     @Override
@@ -66,8 +68,6 @@ public class PerProcessInstanceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testProcessWithBusinessRuleTask() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Long processInstanceId1 = processClient.startProcess(CONTAINER_ID, PROCESS_ID);
         assertNotNull(processInstanceId1);
         assertTrue(processInstanceId1.longValue() > 0);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/RuleRelatedProcessIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/RuleRelatedProcessIntegrationTest.java
@@ -26,13 +26,11 @@ import org.kie.api.KieServices;
 import org.kie.api.command.BatchExecutionCommand;
 import org.kie.api.command.Command;
 import org.kie.api.runtime.ExecutionResults;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.api.model.instance.TaskSummary;
 
 import static org.junit.Assert.*;
-import org.kie.server.integrationtests.shared.KieServerAssert;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 
 
@@ -52,6 +50,9 @@ public class RuleRelatedProcessIntegrationTest extends JbpmKieServerBaseIntegrat
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project").getFile());
 
         kieContainer = KieServices.Factory.get().newKieContainer(releaseId);
+
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
     }
 
     @Override
@@ -61,7 +62,6 @@ public class RuleRelatedProcessIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testProcessWithBusinessRuleTask() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, "business-rule-task");
         assertNotNull(processInstanceId);
         assertTrue(processInstanceId.longValue() > 0);
@@ -133,8 +133,6 @@ public class RuleRelatedProcessIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testProcessWithConditionalEvent() throws Exception {
-
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, "conditionalevent");
         assertNotNull(processInstanceId);
         assertTrue(processInstanceId.longValue() > 0);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/rest/FormServiceRestOnlyIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/rest/FormServiceRestOnlyIntegrationTest.java
@@ -33,16 +33,13 @@ import org.junit.Test;
 import org.junit.rules.ExternalResource;
 import org.kie.server.api.marshalling.Marshaller;
 import org.kie.server.api.marshalling.MarshallerFactory;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.instance.TaskSummary;
 import org.kie.server.api.model.instance.TaskSummaryList;
 import org.kie.server.api.model.type.JaxbLong;
 import org.kie.server.api.rest.RestURI;
-import org.kie.server.client.KieServicesConfiguration;
 import org.kie.server.integrationtests.config.TestConfig;
 import org.kie.server.integrationtests.jbpm.DBExternalResource;
-import org.kie.server.integrationtests.shared.KieServerAssert;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 import org.kie.server.integrationtests.shared.basetests.RestOnlyBaseIntegrationTest;
 
@@ -65,11 +62,8 @@ public class FormServiceRestOnlyIntegrationTest extends RestOnlyBaseIntegrationT
         KieServerDeployer.buildAndDeployCommonMavenParent();
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project").getFile());
 
-    }
-
-    @Override
-    protected void additionalConfiguration(KieServicesConfiguration configuration) {
-        configuration.setTimeout(30000);
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
     }
 
     @Before
@@ -87,11 +81,8 @@ public class FormServiceRestOnlyIntegrationTest extends RestOnlyBaseIntegrationT
 
     @Test
     public void testGetProcessFormTest() throws Exception {
-        KieContainerResource resource = new KieContainerResource(CONTAINER_ID, releaseId);
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, resource));
-
         Map<String, Object> valuesMap = new HashMap<String, Object>();
-        valuesMap.put(RestURI.CONTAINER_ID, resource.getContainerId());
+        valuesMap.put(RestURI.CONTAINER_ID, CONTAINER_ID);
         valuesMap.put(RestURI.PROCESS_ID, HIRING_PROCESS_ID);
 
         WebTarget clientRequest = newRequest(build(TestConfig.getKieServerHttpUrl(), FORM_URI + "/" + PROCESS_FORM_GET_URI, valuesMap));
@@ -108,11 +99,8 @@ public class FormServiceRestOnlyIntegrationTest extends RestOnlyBaseIntegrationT
 
     @Test
     public void testGetTaskFormTest() throws Exception {
-        KieContainerResource resource = new KieContainerResource(CONTAINER_ID, releaseId);
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, resource));
-
         Map<String, Object> valuesMap = new HashMap<String, Object>();
-        valuesMap.put(RestURI.CONTAINER_ID, resource.getContainerId());
+        valuesMap.put(RestURI.CONTAINER_ID, CONTAINER_ID);
         valuesMap.put(RestURI.PROCESS_ID, HIRING_PROCESS_ID);
 
         Marshaller marshaller = MarshallerFactory.getMarshaller(marshallingFormat, ClassLoader.getSystemClassLoader());
@@ -172,11 +160,8 @@ public class FormServiceRestOnlyIntegrationTest extends RestOnlyBaseIntegrationT
 
     @Test
     public void testGetProcessDoesNotExistFormTest() throws Exception {
-        KieContainerResource resource = new KieContainerResource(CONTAINER_ID, releaseId);
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, resource));
-
         Map<String, Object> valuesMap = new HashMap<String, Object>();
-        valuesMap.put(RestURI.CONTAINER_ID, resource.getContainerId());
+        valuesMap.put(RestURI.CONTAINER_ID, CONTAINER_ID);
         valuesMap.put(RestURI.PROCESS_ID, "not-existing");
         valuesMap.put(RestURI.TASK_INSTANCE_ID, 99999);
 
@@ -189,11 +174,8 @@ public class FormServiceRestOnlyIntegrationTest extends RestOnlyBaseIntegrationT
 
     @Test
     public void testGetTaskDoesNotExistFormTest() throws Exception {
-        KieContainerResource resource = new KieContainerResource(CONTAINER_ID, releaseId);
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, resource));
-
         Map<String, Object> valuesMap = new HashMap<String, Object>();
-        valuesMap.put(RestURI.CONTAINER_ID, resource.getContainerId());
+        valuesMap.put(RestURI.CONTAINER_ID, CONTAINER_ID);
         valuesMap.put(RestURI.PROCESS_ID, "not-existing");
 
         WebTarget clientRequest = newRequest(build(TestConfig.getKieServerHttpUrl(), FORM_URI + "/" + PROCESS_FORM_GET_URI, valuesMap));

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/rest/ImageServiceRestOnlyIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/rest/ImageServiceRestOnlyIntegrationTest.java
@@ -34,14 +34,11 @@ import org.junit.Test;
 import org.junit.rules.ExternalResource;
 import org.kie.server.api.marshalling.Marshaller;
 import org.kie.server.api.marshalling.MarshallerFactory;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.type.JaxbLong;
 import org.kie.server.api.rest.RestURI;
-import org.kie.server.client.KieServicesConfiguration;
 import org.kie.server.integrationtests.config.TestConfig;
 import org.kie.server.integrationtests.jbpm.DBExternalResource;
-import org.kie.server.integrationtests.shared.KieServerAssert;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 import org.kie.server.integrationtests.shared.basetests.RestOnlyBaseIntegrationTest;
 
@@ -64,11 +61,8 @@ public class ImageServiceRestOnlyIntegrationTest extends RestOnlyBaseIntegration
         KieServerDeployer.buildAndDeployCommonMavenParent();
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project").getFile());
 
-    }
-
-    @Override
-    protected void additionalConfiguration(KieServicesConfiguration configuration) {
-        configuration.setTimeout(30000);
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
     }
 
     @Before
@@ -86,11 +80,8 @@ public class ImageServiceRestOnlyIntegrationTest extends RestOnlyBaseIntegration
 
     @Test
     public void testGetProcessImageTest() throws Exception {
-        KieContainerResource resource = new KieContainerResource(CONTAINER_ID, releaseId);
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, resource));
-
         Map<String, Object> valuesMap = new HashMap<String, Object>();
-        valuesMap.put(RestURI.CONTAINER_ID, resource.getContainerId());
+        valuesMap.put(RestURI.CONTAINER_ID, CONTAINER_ID);
         valuesMap.put(RestURI.PROCESS_ID, HIRING_PROCESS_ID);
 
         WebTarget clientRequest = newRequest(build(TestConfig.getKieServerHttpUrl(), IMAGE_URI + "/" + PROCESS_IMG_GET_URI, valuesMap));
@@ -107,11 +98,8 @@ public class ImageServiceRestOnlyIntegrationTest extends RestOnlyBaseIntegration
 
     @Test
     public void testGetProcessInstanceImageTest() throws Exception {
-        KieContainerResource resource = new KieContainerResource(CONTAINER_ID, releaseId);
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, resource));
-
         Map<String, Object> valuesMap = new HashMap<String, Object>();
-        valuesMap.put(RestURI.CONTAINER_ID, resource.getContainerId());
+        valuesMap.put(RestURI.CONTAINER_ID, CONTAINER_ID);
         valuesMap.put(RestURI.PROCESS_ID, HIRING_PROCESS_ID);
 
         Marshaller marshaller = MarshallerFactory.getMarshaller(marshallingFormat, ClassLoader.getSystemClassLoader());
@@ -153,11 +141,8 @@ public class ImageServiceRestOnlyIntegrationTest extends RestOnlyBaseIntegration
 
     @Test
     public void testGetProcessImageNotExistingTest() throws Exception {
-        KieContainerResource resource = new KieContainerResource(CONTAINER_ID, releaseId);
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, resource));
-
         Map<String, Object> valuesMap = new HashMap<String, Object>();
-        valuesMap.put(RestURI.CONTAINER_ID, resource.getContainerId());
+        valuesMap.put(RestURI.CONTAINER_ID, CONTAINER_ID);
         valuesMap.put(RestURI.PROCESS_ID, "not-existing");
 
         WebTarget clientRequest = newRequest(build(TestConfig.getKieServerHttpUrl(), IMAGE_URI + "/" + PROCESS_IMG_GET_URI, valuesMap));
@@ -169,11 +154,8 @@ public class ImageServiceRestOnlyIntegrationTest extends RestOnlyBaseIntegration
 
     @Test
     public void testGetProcessInstanceImageNotExistingTest() throws Exception {
-        KieContainerResource resource = new KieContainerResource(CONTAINER_ID, releaseId);
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, resource));
-
         Map<String, Object> valuesMap = new HashMap<String, Object>();
-        valuesMap.put(RestURI.CONTAINER_ID, resource.getContainerId());
+        valuesMap.put(RestURI.CONTAINER_ID, CONTAINER_ID);
         valuesMap.put(RestURI.PROCESS_INST_ID, 9999);
 
         WebTarget clientRequest = newRequest(build(TestConfig.getKieServerHttpUrl(), IMAGE_URI + "/" + PROCESS_INST_IMG_GET_URI, valuesMap));

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/KieServerContainerCRUDIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/KieServerContainerCRUDIntegrationTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -42,6 +43,11 @@ public class KieServerContainerCRUDIntegrationTest extends RestJmsSharedBaseInte
     public static void initialize() throws Exception {
         KieServerDeployer.createAndDeployKJar(releaseId1);
         KieServerDeployer.createAndDeployKJar(releaseId2);
+    }
+
+    @Before
+    public void setupKieServer() throws Exception {
+        disposeAllContainers();
     }
 
     @Test

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/KieServerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/KieServerIntegrationTest.java
@@ -35,14 +35,15 @@ import org.kie.server.integrationtests.shared.basetests.RestJmsSharedBaseIntegra
 
 public class KieServerIntegrationTest extends RestJmsSharedBaseIntegrationTest {
     private static ReleaseId releaseId1 = new ReleaseId("foo.bar", "baz", "2.1.0.GA");
-    private static ReleaseId releaseId2 = new ReleaseId("foo.bar", "baz", "2.1.1.GA");
 
     private static final String CONTAINER_ID = "kie1";
 
     @BeforeClass
     public static void initialize() throws Exception {
         KieServerDeployer.createAndDeployKJar(releaseId1);
-        KieServerDeployer.createAndDeployKJar(releaseId2);
+
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId1);
     }
 
     @Test
@@ -60,10 +61,6 @@ public class KieServerIntegrationTest extends RestJmsSharedBaseIntegrationTest {
 
     @Test
     public void testScanner() throws Exception {
-        client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId1));
-        ServiceResponse<KieContainerResource> reply = client.getContainerInfo(CONTAINER_ID);
-        Assert.assertEquals(ServiceResponse.ResponseType.SUCCESS, reply.getType());
-        
         ServiceResponse<KieScannerResource> si = client.getScannerInfo(CONTAINER_ID);
         Assert.assertEquals( ResponseType.SUCCESS, si.getType() );
         KieScannerResource info = si.getResult();
@@ -102,10 +99,6 @@ public class KieServerIntegrationTest extends RestJmsSharedBaseIntegrationTest {
 
     @Test
     public void testScannerScanNow() throws Exception {
-        client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId1));
-        ServiceResponse<KieContainerResource> reply = client.getContainerInfo(CONTAINER_ID);
-        Assert.assertEquals(ServiceResponse.ResponseType.SUCCESS, reply.getType());
-
         ServiceResponse<KieScannerResource> si = client.getScannerInfo(CONTAINER_ID);
         Assert.assertEquals( ResponseType.SUCCESS, si.getType() );
         KieScannerResource info = si.getResult();
@@ -134,7 +127,6 @@ public class KieServerIntegrationTest extends RestJmsSharedBaseIntegrationTest {
 
     @Test
     public void testScannerStatusOnContainerInfo() throws Exception {
-        client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId1));
         ServiceResponse<KieContainerResource> reply = client.getContainerInfo(CONTAINER_ID);
         Assert.assertEquals(ServiceResponse.ResponseType.SUCCESS, reply.getType());
 
@@ -169,7 +161,7 @@ public class KieServerIntegrationTest extends RestJmsSharedBaseIntegrationTest {
 
     @Test
     public void testConversationIdHandling() throws Exception {
-        client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId1));
+        client.getContainerInfo(CONTAINER_ID);
         String conversationId = client.getConversationId();
         assertNotNull(conversationId);
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerBaseTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerBaseTest.java
@@ -35,6 +35,14 @@ public abstract class KieControllerBaseTest extends RestOnlyBaseIntegrationTest 
         controllerClient.setMarshallingFormat(marshallingFormat);
     }
 
+    @Before
+    @Override
+    public void setup() throws Exception {
+        super.setup();
+        disposeAllContainers();
+        disposeAllServerInstances();
+    }
+
     @After
     public void closeControllerClient() {
         controllerClient.close();

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerManagementBaseTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerManagementBaseTest.java
@@ -35,6 +35,14 @@ public abstract class KieControllerManagementBaseTest extends RestOnlyBaseIntegr
         mgmtControllerClient.setMarshallingFormat(marshallingFormat);
     }
 
+    @Before
+    @Override
+    public void setup() throws Exception {
+        super.setup();
+        disposeAllContainers();
+        disposeAllServerInstances();
+    }
+
     @After
     public void closeControllerClient() {
         mgmtControllerClient.close();

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/activation-group/src/main/resources/META-INF/kmodule.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/activation-group/src/main/resources/META-INF/kmodule.xml
@@ -1,1 +1,6 @@
-<kmodule xmlns="http://www.drools.org/xsd/kmodule" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<kmodule xmlns="http://www.drools.org/xsd/kmodule">
+  <kbase name="kbase1">
+    <ksession name="ksession1" type="stateless"/>
+  </kbase>
+</kmodule>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/agenda-group/src/main/resources/META-INF/kmodule.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/agenda-group/src/main/resources/META-INF/kmodule.xml
@@ -1,1 +1,6 @@
-<kmodule xmlns="http://www.drools.org/xsd/kmodule" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<kmodule xmlns="http://www.drools.org/xsd/kmodule">
+  <kbase name="kbase1">
+    <ksession name="ksession1" type="stateless"/>
+  </kbase>
+</kmodule>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/container-isolation-kjar1/src/main/resources/META-INF/kmodule.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/container-isolation-kjar1/src/main/resources/META-INF/kmodule.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <kmodule xmlns="http://www.drools.org/xsd/kmodule">
   <kbase name="kbase.kjar1" packages="kjar1">
-    <ksession name="kjar1.session" type="stateful"/>
+    <ksession name="kjar1.session" type="stateless"/>
   </kbase>
 </kmodule>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/container-isolation-kjar2/src/main/resources/META-INF/kmodule.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/container-isolation-kjar2/src/main/resources/META-INF/kmodule.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <kmodule xmlns="http://www.drools.org/xsd/kmodule">
   <kbase name="kbase.kjar2" packages="kjar2">
-    <ksession name="kjar2.session" type="stateful"/>
+    <ksession name="kjar2.session" type="stateless"/>
   </kbase>
 </kmodule>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/ActivationGroupIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/ActivationGroupIntegrationTest.java
@@ -9,7 +9,6 @@ import org.junit.Test;
 import org.kie.api.command.BatchExecutionCommand;
 import org.kie.api.command.Command;
 import org.kie.api.runtime.ExecutionResults;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
 
@@ -25,13 +24,16 @@ public class ActivationGroupIntegrationTest extends DroolsKieServerBaseIntegrati
     private static final String CONTAINER_ID = "activation";
     private static final String LIST_NAME = "list";
     private static final String LIST_OUTPUT_NAME = "output-list";
-    private static final String KIE_SESSION = "defaultKieSession";
+    private static final String KIE_SESSION = "ksession1";
     private static final String ACTIVATION_GROUP = "first-group";
 
     @BeforeClass
     public static void buildAndDeployArtifacts() {
         KieServerDeployer.buildAndDeployCommonMavenParent();
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/activation-group").getFile());
+
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
     }
 
     /**
@@ -39,8 +41,6 @@ public class ActivationGroupIntegrationTest extends DroolsKieServerBaseIntegrati
      */
     @Test
     public void testActivationGroup() {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         List<Command<?>> commands = new ArrayList<Command<?>>();
 
         BatchExecutionCommand batchExecution = commandsFactory.newBatchExecution(commands, KIE_SESSION);
@@ -67,8 +67,6 @@ public class ActivationGroupIntegrationTest extends DroolsKieServerBaseIntegrati
      */
     @Test
     public void testClearActivationGroup() {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         List<Command<?>> commands = new ArrayList<Command<?>>();
 
         BatchExecutionCommand batchExecution = commandsFactory.newBatchExecution(commands, KIE_SESSION);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/AgendaGroupIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/AgendaGroupIntegrationTest.java
@@ -9,7 +9,6 @@ import org.junit.Test;
 import org.kie.api.command.BatchExecutionCommand;
 import org.kie.api.command.Command;
 import org.kie.api.runtime.ExecutionResults;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
 
@@ -25,13 +24,16 @@ public class AgendaGroupIntegrationTest extends DroolsKieServerBaseIntegrationTe
     private static final String CONTAINER_ID = "agenda";
     private static final String LIST_NAME = "list";
     private static final String LIST_OUTPUT_NAME = "output-list";
-    private static final String KIE_SESSION = "defaultKieSession";
+    private static final String KIE_SESSION = "ksession1";
     private static final String AGENDA_GROUP = "first-agenda";
 
     @BeforeClass
     public static void buildAndDeployArtifacts() {
         KieServerDeployer.buildAndDeployCommonMavenParent();
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/agenda-group").getFile());
+
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
     }
 
     /**
@@ -39,8 +41,6 @@ public class AgendaGroupIntegrationTest extends DroolsKieServerBaseIntegrationTe
      */
     @Test
     public void testAgendaGroup() {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         List<Command<?>> commands = new ArrayList<Command<?>>();
 
         BatchExecutionCommand batchExecution = commandsFactory.newBatchExecution(commands, KIE_SESSION);
@@ -67,8 +67,6 @@ public class AgendaGroupIntegrationTest extends DroolsKieServerBaseIntegrationTe
      */
     @Test
     public void testClearAgendaGroup() {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         List<Command<?>> commands = new ArrayList<Command<?>>();
 
         BatchExecutionCommand batchExecution = commandsFactory.newBatchExecution(commands, KIE_SESSION);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/AgendaIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/AgendaIntegrationTest.java
@@ -9,7 +9,6 @@ import org.junit.Test;
 import org.kie.api.command.BatchExecutionCommand;
 import org.kie.api.command.Command;
 import org.kie.api.runtime.ExecutionResults;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
 
@@ -25,12 +24,15 @@ public class AgendaIntegrationTest extends DroolsKieServerBaseIntegrationTest {
     private static final String CONTAINER_ID = "agenda";
     private static final String LIST_NAME = "list";
     private static final String LIST_OUTPUT_NAME = "output-list";
-    private static final String KIE_SESSION = "defaultKieSession";
+    private static final String KIE_SESSION = "ksession1";
 
     @BeforeClass
     public static void buildAndDeployArtifacts() {
         KieServerDeployer.buildAndDeployCommonMavenParent();
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/agenda-group").getFile());
+
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
     }
 
     /**
@@ -38,8 +40,6 @@ public class AgendaIntegrationTest extends DroolsKieServerBaseIntegrationTest {
      */
     @Test
     public void testClearAgenda() {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         List<Command<?>> commands = new ArrayList<Command<?>>();
 
         BatchExecutionCommand batchExecution = commandsFactory.newBatchExecution(commands, KIE_SESSION);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/ClassesInludedInKJarIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/ClassesInludedInKJarIntegrationTest.java
@@ -19,13 +19,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kie.api.KieServices;
 import org.kie.api.command.BatchExecutionCommand;
 import org.kie.api.command.Command;
 import org.kie.api.runtime.ExecutionResults;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
 
@@ -57,6 +57,12 @@ public class ClassesInludedInKJarIntegrationTest extends DroolsKieServerBaseInte
         kjarClassLoader = KieServices.Factory.get().newKieContainer(releaseId).getClassLoader();
     }
 
+    @Before
+    public void cleanupContainers() {
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
+    }
+
     @Override
     protected void addExtraCustomClasses(Map<String, Class<?>> extraClasses) throws Exception {
         extraClasses.put(PERSON_CLASS_NAME, Class.forName(PERSON_CLASS_NAME, true, kjarClassLoader));
@@ -64,8 +70,6 @@ public class ClassesInludedInKJarIntegrationTest extends DroolsKieServerBaseInte
 
     @Test
     public void testStateIsKeptBetweenCalls() {
-        client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId));
-
         List<Command<?>> commands = new ArrayList<Command<?>>();
         BatchExecutionCommand executionCommand = commandsFactory.newBatchExecution(commands, KIE_SESSION);
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/ConcurrentRequestsIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/ConcurrentRequestsIntegrationTest.java
@@ -32,7 +32,6 @@ import org.kie.api.command.BatchExecutionCommand;
 import org.kie.api.command.Command;
 import org.kie.api.runtime.ExecutionResults;
 import org.kie.api.runtime.KieContainer;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.client.KieServicesClient;
@@ -58,6 +57,9 @@ public class ConcurrentRequestsIntegrationTest extends DroolsKieServerBaseIntegr
     public static void initialize() throws Exception {
         KieServerDeployer.buildAndDeployCommonMavenParent();
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/stateless-session-kjar").getFile());
+
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
     }
 
     @Override
@@ -70,8 +72,6 @@ public class ConcurrentRequestsIntegrationTest extends DroolsKieServerBaseIntegr
 
     @Test
     public void testCallingStatelessSessionFromMultipleThreads() throws Exception {
-        client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId));
-
         List<Future<String>> futureResults = new ArrayList<Future<String>>();
         ExecutorService es = Executors.newFixedThreadPool(NR_OF_THREADS);
         for (int i = 0; i < NR_OF_THREADS; i++) {

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/ContainerIsolationIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/ContainerIsolationIntegrationTest.java
@@ -28,7 +28,6 @@ import org.kie.api.command.BatchExecutionCommand;
 import org.kie.api.command.Command;
 import org.kie.api.runtime.ExecutionResults;
 import org.kie.api.runtime.KieContainer;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.integrationtests.shared.KieServerAssert;
@@ -52,6 +51,10 @@ public class ContainerIsolationIntegrationTest extends DroolsKieServerBaseIntegr
         KieServerDeployer.buildAndDeployCommonMavenParent();
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/container-isolation-kjar1").getFile());
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/container-isolation-kjar2").getFile());
+
+        disposeAllContainers();
+        createContainer(CONTAINER_1_ID, kjar1);
+        createContainer(CONTAINER_2_ID, kjar2);
     }
 
     @Override
@@ -62,8 +65,6 @@ public class ContainerIsolationIntegrationTest extends DroolsKieServerBaseIntegr
 
     @Test 
     public void testUseClassWithSameFQNInDifferentContainers() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_1_ID, new KieContainerResource(CONTAINER_1_ID, kjar1)));
-
         Object person = createInstance(PERSON_CLASS_NAME);
         List<Command<?>> commands = new ArrayList<Command<?>>();
         BatchExecutionCommand batchExecution1 = commandsFactory.newBatchExecution(commands, KIE_SESSION_1);
@@ -80,8 +81,6 @@ public class ContainerIsolationIntegrationTest extends DroolsKieServerBaseIntegr
 
         // now execute the same commands, but for the second container. The rule in there should set different id
         // (namely "Person from kjar2") for the inserted person
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_2_ID, new KieContainerResource(CONTAINER_2_ID, kjar2)));
-
         person = createInstance(PERSON_CLASS_NAME);
         commands = new ArrayList<Command<?>>();
         BatchExecutionCommand batchExecution2 = commandsFactory.newBatchExecution(commands, KIE_SESSION_2);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/DroolsKieServerBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/DroolsKieServerBaseIntegrationTest.java
@@ -18,7 +18,6 @@ package org.kie.server.integrationtests.drools;
 import org.junit.BeforeClass;
 import org.kie.api.KieServices;
 import org.kie.server.client.KieServicesClient;
-import org.kie.server.client.KieServicesConfiguration;
 import org.kie.server.client.RuleServicesClient;
 import org.kie.server.integrationtests.shared.basetests.RestJmsSharedBaseIntegrationTest;
 
@@ -29,12 +28,6 @@ public abstract class DroolsKieServerBaseIntegrationTest extends RestJmsSharedBa
     @BeforeClass
     public static void setupFactory() throws Exception {
         commandsFactory = KieServices.Factory.get().getCommands();
-    }
-
-    @Override
-    protected void additionalConfiguration(KieServicesConfiguration configuration) throws Exception {
-        super.additionalConfiguration(configuration);
-        configuration.setTimeout(10000);
     }
 
     @Override

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/GuidedDecisionTableIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/GuidedDecisionTableIntegrationTest.java
@@ -25,7 +25,6 @@ import org.kie.api.KieServices;
 import org.kie.api.command.BatchExecutionCommand;
 import org.kie.api.command.Command;
 import org.kie.api.runtime.ExecutionResults;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
 
@@ -54,6 +53,9 @@ public class GuidedDecisionTableIntegrationTest extends DroolsKieServerBaseInteg
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/gdst-project").getFile());
 
         kjarClassLoader = KieServices.Factory.get().newKieContainer(releaseId).getClassLoader();
+
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
     }
 
     @Override
@@ -63,8 +65,6 @@ public class GuidedDecisionTableIntegrationTest extends DroolsKieServerBaseInteg
 
     @Test
     public void testExecuteGuidedDecisionTableRule() {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Object person = createInstance(PERSON_CLASS_NAME, PERSON_NAME);
         List<Command<?>> commands = new ArrayList<Command<?>>();
         BatchExecutionCommand batchExecution = commandsFactory.newBatchExecution(commands, "kbase1.stateless");

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/GuidedDecisionTreeIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/GuidedDecisionTreeIntegrationTest.java
@@ -25,7 +25,6 @@ import org.kie.api.KieServices;
 import org.kie.api.command.BatchExecutionCommand;
 import org.kie.api.command.Command;
 import org.kie.api.runtime.ExecutionResults;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
 
@@ -54,6 +53,9 @@ public class GuidedDecisionTreeIntegrationTest extends DroolsKieServerBaseIntegr
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/tdrl-project").getFile());
 
         kjarClassLoader = KieServices.Factory.get().newKieContainer(releaseId).getClassLoader();
+
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
     }
 
     @Override
@@ -63,8 +65,6 @@ public class GuidedDecisionTreeIntegrationTest extends DroolsKieServerBaseIntegr
 
     @Test
     public void testExecuteGuidedDecisionTableRule() {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Object person = createInstance(PERSON_CLASS_NAME, PERSON_NAME);
         List<Command<?>> commands = new ArrayList<Command<?>>();
         BatchExecutionCommand batchExecution = commandsFactory.newBatchExecution(commands, "kbase1.stateless");

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/KieServerBackwardCompatDroolsIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/KieServerBackwardCompatDroolsIntegrationTest.java
@@ -32,7 +32,6 @@ import org.kie.api.command.Command;
 import org.kie.api.runtime.ExecutionResults;
 import org.kie.server.api.marshalling.Marshaller;
 import org.kie.server.api.marshalling.MarshallerFactory;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
@@ -58,6 +57,9 @@ public class KieServerBackwardCompatDroolsIntegrationTest extends DroolsKieServe
 
         File jar = KieServerDeployer.getRepository().resolveArtifact(releaseId).getFile();
         kjarClassLoader = new URLClassLoader(new URL[]{jar.toURI().toURL()});
+
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
     }
 
     @Override
@@ -68,7 +70,6 @@ public class KieServerBackwardCompatDroolsIntegrationTest extends DroolsKieServe
     @Test
     public void testCallContainer() throws Exception {
         Marshaller marshaller = MarshallerFactory.getMarshaller(new HashSet<Class<?>>(extraClasses.values()), configuration.getMarshallingFormat(), kjarClassLoader);
-        client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId));
 
         Object message = createInstance(MESSAGE_CLASS_NAME);
         setValue(message, MESSAGE_TEXT_FIELD, MESSAGE_REQUEST);
@@ -89,7 +90,6 @@ public class KieServerBackwardCompatDroolsIntegrationTest extends DroolsKieServe
     @Test
     public void testCallContainerWithStringPayload() throws Exception {
         Marshaller marshaller = MarshallerFactory.getMarshaller(new HashSet<Class<?>>(extraClasses.values()), configuration.getMarshallingFormat(), kjarClassLoader);
-        client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId));
 
         Object message = createInstance(MESSAGE_CLASS_NAME);
         setValue(message, MESSAGE_TEXT_FIELD, MESSAGE_REQUEST);
@@ -112,7 +112,6 @@ public class KieServerBackwardCompatDroolsIntegrationTest extends DroolsKieServe
     @Test
     public void testCallContainerRuleClient() throws Exception {
         Marshaller marshaller = MarshallerFactory.getMarshaller(new HashSet<Class<?>>(extraClasses.values()), configuration.getMarshallingFormat(), kjarClassLoader);
-        client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId));
 
         Object message = createInstance(MESSAGE_CLASS_NAME);
         setValue(message, MESSAGE_TEXT_FIELD, MESSAGE_REQUEST);
@@ -133,7 +132,6 @@ public class KieServerBackwardCompatDroolsIntegrationTest extends DroolsKieServe
     @Test
     public void testCallContainerWithStringPayloadRuleClient() throws Exception {
         Marshaller marshaller = MarshallerFactory.getMarshaller(new HashSet<Class<?>>(extraClasses.values()), configuration.getMarshallingFormat(), kjarClassLoader);
-        client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId));
 
         Object message = createInstance(MESSAGE_CLASS_NAME);
         setValue(message, MESSAGE_TEXT_FIELD, MESSAGE_REQUEST);
@@ -155,8 +153,6 @@ public class KieServerBackwardCompatDroolsIntegrationTest extends DroolsKieServe
 
     @Test
     public void testCallContainerLookupError() throws Exception {
-        client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId));
-
         List<Command<?>> commands = new ArrayList<Command<?>>();
         BatchExecutionCommand batchExecution = commandsFactory.newBatchExecution(commands, "xyz");
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/KieServerDroolsIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/KieServerDroolsIntegrationTest.java
@@ -68,6 +68,9 @@ public class KieServerDroolsIntegrationTest extends DroolsKieServerBaseIntegrati
 
         File jar = KieServerDeployer.getRepository().resolveArtifact(releaseId).getFile();
         kjarClassLoader = new URLClassLoader(new URL[]{jar.toURI().toURL()});
+
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
     }
 
     @Override
@@ -78,8 +81,6 @@ public class KieServerDroolsIntegrationTest extends DroolsKieServerBaseIntegrati
     @Test
     @Category(Smoke.class)
     public void testCallContainer() throws Exception {
-        client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId));
-
         Object message = createInstance(MESSAGE_CLASS_NAME);
         setValue(message, MESSAGE_TEXT_FIELD, MESSAGE_REQUEST);
 
@@ -99,7 +100,6 @@ public class KieServerDroolsIntegrationTest extends DroolsKieServerBaseIntegrati
     @Test
     public void testCallContainerWithStringPayload() throws Exception {
         Marshaller marshaller = MarshallerFactory.getMarshaller(new HashSet<Class<?>>(extraClasses.values()), configuration.getMarshallingFormat(), kjarClassLoader);
-        client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId));
 
         Object message = createInstance(MESSAGE_CLASS_NAME);
         setValue(message, MESSAGE_TEXT_FIELD, MESSAGE_REQUEST);
@@ -149,8 +149,6 @@ public class KieServerDroolsIntegrationTest extends DroolsKieServerBaseIntegrati
 
     @Test
     public void testCallContainerLookupError() throws Exception {
-        client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId));
-
         List<Command<?>> commands = new ArrayList<Command<?>>();
         BatchExecutionCommand batchExecution = commandsFactory.newBatchExecution(commands, "xyz");
 
@@ -160,7 +158,8 @@ public class KieServerDroolsIntegrationTest extends DroolsKieServerBaseIntegrati
 
     @Test
     public void testCallContainerWithinConversation() throws Exception {
-        client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId));
+        // Call container info to get conversation Id.
+        client.getContainerInfo(CONTAINER_ID);
         String conversationId = client.getConversationId();
         assertNotNull(conversationId);
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/MultiModuleProjectIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/MultiModuleProjectIntegrationTest.java
@@ -26,7 +26,6 @@ import org.kie.api.command.BatchExecutionCommand;
 import org.kie.api.command.Command;
 import org.kie.api.runtime.ExecutionResults;
 import org.kie.api.runtime.KieContainer;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
 
@@ -54,6 +53,10 @@ public class MultiModuleProjectIntegrationTest extends DroolsKieServerBaseIntegr
         KieServerDeployer.buildAndDeployCommonMavenParent();
         // the parent will build and deploy also all of its modules, so no need to deploy them individually
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/multimodule-project").getFile());
+
+        disposeAllContainers();
+        createContainer(CONTAINER_1_ID, releaseIdRules1);
+        createContainer(CONTAINER_2_ID, releaseIdRules2);
     }
 
     @Override
@@ -66,9 +69,6 @@ public class MultiModuleProjectIntegrationTest extends DroolsKieServerBaseIntegr
 
     @Test
     public void testCreateMultipleContainersAndExecuteRules() {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_1_ID, new KieContainerResource(CONTAINER_1_ID, releaseIdRules1)));
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_2_ID, new KieContainerResource(CONTAINER_2_ID, releaseIdRules2)));
-
         Object car = createInstance(CAR_CLASS_NAME);
         List<Command<?>> commands = new ArrayList<Command<?>>();
         BatchExecutionCommand batchExecution1 = commandsFactory.newBatchExecution(commands, KIE_SESSION);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/ObjectHandlingIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/ObjectHandlingIntegrationTest.java
@@ -10,7 +10,6 @@ import org.kie.api.KieServices;
 import org.kie.api.command.BatchExecutionCommand;
 import org.kie.api.command.Command;
 import org.kie.api.runtime.ExecutionResults;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
 
@@ -40,6 +39,9 @@ public class ObjectHandlingIntegrationTest extends DroolsKieServerBaseIntegratio
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/stateless-session-kjar").getFile());
 
         kjarClassLoader = KieServices.Factory.get().newKieContainer(releaseId).getClassLoader();
+
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
     }
 
     @Override
@@ -49,8 +51,6 @@ public class ObjectHandlingIntegrationTest extends DroolsKieServerBaseIntegratio
 
     @Test
     public void testGetObjects() {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         List<Command<?>> commands = new ArrayList<Command<?>>();
         Object person = createInstance(PERSON_CLASS_NAME, PERSON_NAME, "");
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/RuleFlowIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/RuleFlowIntegrationTest.java
@@ -19,12 +19,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.drools.core.command.runtime.rule.ClearRuleFlowGroupCommand;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kie.api.command.BatchExecutionCommand;
 import org.kie.api.command.Command;
 import org.kie.api.runtime.ExecutionResults;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
 
@@ -51,10 +51,14 @@ public class RuleFlowIntegrationTest extends DroolsKieServerBaseIntegrationTest 
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/ruleflow-group").getFile());
     }
 
+    @Before
+    public void cleanContainers() {
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
+    }
+
     @Test
     public void testExecuteSimpleRuleFlowProcess() {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         List<Command<?>> commands = new ArrayList<Command<?>>();
         BatchExecutionCommand batchExecution = commandsFactory.newBatchExecution(commands, KIE_SESSION);
 
@@ -77,8 +81,6 @@ public class RuleFlowIntegrationTest extends DroolsKieServerBaseIntegrationTest 
 
     @Test
     public void testExecuteSimpleRuleFlowProcessInStatelessSession() {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         List<Command<?>> commands = new ArrayList<Command<?>>();
         BatchExecutionCommand batchExecution = commandsFactory.newBatchExecution(commands, KIE_SESSION_STATELESS);
 
@@ -101,8 +103,6 @@ public class RuleFlowIntegrationTest extends DroolsKieServerBaseIntegrationTest 
 
     @Test
     public void testClearRuleFlowGroup() {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         List<Command<?>> commands = new ArrayList<Command<?>>();
         BatchExecutionCommand batchExecution = commandsFactory.newBatchExecution(commands, KIE_SESSION);
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/RuleTemplateIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/RuleTemplateIntegrationTest.java
@@ -25,7 +25,6 @@ import org.kie.api.KieServices;
 import org.kie.api.command.BatchExecutionCommand;
 import org.kie.api.command.Command;
 import org.kie.api.runtime.ExecutionResults;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
 
@@ -54,6 +53,9 @@ public class RuleTemplateIntegrationTest extends DroolsKieServerBaseIntegrationT
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/template-project").getFile());
 
         kjarClassLoader = KieServices.Factory.get().newKieContainer(releaseId).getClassLoader();
+
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
     }
 
     @Override
@@ -63,8 +65,6 @@ public class RuleTemplateIntegrationTest extends DroolsKieServerBaseIntegrationT
 
     @Test
     public void testExecuteGuidedDecisionTableRule() {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Object person = createInstance(PERSON_CLASS_NAME, PERSON_NAME);
         List<Command<?>> commands = new ArrayList<Command<?>>();
         BatchExecutionCommand batchExecution = commandsFactory.newBatchExecution(commands, "kbase1.stateless");

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/SpreadsheetIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/SpreadsheetIntegrationTest.java
@@ -25,7 +25,6 @@ import org.kie.api.KieServices;
 import org.kie.api.command.BatchExecutionCommand;
 import org.kie.api.command.Command;
 import org.kie.api.runtime.ExecutionResults;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
 
@@ -54,6 +53,9 @@ public class SpreadsheetIntegrationTest extends DroolsKieServerBaseIntegrationTe
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/spreadsheet").getFile());
 
         kjarClassLoader = KieServices.Factory.get().newKieContainer(releaseId).getClassLoader();
+
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
     }
 
     @Override
@@ -63,8 +65,6 @@ public class SpreadsheetIntegrationTest extends DroolsKieServerBaseIntegrationTe
 
     @Test
     public void testExecuteSpreadsheetRule() {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Object person = createInstance(PERSON_CLASS_NAME, PERSON_AGE);
         List<Command<?>> commands = new ArrayList<Command<?>>();
         BatchExecutionCommand batchExecution = commandsFactory.newBatchExecution(commands);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/StatefulSessionUsageIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/StatefulSessionUsageIntegrationTest.java
@@ -20,6 +20,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kie.api.KieServices;
@@ -29,7 +30,6 @@ import org.kie.api.runtime.ExecutionResults;
 import org.kie.api.runtime.rule.FactHandle;
 import org.kie.api.runtime.rule.QueryResults;
 import org.kie.api.runtime.rule.QueryResultsRow;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
 
@@ -61,6 +61,12 @@ public class StatefulSessionUsageIntegrationTest extends DroolsKieServerBaseInte
         kjarClassLoader = KieServices.Factory.get().newKieContainer(releaseId).getClassLoader();
     }
 
+    @Before
+    public void cleanContainers() {
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
+    }
+
     @Override
     protected void addExtraCustomClasses(Map<String, Class<?>> extraClasses) throws Exception {
         extraClasses.put(PERSON_CLASS_NAME, Class.forName(PERSON_CLASS_NAME, true, kjarClassLoader));
@@ -68,8 +74,6 @@ public class StatefulSessionUsageIntegrationTest extends DroolsKieServerBaseInte
 
     @Test
     public void testErrorHandlingWhenContainerIsDisposedBetweenCalls() {
-        client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId));
-
         List<Command<?>> commands = new ArrayList<Command<?>>();
         BatchExecutionCommand executionCommand = commandsFactory.newBatchExecution(commands, KIE_SESSION);
 
@@ -91,8 +95,6 @@ public class StatefulSessionUsageIntegrationTest extends DroolsKieServerBaseInte
 
     @Test
     public void testStateIsKeptBetweenCalls() {
-        client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId));
-
         List<Command<?>> commands = new ArrayList<Command<?>>();
         BatchExecutionCommand executionCommand = commandsFactory.newBatchExecution(commands, KIE_SESSION);
 
@@ -138,8 +140,6 @@ public class StatefulSessionUsageIntegrationTest extends DroolsKieServerBaseInte
 
     @Test
     public void testInsertFireGetQuery() {
-        client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId));
-
         List<Command<?>> commands = new ArrayList<Command<?>>();
         BatchExecutionCommand executionCommand = commandsFactory.newBatchExecution(commands, KIE_SESSION);
 
@@ -183,8 +183,6 @@ public class StatefulSessionUsageIntegrationTest extends DroolsKieServerBaseInte
 
     @Test
     public void testInsertFireGetQueryMultipleResults() {
-        client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId));
-
         List<Command<?>> commands = new ArrayList<Command<?>>();
         BatchExecutionCommand executionCommand = commandsFactory.newBatchExecution(commands, KIE_SESSION);
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/StatelessSessionUsageIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/StatelessSessionUsageIntegrationTest.java
@@ -19,7 +19,6 @@ package org.kie.server.integrationtests.drools;
 import static org.junit.Assert.*;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -29,9 +28,6 @@ import org.kie.api.KieServices;
 import org.kie.api.command.BatchExecutionCommand;
 import org.kie.api.command.Command;
 import org.kie.api.runtime.ExecutionResults;
-import org.kie.server.api.marshalling.Marshaller;
-import org.kie.server.api.marshalling.MarshallerFactory;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
@@ -57,6 +53,9 @@ public class StatelessSessionUsageIntegrationTest extends DroolsKieServerBaseInt
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/stateless-session-kjar").getFile());
 
         kjarClassLoader = KieServices.Factory.get().newKieContainer(releaseId).getClassLoader();
+
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
     }
 
     @Override
@@ -66,9 +65,6 @@ public class StatelessSessionUsageIntegrationTest extends DroolsKieServerBaseInt
 
     @Test
     public void testStatelessCall() {
-        Marshaller marshaller = MarshallerFactory.getMarshaller(new HashSet<Class<?>>(extraClasses.values()), configuration.getMarshallingFormat(), kjarClassLoader);
-        client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId));
-
         List<Command<?>> commands = new ArrayList<Command<?>>();
         BatchExecutionCommand executionCommand = commandsFactory.newBatchExecution(commands, KIE_SESSION);
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/rest/RestMalformedRequestIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/rest/RestMalformedRequestIntegrationTest.java
@@ -48,12 +48,13 @@ public class RestMalformedRequestIntegrationTest extends RestOnlyBaseIntegration
         KieServerDeployer.buildAndDeployCommonMavenParent();
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/state-is-kept-for-stateful-session").getFile());
 
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
     }
 
     @Test
     public void testInvalidCommandBodyOnCallContainer() throws Exception {
         Marshaller marshaller = MarshallerFactory.getMarshaller(marshallingFormat, this.getClass().getClassLoader());
-        client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId));
 
         Response response = null;
         try {
@@ -77,8 +78,6 @@ public class RestMalformedRequestIntegrationTest extends RestOnlyBaseIntegration
 
     @Test
     public void testInvalidBodyOnCallContainer() throws Exception {
-
-        client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId));
 
         Response response = null;
         try {

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/BARuntimeDataServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/BARuntimeDataServiceIntegrationTest.java
@@ -24,7 +24,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kie.api.KieServices;
 import org.kie.api.task.model.Status;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.instance.TaskSummary;
 import org.kie.server.integrationtests.config.TestConfig;
@@ -43,11 +42,13 @@ public class BARuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegr
 
     @BeforeClass
     public static void buildAndDeployArtifacts() {
-
         KieServerDeployer.buildAndDeployCommonMavenParent();
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project").getFile());
 
         kieContainer = KieServices.Factory.get().newKieContainer(releaseId);
+
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
     }
 
     @Override
@@ -58,7 +59,6 @@ public class BARuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegr
     @Test
     public void testFindTaskAssignedAsBusinessAdmin() throws Exception {
         changeUser(USER_ADMINISTRATOR);
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
 
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
@@ -102,7 +102,6 @@ public class BARuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegr
     @Test
     public void testFindTaskAssignedAsBusinessAdminSorted() throws Exception {
         changeUser(USER_ADMINISTRATOR);
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
 
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/DocumentServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/DocumentServiceIntegrationTest.java
@@ -29,7 +29,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.api.KieServices;
 import org.kie.server.api.KieServerConstants;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.instance.DocumentInstance;
 import org.kie.server.api.model.instance.TaskSummary;
@@ -37,7 +36,6 @@ import org.kie.server.client.KieServicesException;
 import org.kie.server.integrationtests.category.Smoke;
 
 import static org.junit.Assert.*;
-import org.kie.server.integrationtests.shared.KieServerAssert;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 
 public class DocumentServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest {
@@ -54,6 +52,9 @@ public class DocumentServiceIntegrationTest extends JbpmKieServerBaseIntegration
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project").getFile());
 
         kieContainer = KieServices.Factory.get().newKieContainer(releaseId);
+
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
     }
 
     private DocumentInstance document;
@@ -228,8 +229,6 @@ public class DocumentServiceIntegrationTest extends JbpmKieServerBaseIntegration
 
     @Test
     public void testDocumentProcess() {
-
-        KieServerAssert.assertSuccess(client.createContainer("definition-project", new KieContainerResource("definition-project", releaseId)));
 
         DocumentImpl docToTranslate = new DocumentImpl();
         docToTranslate.setContent(document.getContent());

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/JobServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/JobServiceIntegrationTest.java
@@ -29,7 +29,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.api.KieServices;
 import org.kie.internal.executor.api.STATUS;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.instance.JobRequestInstance;
 import org.kie.server.api.model.instance.RequestInfoInstance;
@@ -38,7 +37,6 @@ import org.kie.server.integrationtests.category.Smoke;
 import static org.junit.Assert.*;
 import static org.hamcrest.core.AnyOf.*;
 import static org.hamcrest.core.IsEqual.*;
-import org.kie.server.integrationtests.shared.KieServerAssert;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 import org.kie.server.integrationtests.shared.KieServerSynchronization;
 
@@ -57,6 +55,9 @@ public class JobServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest 
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project").getFile());
 
         kieContainer = KieServices.Factory.get().newKieContainer(releaseId);
+
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
     }
 
     @Before
@@ -79,8 +80,6 @@ public class JobServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest 
 
     @Test
     public void testScheduleViewAndCancelJob() {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Calendar tomorrow = Calendar.getInstance();
         tomorrow.add(Calendar.DATE, 1);
 
@@ -106,8 +105,6 @@ public class JobServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest 
     @Test
     @Category(Smoke.class)
     public void testScheduleAndRunJob() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         JobRequestInstance jobRequestInstance = createJobRequestInstance();
 
         Long jobId = jobServicesClient.scheduleRequest(jobRequestInstance);
@@ -137,8 +134,6 @@ public class JobServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest 
 
     @Test
     public void testScheduleAndRunJobWithCustomTypeFromContainer() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Class<?> personClass = Class.forName(PERSON_CLASS_NAME, true, kieContainer.getClassLoader());
 
         Map<String, Object> data = new HashMap<String, Object>();
@@ -197,8 +192,6 @@ public class JobServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest 
 
     @Test
     public void testScheduleSearchByStatusAndCancelJob() {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         int currentNumberOfCancelled = jobServicesClient.getRequestsByStatus(Collections.singletonList(STATUS.CANCELLED.toString()), 0, 100).size();
 
         Calendar tomorrow = Calendar.getInstance();
@@ -240,8 +233,6 @@ public class JobServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest 
 
     @Test
     public void testScheduleAndRequeueJob() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         String command = "org.jbpm.executor.commands.PrintOutCommand123";
 
         Map<String, Object> data = new HashMap<String, Object>();
@@ -285,8 +276,6 @@ public class JobServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest 
 
     @Test
     public void testScheduleSearchByKeyJob() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         int currentNumberOfRequests = jobServicesClient.getRequestsByBusinessKey(BUSINESS_KEY, 0, 100).size();
 
         Calendar tomorrow = Calendar.getInstance();

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/ProcessDefinitionIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/ProcessDefinitionIntegrationTest.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kie.api.KieServices;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.definition.AssociatedEntitiesDefinition;
 import org.kie.server.api.model.definition.ProcessDefinition;
@@ -34,7 +33,6 @@ import org.kie.server.api.model.definition.VariablesDefinition;
 import org.kie.server.client.KieServicesException;
 
 import static org.junit.Assert.*;
-import org.kie.server.integrationtests.shared.KieServerAssert;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 
 
@@ -51,12 +49,14 @@ public class ProcessDefinitionIntegrationTest extends JbpmKieServerBaseIntegrati
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project").getFile());
 
         kieContainer = KieServices.Factory.get().newKieContainer(releaseId);
+
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
     }
 
 
     @Test
     public void testEvaluationProcessDefinition() {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         ProcessDefinition result = processClient.getProcessDefinition(CONTAINER_ID, PROCESS_ID_EVALUATION);
 
         assertNotNull(result);
@@ -103,7 +103,6 @@ public class ProcessDefinitionIntegrationTest extends JbpmKieServerBaseIntegrati
 
     @Test
     public void testCallEvaluationProcessDefinition() {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         ProcessDefinition result = processClient.getProcessDefinition(CONTAINER_ID, PROCESS_ID_CALL_EVALUATION);
 
         assertNotNull(result);
@@ -144,14 +143,12 @@ public class ProcessDefinitionIntegrationTest extends JbpmKieServerBaseIntegrati
 
     @Test(expected = KieServicesException.class)
     public void testNonExistingProcessDefinition() {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         processClient.getProcessDefinition(CONTAINER_ID, "non-existing-process");
     }
 
 
     @Test
     public void testReusableSubProcessDefinition() {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         SubProcessesDefinition result = processClient.getReusableSubProcessDefinitions(CONTAINER_ID, PROCESS_ID_CALL_EVALUATION);
 
         assertNotNull(result);
@@ -164,8 +161,6 @@ public class ProcessDefinitionIntegrationTest extends JbpmKieServerBaseIntegrati
 
     @Test
     public void testProcessVariableDefinitions() {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         // assert variable definitions
         VariablesDefinition variablesDefinition = processClient.getProcessVariableDefinitions(CONTAINER_ID, PROCESS_ID_EVALUATION);
 
@@ -184,7 +179,6 @@ public class ProcessDefinitionIntegrationTest extends JbpmKieServerBaseIntegrati
 
     @Test
     public void testServiceTasksDefinition() {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         ServiceTasksDefinition result = processClient.getServiceTaskDefinitions(CONTAINER_ID, PROCESS_ID_EVALUATION);
         // assert services tasks
         assertEquals(1, result.getServiceTasks().size());
@@ -196,7 +190,6 @@ public class ProcessDefinitionIntegrationTest extends JbpmKieServerBaseIntegrati
 
     @Test
     public void testAssociatedEntitiesDefinition() {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         AssociatedEntitiesDefinition result = processClient.getAssociatedEntityDefinitions(CONTAINER_ID, PROCESS_ID_EVALUATION);
 
         // assert associated entities - users and groups
@@ -213,7 +206,6 @@ public class ProcessDefinitionIntegrationTest extends JbpmKieServerBaseIntegrati
 
     @Test
     public void testUserTasksDefinition() {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         UserTaskDefinitionList result = processClient.getUserTaskDefinitions(CONTAINER_ID, PROCESS_ID_EVALUATION);
 
         assertNotNull(result);
@@ -268,7 +260,6 @@ public class ProcessDefinitionIntegrationTest extends JbpmKieServerBaseIntegrati
 
     @Test
     public void testUserTaskInputDefinition() {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         TaskInputsDefinition result = processClient.getUserTaskInputDefinitions(CONTAINER_ID, PROCESS_ID_EVALUATION, "Evaluate items");
 
         assertNotNull(result);
@@ -292,7 +283,6 @@ public class ProcessDefinitionIntegrationTest extends JbpmKieServerBaseIntegrati
 
     @Test
     public void testTaskOutputsDefinition() {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         TaskOutputsDefinition result = processClient.getUserTaskOutputDefinitions(CONTAINER_ID, PROCESS_ID_EVALUATION, "Evaluate items");
 
         assertNotNull(result);
@@ -309,7 +299,6 @@ public class ProcessDefinitionIntegrationTest extends JbpmKieServerBaseIntegrati
 
     @Test
     public void testUserTasksDefinitionWithEmptyAssociatedEntities() {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         UserTaskDefinitionList result = processClient.getUserTaskDefinitions(CONTAINER_ID, PROCESS_ID_XYZ_TRANSLATIONS);
 
         assertNotNull(result);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/ProcessServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/ProcessServiceIntegrationTest.java
@@ -30,7 +30,6 @@ import org.kie.internal.KieInternalServices;
 import org.kie.internal.executor.api.STATUS;
 import org.kie.internal.process.CorrelationKey;
 import org.kie.internal.process.CorrelationKeyFactory;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.instance.ProcessInstance;
 import org.kie.server.api.model.instance.RequestInfoInstance;
@@ -42,7 +41,6 @@ import org.kie.server.integrationtests.category.Smoke;
 import org.kie.server.integrationtests.config.TestConfig;
 
 import static org.junit.Assert.*;
-import org.kie.server.integrationtests.shared.KieServerAssert;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 import org.kie.server.integrationtests.shared.KieServerSynchronization;
 
@@ -60,6 +58,9 @@ public class ProcessServiceIntegrationTest extends JbpmKieServerBaseIntegrationT
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project").getFile());
 
         kieContainer = KieServices.Factory.get().newKieContainer(releaseId);
+
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
     }
 
     @Override
@@ -69,7 +70,6 @@ public class ProcessServiceIntegrationTest extends JbpmKieServerBaseIntegrationT
 
     @Test
     public void testStartCheckVariablesAndAbortProcess() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         Class<?> personClass = Class.forName(PERSON_CLASS_NAME, true, kieContainer.getClassLoader());
 
         Object person = createPersonInstance(USER_JOHN);
@@ -137,14 +137,11 @@ public class ProcessServiceIntegrationTest extends JbpmKieServerBaseIntegrationT
 
     @Test(expected = KieServicesException.class)
     public void testStartNotExistingProcess() {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         processClient.startProcess(CONTAINER_ID, "not-existing", (Map)null);
     }
 
     @Test()
     public void testAbortExistingProcess() {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
 
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_EVALUATION, parameters);
@@ -171,14 +168,11 @@ public class ProcessServiceIntegrationTest extends JbpmKieServerBaseIntegrationT
 
     @Test(expected = KieServicesException.class)
     public void testAbortNonExistingProcess() {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         processClient.abortProcessInstance(CONTAINER_ID, 9999l);
     }
 
     @Test(expected = KieServicesException.class)
     public void testStartCheckNonExistingVariables() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_EVALUATION, parameters);
         try {
@@ -191,8 +185,6 @@ public class ProcessServiceIntegrationTest extends JbpmKieServerBaseIntegrationT
 
     @Test
     public void testAbortMultipleProcessInstances() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
 
         Long processInstanceId1 = processClient.startProcess(CONTAINER_ID, PROCESS_ID_EVALUATION);
         Long processInstanceId2 = processClient.startProcess(CONTAINER_ID, PROCESS_ID_EVALUATION);
@@ -210,7 +202,6 @@ public class ProcessServiceIntegrationTest extends JbpmKieServerBaseIntegrationT
 
     @Test
     public void testSignalProcessInstance() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_SIGNAL_PROCESS);
 
         assertNotNull(processInstanceId);
@@ -233,7 +224,6 @@ public class ProcessServiceIntegrationTest extends JbpmKieServerBaseIntegrationT
 
     @Test
     public void testSignalProcessInstanceNullEvent() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_SIGNAL_PROCESS);
         assertNotNull(processInstanceId);
         assertTrue(processInstanceId.longValue() > 0);
@@ -254,7 +244,6 @@ public class ProcessServiceIntegrationTest extends JbpmKieServerBaseIntegrationT
 
     @Test
     public void testSignalProcessInstances() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_SIGNAL_PROCESS);
 
         assertNotNull(processInstanceId);
@@ -287,7 +276,6 @@ public class ProcessServiceIntegrationTest extends JbpmKieServerBaseIntegrationT
 
     @Test
     public void testManipulateProcessVariable() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_SIGNAL_PROCESS);
 
         assertNotNull(processInstanceId);
@@ -325,7 +313,6 @@ public class ProcessServiceIntegrationTest extends JbpmKieServerBaseIntegrationT
 
     @Test
     public void testManipulateProcessVariables() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_SIGNAL_PROCESS);
         assertNotNull(processInstanceId);
         assertTrue(processInstanceId.longValue() > 0);
@@ -376,7 +363,6 @@ public class ProcessServiceIntegrationTest extends JbpmKieServerBaseIntegrationT
     @Test
     @Category(Smoke.class)
     public void testGetProcessInstance() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_SIGNAL_PROCESS);
 
         assertNotNull(processInstanceId);
@@ -397,8 +383,6 @@ public class ProcessServiceIntegrationTest extends JbpmKieServerBaseIntegrationT
 
     @Test
     public void testGetProcessInstanceWithVariables() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -441,7 +425,6 @@ public class ProcessServiceIntegrationTest extends JbpmKieServerBaseIntegrationT
 
     @Test(expected = KieServicesException.class)
     public void testGetNonExistingProcessInstance() {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         processClient.getProcessInstance(CONTAINER_ID, 9999l);
     }
 
@@ -449,8 +432,6 @@ public class ProcessServiceIntegrationTest extends JbpmKieServerBaseIntegrationT
     public void testWorkItemOperations() throws Exception {
 
         changeUser(USER_JOHN);
-
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
 
         Map<String, Object> parameters = new HashMap<String, Object>();
 
@@ -525,8 +506,6 @@ public class ProcessServiceIntegrationTest extends JbpmKieServerBaseIntegrationT
 
         changeUser(USER_JOHN);
 
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
 
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_EVALUATION, parameters);
@@ -573,8 +552,6 @@ public class ProcessServiceIntegrationTest extends JbpmKieServerBaseIntegrationT
 
     @Test
     public void testStartCheckProcessWithCorrelationKey() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         String firstSimpleKey = "first-simple-key";
         String secondSimpleKey = "second-simple-key";
         String stringVarName = "stringData";
@@ -609,7 +586,6 @@ public class ProcessServiceIntegrationTest extends JbpmKieServerBaseIntegrationT
 
     @Test
     public void testStartProcessWithCustomTask() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("id", "custom id");
         Long processInstanceId = null;
@@ -633,7 +609,6 @@ public class ProcessServiceIntegrationTest extends JbpmKieServerBaseIntegrationT
 
     @Test
     public void testSignalContainer() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_SIGNAL_PROCESS);
 
         assertNotNull(processInstanceId);
@@ -660,7 +635,6 @@ public class ProcessServiceIntegrationTest extends JbpmKieServerBaseIntegrationT
 
     @Test
     public void testSignalStartProcess() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         try {
 
             List<Integer> status = new ArrayList<Integer>();
@@ -687,8 +661,6 @@ public class ProcessServiceIntegrationTest extends JbpmKieServerBaseIntegrationT
 
     @Test(timeout = 60 * 1000)
     public void testStartProcessInstanceWithAsyncNodes() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         List<String> status = new ArrayList<String>();
         status.add(STATUS.QUEUED.toString());
         status.add(STATUS.RUNNING.toString());
@@ -721,8 +693,6 @@ public class ProcessServiceIntegrationTest extends JbpmKieServerBaseIntegrationT
 
     @Test(timeout = 60 * 1000)
     public void testProcessInstanceWithTimer() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_TIMER);
         assertNotNull(processInstanceId);
         assertTrue(processInstanceId.longValue() > 0);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/QueryDataServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/QueryDataServiceIntegrationTest.java
@@ -21,25 +21,26 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kie.api.KieServices;
 import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
+import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.api.model.definition.ProcessDefinition;
 import org.kie.server.api.model.definition.QueryDefinition;
 import org.kie.server.api.model.definition.QueryFilterSpec;
 import org.kie.server.api.model.instance.ProcessInstance;
 import org.kie.server.api.model.instance.TaskInstance;
 import org.kie.server.api.util.QueryFilterSpecBuilder;
-import org.kie.server.client.KieServicesConfiguration;
+import org.kie.server.client.KieServicesClient;
 import org.kie.server.client.QueryServicesClient;
 import org.kie.server.integrationtests.config.TestConfig;
 
 import static org.junit.Assert.*;
 import static org.junit.Assume.assumeFalse;
 
-import org.kie.server.integrationtests.shared.KieServerAssert;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 
 public class QueryDataServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest {
@@ -49,13 +50,20 @@ public class QueryDataServiceIntegrationTest extends JbpmKieServerBaseIntegratio
 
     private static final String CONTAINER_ID = "query-definition-project";
 
+    private static final long EXTENDED_TIMEOUT = 300000;
+
     @BeforeClass
     public static void buildAndDeployArtifacts() {
-
         KieServerDeployer.buildAndDeployCommonMavenParent();
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/query-definition-project").getFile());
 
         kieContainer = KieServices.Factory.get().newKieContainer(releaseId);
+
+        disposeAllContainers();
+        // Having timeout issues due to kjar dependencies -> raised timeout.
+        KieServicesClient client = createDefaultStaticClient(EXTENDED_TIMEOUT);
+        ServiceResponse<KieContainerResource> reply = client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId));
+        Assume.assumeTrue(reply.getType().equals(ServiceResponse.ResponseType.SUCCESS));
     }
 
     @Override
@@ -63,17 +71,8 @@ public class QueryDataServiceIntegrationTest extends JbpmKieServerBaseIntegratio
         extraClasses.put(PERSON_CLASS_NAME, Class.forName(PERSON_CLASS_NAME, true, kieContainer.getClassLoader()));
     }
 
-    @Override
-    protected void additionalConfiguration(KieServicesConfiguration configuration) throws Exception {
-        super.additionalConfiguration(configuration);
-        // Having timeout issues due to kjar dependencies -> raised timeout.
-        configuration.setTimeout(300000);
-    }
-
     @Test
     public void testCRUDOnQueryDefinition() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -117,8 +116,6 @@ public class QueryDataServiceIntegrationTest extends JbpmKieServerBaseIntegratio
 
     @Test
     public void testGetProcessInstancesWithQueryDataService() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -154,8 +151,6 @@ public class QueryDataServiceIntegrationTest extends JbpmKieServerBaseIntegratio
 
     @Test
     public void testGetProcessInstancesWithVariablesQueryDataService() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -206,8 +201,6 @@ public class QueryDataServiceIntegrationTest extends JbpmKieServerBaseIntegratio
 
     @Test
     public void testGetProcessInstancesFilteredWithVariablesQueryDataService() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -247,8 +240,6 @@ public class QueryDataServiceIntegrationTest extends JbpmKieServerBaseIntegratio
 
     @Test
     public void testGetProcessInstancesWithQueryDataServiceUsingCustomMapper() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -284,8 +275,6 @@ public class QueryDataServiceIntegrationTest extends JbpmKieServerBaseIntegratio
 
     @Test
     public void testGetProcessInstancesWithQueryDataServiceUsingCustomQueryBuilder() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -314,8 +303,6 @@ public class QueryDataServiceIntegrationTest extends JbpmKieServerBaseIntegratio
 
     @Test
     public void testGetProcessInstancesWithQueryDataServiceRawMapper() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -352,8 +339,6 @@ public class QueryDataServiceIntegrationTest extends JbpmKieServerBaseIntegratio
 
     @Test
     public void testQueryDataServiceReplaceQuery() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(CONTAINER_ID));
@@ -396,8 +381,6 @@ public class QueryDataServiceIntegrationTest extends JbpmKieServerBaseIntegratio
 
     @Test
     public void testCRUDOnQueryDefinitionWithDSAsProperty() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         String expectedResolvedDS = System.getProperty("org.kie.server.persistence.ds", "jdbc/jbpm-ds");
 
         Map<String, Object> parameters = new HashMap<String, Object>();
@@ -449,7 +432,6 @@ public class QueryDataServiceIntegrationTest extends JbpmKieServerBaseIntegratio
     public void testGetFilteredProcessInstancesWithQueryDataService() throws Exception {
         // don't run the test on local server as it does not properly support authentication
         assumeFalse(TestConfig.isLocalServer());
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
 
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/RuntimeDataServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/RuntimeDataServiceIntegrationTest.java
@@ -30,7 +30,6 @@ import org.kie.internal.KieInternalServices;
 import org.kie.internal.process.CorrelationKey;
 import org.kie.internal.process.CorrelationKeyFactory;
 import org.kie.internal.task.api.model.TaskEvent;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.definition.ProcessDefinition;
 import org.kie.server.api.model.instance.NodeInstance;
@@ -68,6 +67,9 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project").getFile());
 
         kieContainer = KieServices.Factory.get().newKieContainer(releaseId);
+
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
     }
 
     @Override
@@ -77,8 +79,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetProcessDefinitions() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         List<ProcessDefinition> definitions = queryClient.findProcesses(0, 20);
         assertNotNull(definitions);
 
@@ -109,8 +109,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetProcessDefinitionsSorted() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         List<ProcessDefinition> definitions = queryClient.findProcesses(0, 20, QueryServicesClient.SORT_BY_NAME, false);
         assertNotNull(definitions);
 
@@ -141,8 +139,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetProcessDefinitionsWithFilter() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         List<ProcessDefinition> definitions = queryClient.findProcesses("evaluation", 0, 20);
         assertNotNull(definitions);
 
@@ -170,8 +166,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetProcessDefinitionsWithFilterSorted() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         List<ProcessDefinition> definitions = queryClient.findProcesses("evaluation", 0, 20, QueryServicesClient.SORT_BY_NAME, true);
         assertNotNull(definitions);
 
@@ -193,8 +187,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetProcessDefinitionsByContainer() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         List<ProcessDefinition> definitions = queryClient.findProcessesByContainerId(CONTAINER_ID, 0, 20);
         assertNotNull(definitions);
 
@@ -231,8 +223,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetProcessDefinitionsByContainerSorted() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         List<ProcessDefinition> definitions = queryClient.findProcessesByContainerId(CONTAINER_ID, 0, 20, QueryServicesClient.SORT_BY_NAME, true);
         assertNotNull(definitions);
 
@@ -262,8 +252,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetProcessDefinitionsById() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         List<ProcessDefinition> definitions = queryClient.findProcessesById(PROCESS_ID_USERTASK);
         assertNotNull(definitions);
 
@@ -282,8 +270,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetProcessDefinitionByContainerAndId() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         ProcessDefinition definition = queryClient.findProcessByContainerIdProcessId(CONTAINER_ID, PROCESS_ID_USERTASK);
         assertNotNull(definition);
         assertEquals(PROCESS_ID_USERTASK, definition.getId());
@@ -296,8 +282,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetProcessDefinitionByContainerAndNonExistingId() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         try {
             queryClient.findProcessByContainerIdProcessId(CONTAINER_ID, "non-existing");
             fail("KieServicesException should be thrown complaining about process definition not found.");
@@ -309,8 +293,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetProcessInstances() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -341,8 +323,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetProcessInstancesSortedByName() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -383,8 +363,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetProcessInstancesByContainer() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         int offset = queryClient.findProcessInstancesByContainerId(CONTAINER_ID, Collections.singletonList(2), 0, 10).size();
 
         Map<String, Object> parameters = new HashMap<String, Object>();
@@ -422,8 +400,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetProcessInstancesByContainerSortedByName() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -464,8 +440,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetProcessInstancesByProcessId() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -502,8 +476,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetProcessInstancesByProcessIdSortedByInstanceId() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -525,8 +497,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetProcessInstancesByProcessName() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -563,8 +533,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetProcessInstancesByProcessNameSortedByInstanceId() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -586,8 +554,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetProcessInstancesByStatus() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -621,8 +587,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetProcessInstancesByStatusSortedByName() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -663,8 +627,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetProcessInstancesByInitiator() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         int offset = queryClient.findProcessInstancesByInitiator(USER_YODA, Collections.singletonList(2), 0, 10).size();
 
         Map<String, Object> parameters = new HashMap<String, Object>();
@@ -700,8 +662,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetProcessInstancesByInitiatorSortedByName() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -743,8 +703,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
     @Test
     @Category(Smoke.class)
     public void testGetProcessInstanceById() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_EVALUATION, parameters);
         try {
@@ -766,8 +724,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetProcessInstanceWithVariables() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         Object person = createPersonInstance(USER_JOHN);
@@ -819,8 +775,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetProcessInstanceByNonExistingId() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         try {
             queryClient.findProcessInstanceById(-9999l);
             fail("KieServicesException should be thrown complaining about process instance not found.");
@@ -832,8 +786,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetProcessInstanceByCorrelationKey() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         CorrelationKeyFactory correlationKeyFactory = KieInternalServices.Factory.get().newCorrelationKeyFactory();
 
         String businessKey = "simple-key";
@@ -883,8 +835,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetProcessInstancesByCorrelationKeySortedById() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         CorrelationKeyFactory correlationKeyFactory = KieInternalServices.Factory.get().newCorrelationKeyFactory();
 
         String firstBusinessKey = "my-simple-key-first";
@@ -913,8 +863,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetProcessInstanceByCorrelationKeyPaging() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         CorrelationKeyFactory correlationKeyFactory = KieInternalServices.Factory.get().newCorrelationKeyFactory();
 
         String businessKey = "simple-key";
@@ -936,8 +884,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetProcessInstancesByVariableName() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -968,8 +914,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetProcessInstancesByVariableNameSortedByName() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -1010,8 +954,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetProcessInstancesByVariableNameAndValue() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("personData", createPersonInstance(USER_JOHN));
 
@@ -1055,8 +997,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetProcessInstancesByVariableNameAndValueSortedByName() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("personData", createPersonInstance(USER_JOHN));
 
@@ -1100,8 +1040,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetNodeInstances() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -1176,8 +1114,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testGetVariableInstance() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -1280,8 +1216,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testFindTasks() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -1333,8 +1267,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testFindTasksSortedByProcessInstanceId() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -1363,8 +1295,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testFindTaskEvents() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -1445,8 +1375,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testFindTaskEventsSortedByType() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -1507,8 +1435,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testFindTasksOwned() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -1548,8 +1474,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testFindTasksOwnedSortedByStatus() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -1584,8 +1508,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testFindTasksAssignedAsPotentialOwner() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -1626,8 +1548,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testFindTasksAssignedAsPotentialOwnerSortedByStatus() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -1662,8 +1582,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testFindTasksByStatusByProcessInstanceId() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(USER_JOHN));

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/UserTaskEscalationIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/UserTaskEscalationIntegrationTest.java
@@ -33,7 +33,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.instance.ProcessInstance;
 import org.kie.server.api.model.instance.TaskInstance;
@@ -88,12 +87,13 @@ public class UserTaskEscalationIntegrationTest extends JbpmKieServerBaseIntegrat
     public static void buildAndDeployArtifacts() {
         KieServerDeployer.buildAndDeployCommonMavenParent();
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project").getFile());
+
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
     }
 
     @Test
     public void testEscalation() throws InterruptedException, MessagingException, Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK_ESCALATION, params);
         assertNotNull(processInstanceId);
         assertTrue(processInstanceId > 0);
@@ -143,8 +143,6 @@ public class UserTaskEscalationIntegrationTest extends JbpmKieServerBaseIntegrat
 
     @Test
     public void testCompleteTaskBeforeEscalation() throws InterruptedException {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK_ESCALATION, params);
         assertNotNull(processInstanceId);
         assertTrue(processInstanceId > 0);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/UserTaskServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/UserTaskServiceIntegrationTest.java
@@ -27,7 +27,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.api.KieServices;
 import org.kie.api.task.model.Status;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.instance.TaskAttachment;
 import org.kie.server.api.model.instance.TaskComment;
@@ -58,6 +57,9 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project").getFile());
 
         kieContainer = KieServices.Factory.get().newKieContainer(releaseId);
+
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
     }
 
     @Override
@@ -68,7 +70,6 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
     @Test
     @Category(Smoke.class)
     public void testProcessWithUserTasks() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK);
         assertNotNull(processInstanceId);
         assertTrue(processInstanceId.longValue() > 0);
@@ -112,7 +113,6 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
 
     @Test
     public void testAutoProgressComplete() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK);
         assertNotNull(processInstanceId);
         assertTrue(processInstanceId.longValue() > 0);
@@ -157,7 +157,6 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
 
     @Test
     public void testReleaseAndClaim() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK);
         assertNotNull(processInstanceId);
         assertTrue(processInstanceId.longValue() > 0);
@@ -195,7 +194,6 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
 
     @Test
     public void testStartAndStop() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK);
         assertNotNull(processInstanceId);
         assertTrue(processInstanceId.longValue() > 0);
@@ -233,7 +231,6 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
 
     @Test
     public void testSuspendAndResume() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK);
         assertNotNull(processInstanceId);
         assertTrue(processInstanceId.longValue() > 0);
@@ -270,7 +267,6 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
 
     @Test
     public void testFailUserTask() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK);
         assertNotNull(processInstanceId);
         assertTrue(processInstanceId.longValue() > 0);
@@ -305,7 +301,6 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
 
     @Test
     public void testSkipUserTask() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK);
         assertNotNull(processInstanceId);
         assertTrue(processInstanceId.longValue() > 0);
@@ -334,8 +329,6 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
 
     @Test
     public void testUserTaskContentOperations() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "john is working on it");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -416,7 +409,6 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
 
     @Test
     public void testUserTaskById() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK);
         assertNotNull(processInstanceId);
         assertTrue(processInstanceId.longValue() > 0);
@@ -460,15 +452,11 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
 
     @Test (expected = KieServicesException.class)
     public void testNotExistingUserTaskById() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         taskClient.getTaskInstance(CONTAINER_ID, -9999l);
-
     }
 
     @Test
     public void testUserTaskByIdWithDetails() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "john is working on it");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -546,7 +534,6 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
      */
     @Test
     public void testForwardUserTask() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK);
         assertNotNull(processInstanceId);
         assertTrue(processInstanceId.longValue() > 0);
@@ -608,7 +595,6 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
      */
     @Test
     public void testDelegateUserTask() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK);
         assertNotNull(processInstanceId);
         assertTrue(processInstanceId.longValue() > 0);
@@ -668,8 +654,6 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
 
     @Test
     public void testUserTaskSetTaskProperties() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK);
         assertNotNull(processInstanceId);
         assertTrue(processInstanceId.longValue() > 0);
@@ -716,8 +700,6 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
 
     @Test
     public void testUserTaskComments() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK);
         assertNotNull(processInstanceId);
         assertTrue(processInstanceId.longValue() > 0);
@@ -777,8 +759,6 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
 
     @Test
     public void testUserTaskAttachments() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK);
         assertNotNull(processInstanceId);
         assertTrue(processInstanceId.longValue() > 0);
@@ -851,8 +831,6 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
 
     @Test
     public void testUserTaskAttachmentsAsByteArray() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK);
         assertNotNull(processInstanceId);
         assertTrue(processInstanceId.longValue() > 0);
@@ -879,7 +857,6 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
 
     @Test
     public void testExitUserTask() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK);
         assertNotNull(processInstanceId);
         assertTrue(processInstanceId.longValue() > 0);
@@ -910,7 +887,6 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
     public void testGroupUserTask() throws Exception {
         String taskName = "Group task";
 
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_GROUPTASK);
         assertNotNull(processInstanceId);
         assertTrue(processInstanceId.longValue() > 0);
@@ -961,8 +937,6 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
 
     @Test
     public void testFindTasksByVariable() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "john is working on it");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -1017,8 +991,6 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
 
     @Test
     public void testFindTasksByVariableAndValue() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "john is working on it");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -1073,8 +1045,6 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
 
     @Test
     public void testFindTasksByVariableAndValueSortedByProcessInstanceId() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "john is working on it");
         parameters.put("personData", createPersonInstance(USER_JOHN));
@@ -1107,8 +1077,8 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
 
     @Test
     public void testProcessWithUserTasksWithConversationId() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
-
+        // Used to load conversation Id.
+        client.getContainerInfo(CONTAINER_ID);
         String conversationId = client.getConversationId();
         assertNotNull(conversationId);
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/jms/JmsQueueIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/jms/JmsQueueIntegrationTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runners.Parameterized;
 import org.kie.server.api.marshalling.MarshallingFormat;
-import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.instance.ProcessInstance;
 import org.kie.server.client.KieServicesClient;
@@ -40,7 +39,6 @@ import org.kie.server.integrationtests.controller.ContainerRemoteController;
 import org.kie.server.integrationtests.jbpm.JbpmKieServerBaseIntegrationTest;
 
 import static org.junit.Assert.*;
-import org.kie.server.integrationtests.shared.KieServerAssert;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 
 @Category({JMSOnly.class, RemotelyControlled.class})
@@ -69,12 +67,13 @@ public class JmsQueueIntegrationTest extends JbpmKieServerBaseIntegrationTest {
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project").getFile());
 
         containerRemoteController = new ContainerRemoteController(TestConfig.getContainerId(), TestConfig.getContainerPort());
+
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, RELEASE_ID);
     }
 
     @Test
     public void testStartProcessFromJmsAfterApplicationStart() throws Exception {
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, RELEASE_ID)));
-
         // Custom client with reduced timeout
         KieServicesConfiguration customConfig = configuration.clone();
         customConfig.setTimeout(3000);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/rest/JbpmRestIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/rest/JbpmRestIntegrationTest.java
@@ -37,7 +37,6 @@ import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.type.JaxbLong;
 import org.kie.server.integrationtests.config.TestConfig;
 import org.kie.server.integrationtests.jbpm.DBExternalResource;
-import org.kie.server.integrationtests.shared.KieServerAssert;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 import org.kie.server.integrationtests.shared.basetests.RestOnlyBaseIntegrationTest;
 import org.slf4j.Logger;
@@ -62,6 +61,9 @@ public class JbpmRestIntegrationTest extends RestOnlyBaseIntegrationTest {
         // set the accepted formats with quality param to express preference
         acceptHeadersByFormat.put(MarshallingFormat.JAXB, "application/xml;q=0.9,application/json;q=0.3");// xml is preferred over json
         acceptHeadersByFormat.put(MarshallingFormat.JSON, "application/json;q=0.9,application/xml;q=0.3");// json is preferred over xml
+
+        disposeAllContainers();
+        createContainer(CONTAINER, releaseId);
     }
 
 
@@ -93,7 +95,6 @@ public class JbpmRestIntegrationTest extends RestOnlyBaseIntegrationTest {
     @Test
     public void testBasicJbpmRequest() throws Exception {
         KieContainerResource resource = new KieContainerResource(CONTAINER, releaseId);
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER, resource));
 
         Map<String, Object> valuesMap = new HashMap<String, Object>();
         valuesMap.put(CONTAINER_ID, resource.getContainerId());
@@ -138,7 +139,6 @@ public class JbpmRestIntegrationTest extends RestOnlyBaseIntegrationTest {
     @Test
     public void testBasicJbpmRequestWithSingleAcceptHeader() throws Exception {
         KieContainerResource resource = new KieContainerResource(CONTAINER, releaseId);
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER, resource));
 
         Map<String, Object> valuesMap = new HashMap<String, Object>();
         valuesMap.put(CONTAINER_ID, resource.getContainerId());
@@ -172,7 +172,6 @@ public class JbpmRestIntegrationTest extends RestOnlyBaseIntegrationTest {
     @Test
     public void testBasicJbpmRequestManyAcceptHeaders() throws Exception {
         KieContainerResource resource = new KieContainerResource(CONTAINER, releaseId);
-        KieServerAssert.assertSuccess(client.createContainer(CONTAINER, resource));
 
         Map<String, Object> valuesMap = new HashMap<String, Object>();
         valuesMap.put(CONTAINER_ID, resource.getContainerId());


### PR DESCRIPTION
Creating of containers is very costly operation. Reuse existing containers between test methods to significantly reduce test time - just for tests where it is possible.
@mswiderski @psiroky what do you think about it?

Rough local test:
before PR:
common - Total time: 59.200 s
drools - Total time: 03:24 min
jbpm - Total time: 12:35 min
optaplanner - Total time: 03:42 min
all - Total time: 01:55 min
controller - Total time: 01:19 min


after PR:
common - Total time: 59.290 s
drools - Total time: 02:25 min
jbpm - Total time: 07:23 min
optaplanner - Total time: 03:17 min
all - Total time: 01:25 min
controller - Total time: 01:19 min