### PR TITLE
kie-server-tests: move container disposing to base test class

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/DeploymentDescriptorIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/DeploymentDescriptorIntegrationTest.java
@@ -53,7 +53,6 @@ public class DeploymentDescriptorIntegrationTest extends JbpmKieServerBaseIntegr
 
         kieContainer = KieServices.Factory.get().newKieContainer(releaseId);
 
-        disposeAllContainers();
         createContainer(CONTAINER_ID, releaseId);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/FormServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/FormServiceIntegrationTest.java
@@ -41,7 +41,6 @@ public class FormServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
         KieServerDeployer.buildAndDeployCommonMavenParent();
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project").getFile());
 
-        disposeAllContainers();
         createContainer(CONTAINER_ID, releaseId);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/ImageServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/ImageServiceIntegrationTest.java
@@ -38,7 +38,6 @@ public class ImageServiceIntegrationTest extends JbpmKieServerBaseIntegrationTes
         KieServerDeployer.buildAndDeployCommonMavenParent();
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project").getFile());
 
-        disposeAllContainers();
         createContainer(CONTAINER_ID, releaseId);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/PerProcessInstanceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/PerProcessInstanceIntegrationTest.java
@@ -57,7 +57,6 @@ public class PerProcessInstanceIntegrationTest extends JbpmKieServerBaseIntegrat
 
         kieContainer = KieServices.Factory.get().newKieContainer(releaseId);
 
-        disposeAllContainers();
         createContainer(CONTAINER_ID, releaseId);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/RuleRelatedProcessIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/RuleRelatedProcessIntegrationTest.java
@@ -51,7 +51,6 @@ public class RuleRelatedProcessIntegrationTest extends JbpmKieServerBaseIntegrat
 
         kieContainer = KieServices.Factory.get().newKieContainer(releaseId);
 
-        disposeAllContainers();
         createContainer(CONTAINER_ID, releaseId);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/rest/FormServiceRestOnlyIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/rest/FormServiceRestOnlyIntegrationTest.java
@@ -62,7 +62,6 @@ public class FormServiceRestOnlyIntegrationTest extends RestOnlyBaseIntegrationT
         KieServerDeployer.buildAndDeployCommonMavenParent();
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project").getFile());
 
-        disposeAllContainers();
         createContainer(CONTAINER_ID, releaseId);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/rest/ImageServiceRestOnlyIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/rest/ImageServiceRestOnlyIntegrationTest.java
@@ -61,7 +61,6 @@ public class ImageServiceRestOnlyIntegrationTest extends RestOnlyBaseIntegration
         KieServerDeployer.buildAndDeployCommonMavenParent();
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project").getFile());
 
-        disposeAllContainers();
         createContainer(CONTAINER_ID, releaseId);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/basetests/KieServerBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/basetests/KieServerBaseIntegrationTest.java
@@ -69,6 +69,7 @@ public abstract class KieServerBaseIntegrationTest {
             server.startKieServer();
         }
         setupCustomSettingsXml();
+        disposeAllContainers();
     }
 
     private static void setupCustomSettingsXml() {

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/KieServerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/KieServerIntegrationTest.java
@@ -42,7 +42,6 @@ public class KieServerIntegrationTest extends RestJmsSharedBaseIntegrationTest {
     public static void initialize() throws Exception {
         KieServerDeployer.createAndDeployKJar(releaseId1);
 
-        disposeAllContainers();
         createContainer(CONTAINER_ID, releaseId1);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/ActivationGroupIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/ActivationGroupIntegrationTest.java
@@ -32,7 +32,6 @@ public class ActivationGroupIntegrationTest extends DroolsKieServerBaseIntegrati
         KieServerDeployer.buildAndDeployCommonMavenParent();
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/activation-group").getFile());
 
-        disposeAllContainers();
         createContainer(CONTAINER_ID, releaseId);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/AgendaGroupIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/AgendaGroupIntegrationTest.java
@@ -32,7 +32,6 @@ public class AgendaGroupIntegrationTest extends DroolsKieServerBaseIntegrationTe
         KieServerDeployer.buildAndDeployCommonMavenParent();
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/agenda-group").getFile());
 
-        disposeAllContainers();
         createContainer(CONTAINER_ID, releaseId);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/AgendaIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/AgendaIntegrationTest.java
@@ -31,7 +31,6 @@ public class AgendaIntegrationTest extends DroolsKieServerBaseIntegrationTest {
         KieServerDeployer.buildAndDeployCommonMavenParent();
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/agenda-group").getFile());
 
-        disposeAllContainers();
         createContainer(CONTAINER_ID, releaseId);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/ConcurrentRequestsIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/ConcurrentRequestsIntegrationTest.java
@@ -58,7 +58,6 @@ public class ConcurrentRequestsIntegrationTest extends DroolsKieServerBaseIntegr
         KieServerDeployer.buildAndDeployCommonMavenParent();
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/stateless-session-kjar").getFile());
 
-        disposeAllContainers();
         createContainer(CONTAINER_ID, releaseId);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/ContainerIsolationIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/ContainerIsolationIntegrationTest.java
@@ -52,7 +52,6 @@ public class ContainerIsolationIntegrationTest extends DroolsKieServerBaseIntegr
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/container-isolation-kjar1").getFile());
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/container-isolation-kjar2").getFile());
 
-        disposeAllContainers();
         createContainer(CONTAINER_1_ID, kjar1);
         createContainer(CONTAINER_2_ID, kjar2);
     }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/GuidedDecisionTableIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/GuidedDecisionTableIntegrationTest.java
@@ -54,7 +54,6 @@ public class GuidedDecisionTableIntegrationTest extends DroolsKieServerBaseInteg
 
         kjarClassLoader = KieServices.Factory.get().newKieContainer(releaseId).getClassLoader();
 
-        disposeAllContainers();
         createContainer(CONTAINER_ID, releaseId);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/GuidedDecisionTreeIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/GuidedDecisionTreeIntegrationTest.java
@@ -54,7 +54,6 @@ public class GuidedDecisionTreeIntegrationTest extends DroolsKieServerBaseIntegr
 
         kjarClassLoader = KieServices.Factory.get().newKieContainer(releaseId).getClassLoader();
 
-        disposeAllContainers();
         createContainer(CONTAINER_ID, releaseId);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/KieServerBackwardCompatDroolsIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/KieServerBackwardCompatDroolsIntegrationTest.java
@@ -58,7 +58,6 @@ public class KieServerBackwardCompatDroolsIntegrationTest extends DroolsKieServe
         File jar = KieServerDeployer.getRepository().resolveArtifact(releaseId).getFile();
         kjarClassLoader = new URLClassLoader(new URL[]{jar.toURI().toURL()});
 
-        disposeAllContainers();
         createContainer(CONTAINER_ID, releaseId);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/KieServerDroolsIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/KieServerDroolsIntegrationTest.java
@@ -69,7 +69,6 @@ public class KieServerDroolsIntegrationTest extends DroolsKieServerBaseIntegrati
         File jar = KieServerDeployer.getRepository().resolveArtifact(releaseId).getFile();
         kjarClassLoader = new URLClassLoader(new URL[]{jar.toURI().toURL()});
 
-        disposeAllContainers();
         createContainer(CONTAINER_ID, releaseId);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/MultiModuleProjectIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/MultiModuleProjectIntegrationTest.java
@@ -54,7 +54,6 @@ public class MultiModuleProjectIntegrationTest extends DroolsKieServerBaseIntegr
         // the parent will build and deploy also all of its modules, so no need to deploy them individually
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/multimodule-project").getFile());
 
-        disposeAllContainers();
         createContainer(CONTAINER_1_ID, releaseIdRules1);
         createContainer(CONTAINER_2_ID, releaseIdRules2);
     }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/ObjectHandlingIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/ObjectHandlingIntegrationTest.java
@@ -40,7 +40,6 @@ public class ObjectHandlingIntegrationTest extends DroolsKieServerBaseIntegratio
 
         kjarClassLoader = KieServices.Factory.get().newKieContainer(releaseId).getClassLoader();
 
-        disposeAllContainers();
         createContainer(CONTAINER_ID, releaseId);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/RuleTemplateIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/RuleTemplateIntegrationTest.java
@@ -54,7 +54,6 @@ public class RuleTemplateIntegrationTest extends DroolsKieServerBaseIntegrationT
 
         kjarClassLoader = KieServices.Factory.get().newKieContainer(releaseId).getClassLoader();
 
-        disposeAllContainers();
         createContainer(CONTAINER_ID, releaseId);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/SpreadsheetIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/SpreadsheetIntegrationTest.java
@@ -54,7 +54,6 @@ public class SpreadsheetIntegrationTest extends DroolsKieServerBaseIntegrationTe
 
         kjarClassLoader = KieServices.Factory.get().newKieContainer(releaseId).getClassLoader();
 
-        disposeAllContainers();
         createContainer(CONTAINER_ID, releaseId);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/StatelessSessionUsageIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/StatelessSessionUsageIntegrationTest.java
@@ -54,7 +54,6 @@ public class StatelessSessionUsageIntegrationTest extends DroolsKieServerBaseInt
 
         kjarClassLoader = KieServices.Factory.get().newKieContainer(releaseId).getClassLoader();
 
-        disposeAllContainers();
         createContainer(CONTAINER_ID, releaseId);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/rest/RestMalformedRequestIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/rest/RestMalformedRequestIntegrationTest.java
@@ -48,7 +48,6 @@ public class RestMalformedRequestIntegrationTest extends RestOnlyBaseIntegration
         KieServerDeployer.buildAndDeployCommonMavenParent();
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/state-is-kept-for-stateful-session").getFile());
 
-        disposeAllContainers();
         createContainer(CONTAINER_ID, releaseId);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/BARuntimeDataServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/BARuntimeDataServiceIntegrationTest.java
@@ -47,7 +47,6 @@ public class BARuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegr
 
         kieContainer = KieServices.Factory.get().newKieContainer(releaseId);
 
-        disposeAllContainers();
         createContainer(CONTAINER_ID, releaseId);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/DocumentServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/DocumentServiceIntegrationTest.java
@@ -53,7 +53,6 @@ public class DocumentServiceIntegrationTest extends JbpmKieServerBaseIntegration
 
         kieContainer = KieServices.Factory.get().newKieContainer(releaseId);
 
-        disposeAllContainers();
         createContainer(CONTAINER_ID, releaseId);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/JobServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/JobServiceIntegrationTest.java
@@ -56,7 +56,6 @@ public class JobServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest 
 
         kieContainer = KieServices.Factory.get().newKieContainer(releaseId);
 
-        disposeAllContainers();
         createContainer(CONTAINER_ID, releaseId);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/ProcessDefinitionIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/ProcessDefinitionIntegrationTest.java
@@ -50,7 +50,6 @@ public class ProcessDefinitionIntegrationTest extends JbpmKieServerBaseIntegrati
 
         kieContainer = KieServices.Factory.get().newKieContainer(releaseId);
 
-        disposeAllContainers();
         createContainer(CONTAINER_ID, releaseId);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/ProcessServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/ProcessServiceIntegrationTest.java
@@ -59,7 +59,6 @@ public class ProcessServiceIntegrationTest extends JbpmKieServerBaseIntegrationT
 
         kieContainer = KieServices.Factory.get().newKieContainer(releaseId);
 
-        disposeAllContainers();
         createContainer(CONTAINER_ID, releaseId);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/QueryDataServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/QueryDataServiceIntegrationTest.java
@@ -59,7 +59,6 @@ public class QueryDataServiceIntegrationTest extends JbpmKieServerBaseIntegratio
 
         kieContainer = KieServices.Factory.get().newKieContainer(releaseId);
 
-        disposeAllContainers();
         // Having timeout issues due to kjar dependencies -> raised timeout.
         KieServicesClient client = createDefaultStaticClient(EXTENDED_TIMEOUT);
         ServiceResponse<KieContainerResource> reply = client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId));

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/RuntimeDataServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/RuntimeDataServiceIntegrationTest.java
@@ -68,7 +68,6 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
         kieContainer = KieServices.Factory.get().newKieContainer(releaseId);
 
-        disposeAllContainers();
         createContainer(CONTAINER_ID, releaseId);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/UserTaskEscalationIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/UserTaskEscalationIntegrationTest.java
@@ -88,7 +88,6 @@ public class UserTaskEscalationIntegrationTest extends JbpmKieServerBaseIntegrat
         KieServerDeployer.buildAndDeployCommonMavenParent();
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project").getFile());
 
-        disposeAllContainers();
         createContainer(CONTAINER_ID, releaseId);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/UserTaskServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/UserTaskServiceIntegrationTest.java
@@ -58,7 +58,6 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
 
         kieContainer = KieServices.Factory.get().newKieContainer(releaseId);
 
-        disposeAllContainers();
         createContainer(CONTAINER_ID, releaseId);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/jms/JmsQueueIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/jms/JmsQueueIntegrationTest.java
@@ -68,7 +68,6 @@ public class JmsQueueIntegrationTest extends JbpmKieServerBaseIntegrationTest {
 
         containerRemoteController = new ContainerRemoteController(TestConfig.getContainerId(), TestConfig.getContainerPort());
 
-        disposeAllContainers();
         createContainer(CONTAINER_ID, RELEASE_ID);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/rest/JbpmRestIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/rest/JbpmRestIntegrationTest.java
@@ -62,7 +62,6 @@ public class JbpmRestIntegrationTest extends RestOnlyBaseIntegrationTest {
         acceptHeadersByFormat.put(MarshallingFormat.JAXB, "application/xml;q=0.9,application/json;q=0.3");// xml is preferred over json
         acceptHeadersByFormat.put(MarshallingFormat.JSON, "application/json;q=0.9,application/xml;q=0.3");// json is preferred over xml
 
-        disposeAllContainers();
         createContainer(CONTAINER, releaseId);
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/OptaplannerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/OptaplannerIntegrationTest.java
@@ -59,7 +59,6 @@ public class OptaplannerIntegrationTest
 
         kieContainer = KieServices.Factory.get().newKieContainer(kjar1);
 
-        disposeAllContainers();
         createContainer(CONTAINER_1_ID, kjar1);
     }
 


### PR DESCRIPTION
So every test case get clean Kie server out of the box.