### PR TITLE
[6.5.x] kie-server-tests: raise timeout for sync with controller

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerManagementBaseTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerManagementBaseTest.java
@@ -31,7 +31,7 @@ import org.kie.server.integrationtests.shared.RestOnlyBaseIntegrationTest;
 
 public abstract class KieControllerManagementBaseTest extends RestOnlyBaseIntegrationTest {
 
-    private static final long SYNCHRONIZATION_TIMEOUT = 2000;
+    private static final long SYNCHRONIZATION_TIMEOUT = 30000;
     private static final long TIMEOUT_BETWEEN_CALLS = 200;
 
     protected KieServerMgmtControllerClient controllerClient;


### PR DESCRIPTION
Cherrypick of https://github.com/droolsjbpm/droolsjbpm-integration/pull/540