### PR TITLE
DROOLS-1235 MBean naming rework

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
@@ -243,7 +243,7 @@ public class KieServerImpl {
                 if (previous == null) {
                     try {
                         KieServices ks = KieServices.Factory.get();
-                        InternalKieContainer kieContainer = (InternalKieContainer) ks.newKieContainer(releaseId);
+                        InternalKieContainer kieContainer = (InternalKieContainer) ks.newKieContainer(containerId, releaseId);
                         if (kieContainer != null) {
                             ci.setKieContainer(kieContainer);
                             logger.debug("Container {} (for release id {}) general initialization: DONE", containerId, releaseId);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerExecutor.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerExecutor.java
@@ -19,7 +19,10 @@ import org.kie.server.integrationtests.shared.basetests.KieServerBaseIntegration
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
+
+import org.drools.compiler.kie.builder.impl.KieServicesImpl;
 import org.jboss.resteasy.plugins.server.tjws.TJWSEmbeddedJaxrsServer;
+import org.kie.api.KieServices;
 import org.kie.server.api.KieServerConstants;
 import org.kie.server.api.KieServerEnvironment;
 import org.kie.server.integrationtests.config.TestConfig;
@@ -89,6 +92,8 @@ public class KieServerExecutor {
             throw new RuntimeException("Kie execution server is already stopped!");
         }
         kieServer.destroy();
+        // The KieServices instance that was seen by the kieserver, will never be seen again at this point
+        ((KieServicesImpl) KieServices.Factory.get()).nullAllContainerIds();
         server.stop();
         server = null;
     }


### PR DESCRIPTION
Depends on droolsjbpm/droolsjbpm-knowledge#150 .
Depends on droolsjbpm/drools#866 .

* KieServer cascade containerId while creating via KieServices