### PR TITLE
[6.4.x] kie-server-tests: update unstable escalation test

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/category/Unstable.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/category/Unstable.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.server.integrationtests.category;
+
+/**
+ * Marks tests which are unstable and may cause false positives.
+ * Instability can be caused by external factors - slow database connection, slow network and such.
+ */
+public interface Unstable {
+}

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/UserTaskEscalationIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/UserTaskEscalationIntegrationTest.java
@@ -39,6 +39,7 @@ import org.kie.server.api.model.instance.ProcessInstance;
 import org.kie.server.api.model.instance.TaskInstance;
 import org.kie.server.api.model.instance.TaskSummary;
 import org.kie.server.integrationtests.category.Email;
+import org.kie.server.integrationtests.category.Unstable;
 import org.kie.server.integrationtests.config.TestConfig;
 
 import org.subethamail.wiser.Wiser;
@@ -141,7 +142,9 @@ public class UserTaskEscalationIntegrationTest extends JbpmKieServerBaseIntegrat
     }
 
     @Test
+    @Category(Unstable.class)
     public void testCompleteTaskBeforeEscalation() throws InterruptedException {
+        // Unstable on slow DBs where starting of task is called after escalation timeout.
         assertSuccess(client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId)));
 
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK_ESCALATION, params);
@@ -154,10 +157,6 @@ public class UserTaskEscalationIntegrationTest extends JbpmKieServerBaseIntegrat
         TaskSummary taskSummary = taskList.get(0);
         assertEquals("User Task", taskSummary.getName());
         Long taskId = taskSummary.getId();
-
-        TaskInstance taskInstance = taskClient.findTaskById(taskId);
-        assertNotNull(taskInstance);
-        assertEquals(USER_YODA, taskInstance.getActualOwner());
 
         taskClient.startTask(CONTAINER_ID, taskId, USER_YODA);
         taskClient.completeTask(CONTAINER_ID, taskId, USER_YODA, new HashMap<String, Object>());


### PR DESCRIPTION
Cherrypick of https://github.com/droolsjbpm/droolsjbpm-integration/pull/543