### PR TITLE
[6.5.x] kie-remote-jaxb-gen: upgrade jaxb2-maven-plugin from 1.6 to 2.2

### DIFF
--- a/kie-remote/kie-remote-jaxb-gen/pom.xml
+++ b/kie-remote/kie-remote-jaxb-gen/pom.xml
@@ -237,32 +237,9 @@
       </plugin>
 
       <plugin>
-        <!-- We use this plugin to ensure that our usage of the
-             jaxb2-maven-plugin is JDK 8 compatible. -->
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
-        <version>1.0-alpha-2</version>
-        <executions>
-          <execution>
-            <id>set-additional-system-properties</id>
-            <goals>
-              <goal>set-system-properties</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <properties>
-            <property>
-              <name>javax.xml.accessExternalSchema</name>
-              <value>file,http</value>
-            </property>
-          </properties>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>jaxb2-maven-plugin</artifactId>
-        <version>1.6</version>
+        <version>2.2</version>
         <executions>
           <!-- 2. generate xsd's based on unpacked sources -->
           <execution>
@@ -272,11 +249,10 @@
               <goal>schemagen</goal>
             </goals>
             <configuration>
-              <includes>
-                <include>org/drools/**/*.java</include>
-                <include>org/jbpm/**/*.java</include>
-              </includes>
-              <verbose>true</verbose>
+              <sources>
+                <source>${project.basedir}/src/main/java/org/drools</source>
+                <source>${project.basedir}/src/main/java/org/jbpm</source>
+              </sources>
               <outputDirectory>${project.build.directory}/generated-xsd/</outputDirectory>
             </configuration>
           </execution>
@@ -290,8 +266,12 @@
             <configuration>
               <packageName>org.kie.remote.jaxb.gen</packageName>
               <outputDirectory>${basedir}/src/main/generated</outputDirectory>
-              <schemaDirectory>${project.build.directory}/generated-xsd/</schemaDirectory>
-              <bindingDirectory>${basedir}/src/main/resources/xjb/</bindingDirectory>
+              <sources>
+                <source>${project.build.directory}/generated-xsd/schema1.xsd</source>
+              </sources>
+              <xjbSources>
+                <xjbSource>${project.basedir}/src/main/resources/xjb/</xjbSource>
+              </xjbSources>
               <extension>true</extension>
             </configuration>
           </execution>


### PR DESCRIPTION
 * the upgrade should fix random failures recently seen when
   building with JDK8

 * similar upgrade was done on master few months back and everything seems to work there

@mbiarnes, @mrietveld could you please take a look?