### PR TITLE
6.4.x: RHBPMS-397 - Allow insecure Remote task operations (not only limited to GetTask* commands)

### DIFF
--- a/kie-remote/kie-remote-client/src/main/java/org/kie/services/client/api/command/AbstractRemoteCommandObject.java
+++ b/kie-remote/kie-remote-client/src/main/java/org/kie/services/client/api/command/AbstractRemoteCommandObject.java
@@ -165,7 +165,7 @@ public abstract class AbstractRemoteCommandObject {
 
     void preprocessCommand( Command cmd ) {
         String cmdName = cmd.getClass().getSimpleName();
-        if( ! config.getDisableTaskSecurity() && cmd instanceof TaskCommand && cmdName.startsWith("GetTask") ) {
+        if( ! config.getDisableTaskSecurity() && cmd instanceof TaskCommand ) {
            TaskCommand taskCmd = (TaskCommand) cmd;
            String cmdUserId = taskCmd.getUserId();
            String authUserId = config.getUserName();

--- a/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/util/ExecuteCommandUtil.java
+++ b/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/util/ExecuteCommandUtil.java
@@ -42,16 +42,14 @@ public class ExecuteCommandUtil {
                 if( cmd instanceof TaskCommand ) {
                     String cmdName = cmd.getClass().getSimpleName();
                     if( ! allowAllUsersAccessToAllTasks ) {
-                        if( cmdName.startsWith("GetTask") ) {
-                            String cmdUserId = ((TaskCommand) cmd).getUserId();
-                            if( cmdUserId == null ) {
-                                throw KieRemoteRestOperationException.badRequest("A null user id for a '" + cmdName + "' is not allowed!");
-                            }
-                            String authUserId = identityProvider.getName();
-                            if( ! cmdUserId.equals(authUserId) ) {
-                                throw KieRemoteRestOperationException.conflict("The user id used when retrieving task information (" + cmdUserId + ")"
-                                        + " must match the authenticating user (" + authUserId + ")!");
-                            }
+                        String cmdUserId = ((TaskCommand) cmd).getUserId();
+                        if( cmdUserId == null ) {
+                            throw KieRemoteRestOperationException.badRequest("A null user id for a '" + cmdName + "' is not allowed!");
+                        }
+                        String authUserId = identityProvider.getName();
+                        if( ! cmdUserId.equals(authUserId) ) {
+                            throw KieRemoteRestOperationException.conflict("The user id used when retrieving task information (" + cmdUserId + ")"
+                                    + " must match the authenticating user (" + authUserId + ")!");
                         }
                     }
                 }


### PR DESCRIPTION

Tested via this code: 
- https://github.com/droolsjbpm/kie-tests/commit/982e830620e744f2747fee4d133c7d5684643fc6#diff-308e0f502097849c0745cffc88160b9aR1341?w=1
- https://github.com/droolsjbpm/kie-tests/commit/982e830620e744f2747fee4d133c7d5684643fc6#diff-ed7496f3242fedf28fbc556124b5d9beR23