### PR TITLE
kie-server-tests: raise timeout for sync with controller

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerSynchronization.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerSynchronization.java
@@ -32,7 +32,6 @@ public class KieServerSynchronization {
 
     private static final long SERVICE_TIMEOUT = 30000;
     private static final long TIMEOUT_BETWEEN_CALLS = 200;
-    private static final long SYNCHRONIZATION_TIMEOUT = 2000;
 
     public static void waitForJobToFinish(JobServicesClient jobServicesClient, Long jobId) throws Exception {
         long timeoutTime = Calendar.getInstance().getTimeInMillis() + SERVICE_TIMEOUT;
@@ -51,7 +50,7 @@ public class KieServerSynchronization {
     }
 
     public static void waitForKieServerSynchronization(KieServicesClient client, int numberOfExpectedContainers) throws Exception {
-        long timeoutTime = Calendar.getInstance().getTimeInMillis() + SYNCHRONIZATION_TIMEOUT;
+        long timeoutTime = Calendar.getInstance().getTimeInMillis() + SERVICE_TIMEOUT;
         while (Calendar.getInstance().getTimeInMillis() < timeoutTime) {
             ServiceResponse<KieContainerResourceList> containersList = client.listContainers();
 


### PR DESCRIPTION
Raise timeout for synchronization between controller and Kie server.
If controller is integrated as part of workbench then starting of containers is executed asynchronously. This cause delays between returning of response from controller and actual start of container. Low timeout threshold  cause test instability.