### PR TITLE
[6.5.x] [JBPM-5220] kie-server: implement filtering for listContainers()

### DIFF
--- a/kie-server-parent/kie-server-api/pom.xml
+++ b/kie-server-parent/kie-server-api/pom.xml
@@ -60,6 +60,18 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/CommandScript.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/CommandScript.java
@@ -87,4 +87,24 @@ public class CommandScript implements Serializable {
         return "CommandScriptImpl{ commands=" + commands +
                '}';
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        CommandScript that = (CommandScript) o;
+
+        return commands != null ? commands.equals(that.commands) : that.commands == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        return commands != null ? commands.hashCode() : 0;
+    }
 }

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/DisposeContainerCommand.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/DisposeContainerCommand.java
@@ -49,4 +49,30 @@ public class DisposeContainerCommand implements KieServerCommand {
         this.containerId = containerId;
     }
 
+    @Override
+    public String toString() {
+        return "DisposeContainerCommand{" +
+                "containerId='" + containerId + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DisposeContainerCommand that = (DisposeContainerCommand) o;
+
+        return containerId != null ? containerId.equals(that.containerId) : that.containerId == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        return containerId != null ? containerId.hashCode() : 0;
+    }
 }

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/ListContainersCommand.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/ListContainersCommand.java
@@ -15,21 +15,60 @@
 
 package org.kie.server.api.commands;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlRootElement;
-
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import org.kie.server.api.model.KieContainerResourceFilter;
 import org.kie.server.api.model.KieServerCommand;
 
-@XmlRootElement(name="list-containers")
-@XStreamAlias( "list-containers" )
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "list-containers")
+@XStreamAlias("list-containers")
 @XmlAccessorType(XmlAccessType.NONE)
 public class ListContainersCommand implements KieServerCommand {
     private static final long serialVersionUID = -1803374525440238478L;
-    
+
+    @XmlElement(name = "kie-container-filter")
+    @XStreamAlias("kie-container-filter")
+    private final KieContainerResourceFilter kieContainerResourceFilter;
+
     public ListContainersCommand() {
-        super();
+        kieContainerResourceFilter = KieContainerResourceFilter.ACCEPT_ALL;
     }
-    
+
+    public ListContainersCommand(KieContainerResourceFilter kieContainerResourceFilter) {
+        this.kieContainerResourceFilter = kieContainerResourceFilter;
+    }
+
+    public KieContainerResourceFilter getKieContainerResourceFilter() {
+        return kieContainerResourceFilter;
+    }
+
+    @Override
+    public String toString() {
+        return "ListContainersCommand{" +
+                "kieContainerResourceFilter=" + kieContainerResourceFilter +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ListContainersCommand that = (ListContainersCommand) o;
+
+        return kieContainerResourceFilter != null ? kieContainerResourceFilter.equals(that.kieContainerResourceFilter) : that.kieContainerResourceFilter == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return kieContainerResourceFilter != null ? kieContainerResourceFilter.hashCode() : 0;
+    }
 }

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/jaxb/JaxbMarshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/jaxb/JaxbMarshaller.java
@@ -61,14 +61,17 @@ import org.kie.server.api.marshalling.MarshallingException;
 import org.kie.server.api.marshalling.MarshallingFormat;
 import org.kie.server.api.marshalling.ModelWrapper;
 import org.kie.server.api.model.KieContainerResource;
+import org.kie.server.api.model.KieContainerResourceFilter;
 import org.kie.server.api.model.KieContainerResourceList;
 import org.kie.server.api.model.KieContainerStatus;
+import org.kie.server.api.model.KieContainerStatusFilter;
 import org.kie.server.api.model.KieServerConfig;
 import org.kie.server.api.model.KieServerConfigItem;
 import org.kie.server.api.model.KieServerInfo;
 import org.kie.server.api.model.KieServerStateInfo;
 import org.kie.server.api.model.Message;
 import org.kie.server.api.model.ReleaseId;
+import org.kie.server.api.model.ReleaseIdFilter;
 import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.api.model.ServiceResponsesList;
 import org.kie.server.api.model.admin.MigrationReportInstance;
@@ -84,8 +87,6 @@ import org.kie.server.api.model.type.JaxbByteArray;
 import org.kie.server.api.model.type.JaxbDate;
 import org.kie.server.api.model.type.JaxbList;
 import org.kie.server.api.model.type.JaxbMap;
-import org.optaplanner.core.api.domain.solution.Solution;
-import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.score.buildin.bendable.BendableScore;
 import org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore;
 import org.optaplanner.core.api.score.buildin.bendablelong.BendableLongScore;
@@ -126,6 +127,10 @@ public class JaxbMarshaller implements Marshaller {
                 ServiceResponse.class,
                 ServiceResponsesList.class,
                 KieServerStateInfo.class,
+
+                ReleaseIdFilter.class,
+                KieContainerStatusFilter.class,
+                KieContainerResourceFilter.class,
 
                 BatchExecutionCommandImpl.class,
                 ExecutionResultImpl.class,

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/xstream/XStreamMarshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/xstream/XStreamMarshaller.java
@@ -37,11 +37,14 @@ import org.kie.server.api.commands.optaplanner.*;
 import org.kie.server.api.marshalling.Marshaller;
 import org.kie.server.api.marshalling.MarshallingFormat;
 import org.kie.server.api.model.KieContainerResource;
+import org.kie.server.api.model.KieContainerResourceFilter;
 import org.kie.server.api.model.KieContainerResourceList;
 import org.kie.server.api.model.KieContainerStatus;
+import org.kie.server.api.model.KieContainerStatusFilter;
 import org.kie.server.api.model.KieScannerResource;
 import org.kie.server.api.model.KieServerInfo;
 import org.kie.server.api.model.ReleaseId;
+import org.kie.server.api.model.ReleaseIdFilter;
 import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.api.model.ServiceResponsesList;
 import org.kie.server.api.model.instance.SolverInstance;
@@ -90,6 +93,10 @@ public class XStreamMarshaller
         this.xstream.processAnnotations( KieContainerStatus.class );
         this.xstream.processAnnotations( KieScannerResource.class );
         this.xstream.processAnnotations( KieServerInfo.class );
+
+        this.xstream.processAnnotations( ReleaseIdFilter.class );
+        this.xstream.processAnnotations( KieContainerStatusFilter.class );
+        this.xstream.processAnnotations( KieContainerResourceFilter.class );
 
         this.xstream.processAnnotations( SolverInstance.class );
         this.xstream.processAnnotations( CreateSolverCommand.class );

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/KieContainerResourceFilter.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/KieContainerResourceFilter.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.api.model;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.List;
+
+@XmlRootElement(name = "kie-container-filter")
+@XStreamAlias("kie-container-filter")
+@XmlAccessorType(XmlAccessType.NONE)
+public class KieContainerResourceFilter {
+
+    public static final KieContainerResourceFilter ACCEPT_ALL = new KieContainerResourceFilter();
+
+    @XmlElement(name = "release-id-filter")
+    @XStreamAlias("release-id-filter")
+    private final ReleaseIdFilter releaseIdFilter;
+
+    @XmlElement(name = "container-status-filter")
+    @XStreamAlias("container-status-filter")
+    private final KieContainerStatusFilter statusFilter;
+
+    private KieContainerResourceFilter() {
+        // needed for JAXB
+        this.releaseIdFilter = ReleaseIdFilter.ACCEPT_ALL;
+        this.statusFilter = KieContainerStatusFilter.ACCEPT_ALL;
+    }
+
+    public KieContainerResourceFilter(ReleaseIdFilter releaseIdFilter, KieContainerStatusFilter statusFilter) {
+        this.releaseIdFilter = releaseIdFilter;
+        this.statusFilter = statusFilter;
+    }
+
+    public KieContainerResourceFilter(ReleaseIdFilter releaseIdFilter) {
+        this(releaseIdFilter, KieContainerStatusFilter.ACCEPT_ALL);
+    }
+
+    public ReleaseIdFilter getReleaseIdFilter() {
+        return releaseIdFilter;
+    }
+
+    public KieContainerStatusFilter getStatusFilter() {
+        return statusFilter;
+    }
+
+    public boolean accept(KieContainerResource kieContainerResource) {
+        if (kieContainerResource == null) {
+            throw new IllegalArgumentException("KieContainerResource can not be null!");
+        }
+        // in case resolved release id exists, check against that
+        ReleaseId resolvedReleaseId = kieContainerResource.getResolvedReleaseId();
+        if (resolvedReleaseId != null) {
+            if (!releaseIdFilter.accept(resolvedReleaseId)) {
+                return false;
+            }
+        } else {
+            if (!releaseIdFilter.accept(kieContainerResource.getReleaseId())) {
+                return false;
+            }
+        }
+        KieContainerStatus status = kieContainerResource.getStatus();
+        if (status != null && !statusFilter.accept(status)) {
+            return false;
+        }
+        // all sub-filters accepted the container, so it is a match
+        return true;
+    }
+
+    /**
+     * Creates representation of this filter which can be used as part of the URL (e.g. the "?" query part).
+     *
+     * @return string representation that can be directly used in URL (as query params), without the leading '?'
+     */
+    public String toURLQueryString() {
+        StringBuilder urlQuerySB = new StringBuilder();
+        if (releaseIdFilter.getGroupId() != null) {
+            urlQuerySB.append("groupId=").append(releaseIdFilter.getGroupId());
+        }
+        if (releaseIdFilter.getArtifactId() != null) {
+            urlQuerySB.append("&artifactId=").append(releaseIdFilter.getArtifactId());
+        }
+        if (releaseIdFilter.getVersion() != null) {
+            urlQuerySB.append("&version=").append(releaseIdFilter.getVersion());
+        }
+        // don't send over the default filter (e.g. one that accepts all the states)
+        if (!statusFilter.equals(KieContainerStatusFilter.ACCEPT_ALL)) {
+            urlQuerySB.append("&status=").append(join(statusFilter.getAcceptedStatuses(), ","));
+        }
+        String urlQueryParams = urlQuerySB.toString();
+        // strip the leading "&" which could have been introduced by the code above -- in case groupId was not specified
+        if (urlQueryParams.startsWith("&")) {
+            return urlQueryParams.substring(1);
+        } else {
+            return urlQueryParams;
+        }
+    }
+
+    private <T> String join(List<T> list, String joinStr) {
+        StringBuilder joinedSB = new StringBuilder();
+        for (T obj : list) {
+            joinedSB.append(joinStr).append(obj.toString());
+        }
+
+        if (!list.isEmpty()) {
+            // remove the unwanted leading joinStr
+            return joinedSB.toString().substring(joinStr.length());
+        } else {
+            return joinedSB.toString();
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "KieContainerResourceFilter{" +
+                "releaseIdFilter=" + releaseIdFilter +
+                ", statusFilter=" + statusFilter +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        KieContainerResourceFilter that = (KieContainerResourceFilter) o;
+
+        if (releaseIdFilter != null ? !releaseIdFilter.equals(that.releaseIdFilter) : that.releaseIdFilter != null)
+            return false;
+        return statusFilter != null ? statusFilter.equals(that.statusFilter) : that.statusFilter == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = releaseIdFilter != null ? releaseIdFilter.hashCode() : 0;
+        result = 31 * result + (statusFilter != null ? statusFilter.hashCode() : 0);
+        return result;
+    }
+
+    public static class Builder {
+        private ReleaseIdFilter releaseIdFilter = ReleaseIdFilter.ACCEPT_ALL;
+        private KieContainerStatusFilter statusFilter = KieContainerStatusFilter.ACCEPT_ALL;
+
+        public Builder() {
+        }
+
+        public Builder releaseId(ReleaseId releaseId) {
+            this.releaseIdFilter = new ReleaseIdFilter(releaseId);
+            return this;
+        }
+
+        public Builder releaseId(String groupId, String artifactId, String version) {
+            this.releaseIdFilter = new ReleaseIdFilter(groupId, artifactId, version);
+            return this;
+        }
+
+        public Builder status(KieContainerStatus containerStatus) {
+            this.statusFilter = new KieContainerStatusFilter(containerStatus);
+            return this;
+        }
+
+        public Builder statuses(KieContainerStatus... containerStatuses) {
+            this.statusFilter = new KieContainerStatusFilter(containerStatuses);
+            return this;
+        }
+
+        public KieContainerResourceFilter build() {
+            return new KieContainerResourceFilter(releaseIdFilter, statusFilter);
+        }
+    }
+
+}

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/KieContainerStatusFilter.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/KieContainerStatusFilter.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.api.model;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@XmlRootElement(name = "kie-container-status-filter")
+@XStreamAlias("kie-container-status-filter")
+@XmlAccessorType(XmlAccessType.NONE)
+public class KieContainerStatusFilter {
+
+    public static final KieContainerStatusFilter ACCEPT_ALL = new KieContainerStatusFilter();
+
+    @XmlElement(name = "accepted-status")
+    @XStreamAlias("accepted-status")
+    private final List<KieContainerStatus> acceptedStatuses;
+
+    /**
+     * Creates status filter from the specified string. The expected format is "status1,status2,status3,...".
+     *
+     * Important: in case the specified string is empty or null, the default ACCEPT_ALL filter is created
+     *
+     * @param inputStr string representation of the filter
+     * @return new filter parsed from the string or ACCEPT_ALL filter in case the string is empty or null
+     */
+    public static KieContainerStatusFilter parseFromNullableString(String inputStr) {
+        if (inputStr == null || inputStr.isEmpty()) {
+            return ACCEPT_ALL;
+        }
+        List<KieContainerStatus> statuses = new ArrayList<KieContainerStatus>();
+        String[] strStatuses = inputStr.split(",");
+        for (String strStatus : strStatuses) {
+            statuses.add(KieContainerStatus.valueOf(strStatus.toUpperCase()));
+        }
+        return new KieContainerStatusFilter(statuses);
+    }
+
+    public KieContainerStatusFilter() {
+        // IMPORTANT: the list acceptedStatuses needs to be mutable in order to not break JAXB unmarshalling
+        // jaxb calls clear() method on the list, which usually throws UnsupportedOperationException on immutable lists
+        this.acceptedStatuses = new ArrayList<KieContainerStatus>(Arrays.asList(KieContainerStatus.values()));
+    }
+
+    public KieContainerStatusFilter(List<KieContainerStatus> acceptedStatuses) {
+        this.acceptedStatuses = acceptedStatuses;
+    }
+
+    public KieContainerStatusFilter(KieContainerStatus... acceptedStatuses) {
+        this.acceptedStatuses = Arrays.asList(acceptedStatuses);
+    }
+
+    public List<KieContainerStatus> getAcceptedStatuses() {
+        return acceptedStatuses;
+    }
+
+    public boolean accept(KieContainerStatus status) {
+        return this.acceptedStatuses.contains(status);
+    }
+
+    @Override
+    public String toString() {
+        return "KieContainerStatusFilter{" +
+                "acceptedStatuses=" + acceptedStatuses +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        KieContainerStatusFilter that = (KieContainerStatusFilter) o;
+
+        return acceptedStatuses != null ? acceptedStatuses.equals(that.acceptedStatuses) : that.acceptedStatuses == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        return acceptedStatuses != null ? acceptedStatuses.hashCode() : 0;
+    }
+}

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/ReleaseIdFilter.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/ReleaseIdFilter.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.api.model;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Enables filtering of {@link ReleaseId}s based on provided constraints (groupId, artifactId, version).
+ * <p>
+ * This implementation compares the expected parts for equality (e.g. the filter accepts the
+ * releaseId in case the groupId/artifactId/version exactly matches the configured one). It is also possible
+ * to filter only on a subset of the constraints (e.g. only on groupId).
+ * <p>
+ * The class comes with {@link Builder} which can be used to easily create all kinds of filters.
+ */
+@XmlRootElement(name = "release-id-filter")
+@XStreamAlias("release-id-filter")
+@XmlAccessorType(XmlAccessType.NONE)
+public class ReleaseIdFilter {
+    @XmlElement(name = "group-id")
+    @XStreamAlias("group-id")
+    private final String groupId;
+    @XmlElement(name = "artifact-id")
+    @XStreamAlias("artifact-id")
+    private final String artifactId;
+    @XmlElement(name = "version")
+    @XStreamAlias("version")
+    private final String version;
+
+    public static final ReleaseIdFilter ACCEPT_ALL = new ReleaseIdFilter(null, null, null);
+
+    private ReleaseIdFilter() {
+        // passing NULLs is a bad practice, but JAXB needs no-arg constructor
+        this(null, null, null);
+    }
+
+    public ReleaseIdFilter(String groupId, String artifactId, String version) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.version = version;
+    }
+
+    public ReleaseIdFilter(ReleaseId releaseId) {
+        this(releaseId.getGroupId(), releaseId.getArtifactId(),releaseId.getVersion());
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    /**
+     * Checks whether the specified releaseId matches (is accepted by) this filter.
+     *
+     * @param releaseId releaseId to match against
+     * @return true if this filter accepts the specified releaseId, otherwise false
+     */
+    public boolean accept(ReleaseId releaseId) {
+        if (releaseId == null) {
+            throw new IllegalArgumentException("ReleaseId can not be null!");
+        }
+        return matches(groupId, releaseId.getGroupId()) &&
+                matches(artifactId, releaseId.getArtifactId()) &&
+                matches(version, releaseId.getVersion());
+    }
+
+    /**
+     * Checks whether the string filter matches the provided value.
+     * <p>
+     * Filter can be null, which means "match all".
+     *
+     * @param filter string filter
+     * @param value  value to match against
+     * @return true if the filter matches the value, otherwise false
+     */
+    private boolean matches(String filter, String value) {
+        if (filter == null) {
+            return true;
+        }
+        return filter.equals(value);
+    }
+
+    @Override
+    public String toString() {
+        return "ReleaseIdFilter{" +
+                "groupId='" + groupId + '\'' +
+                ", artifactId='" + artifactId + '\'' +
+                ", version='" + version + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ReleaseIdFilter that = (ReleaseIdFilter) o;
+
+        if (groupId != null ? !groupId.equals(that.groupId) : that.groupId != null) {
+            return false;
+        }
+        if (artifactId != null ? !artifactId.equals(that.artifactId) : that.artifactId != null) {
+            return false;
+        }
+        return version != null ? version.equals(that.version) : that.version == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = groupId != null ? groupId.hashCode() : 0;
+        result = 31 * result + (artifactId != null ? artifactId.hashCode() : 0);
+        result = 31 * result + (version != null ? version.hashCode() : 0);
+        return result;
+    }
+
+    public static class Builder {
+        private String groupId;
+        private String artifactId;
+        private String version;
+
+        public Builder groupId(String groupId) {
+            this.groupId = groupId;
+            return this;
+        }
+
+        public Builder artifactId(String artifactId) {
+            this.artifactId = artifactId;
+            return this;
+        }
+
+        public Builder version(String version) {
+            this.version = version;
+            return this;
+        }
+
+        public Builder releaseId(ReleaseId releaseId) {
+            this.groupId = releaseId.getGroupId();
+            this.artifactId = releaseId.getArtifactId();
+            this.version = releaseId.getVersion();
+            return this;
+        }
+
+        public ReleaseIdFilter build() {
+            return new ReleaseIdFilter(groupId, artifactId, version);
+        }
+    }
+
+}

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/model/KieContainerResourceFilterMatchTest.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/model/KieContainerResourceFilterMatchTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.api.model;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class KieContainerResourceFilterMatchTest {
+
+    private static final ReleaseId MATCHING_RELEASE_ID = new ReleaseId("org.example","test-artifact", "2.0.0.Final");
+    private static final ReleaseId NON_MATCHING_RELEASE_ID = new ReleaseId("foo","bar", "baz");
+
+    private static final KieContainerResourceFilter RELEASE_ID_FILTER =
+            new KieContainerResourceFilter.Builder().releaseId(MATCHING_RELEASE_ID).build();
+
+    private static final KieContainerResourceFilter STATUS_FILTER =
+            new KieContainerResourceFilter.Builder().status(KieContainerStatus.CREATING).build();
+
+    private static final KieContainerResource MATCHING_CONTAINER = new KieContainerResource("id1", MATCHING_RELEASE_ID, KieContainerStatus.CREATING);
+    private static final KieContainerResource NON_MATCHING_CONTAINER = new KieContainerResource("id2", NON_MATCHING_RELEASE_ID, KieContainerStatus.STOPPED);
+
+    @Parameterized.Parameters(name = "{index}: filter={0}; MATCHING_RELEASE_ID={1}; expecting to match={2}")
+    public static Collection<Object[]> data() {
+        Collection<Object[]> data = new ArrayList<Object[]>(Arrays.asList(new Object[][]
+                {
+                        {RELEASE_ID_FILTER, MATCHING_CONTAINER, true},
+                        {RELEASE_ID_FILTER, NON_MATCHING_CONTAINER, false},
+                        {STATUS_FILTER, MATCHING_CONTAINER, true},
+                        {STATUS_FILTER, NON_MATCHING_CONTAINER, false}
+
+                }
+        ));
+
+        return data;
+    }
+
+    @Parameterized.Parameter(0)
+    public KieContainerResourceFilter filter;
+
+    @Parameterized.Parameter(1)
+    public KieContainerResource containerResource;
+
+    @Parameterized.Parameter(2)
+    public boolean expectedResult;
+
+    @Test
+    public void testAccept() {
+        boolean result = filter.accept(containerResource);
+        Assertions.assertThat(result).isEqualTo(expectedResult);
+    }
+}

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/model/KieContainerResourceFilterTest.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/model/KieContainerResourceFilterTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.api.model;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class KieContainerResourceFilterTest {
+
+    private static final String GROUP_ID = "org.example";
+    private static final String ARTIFACT_ID = "project";
+    private static final String VERSION= "1.0.0.Final";
+
+    private static final ReleaseId RELEASE_ID = new ReleaseId(GROUP_ID, ARTIFACT_ID, VERSION);
+
+    @Test
+    public void toURLQueryStringGroupIdOnly() {
+        KieContainerResourceFilter filter = new KieContainerResourceFilter.Builder()
+                .releaseId(new ReleaseId(GROUP_ID, null, null)).build();
+        Assertions.assertThat(filter.toURLQueryString()).isEqualTo("groupId=" + GROUP_ID);
+    }
+
+    @Test
+    public void toURLQueryStringArtifactIdOnly() {
+        KieContainerResourceFilter filter = new KieContainerResourceFilter.Builder()
+                .releaseId(new ReleaseId(null, ARTIFACT_ID, null)).build();
+        Assertions.assertThat(filter.toURLQueryString()).isEqualTo("artifactId=" + ARTIFACT_ID);
+    }
+
+    @Test
+    public void toURLQueryStringVersionOnly() {
+        KieContainerResourceFilter filter = new KieContainerResourceFilter.Builder()
+                .releaseId(new ReleaseId(null, null, VERSION)).build();
+        Assertions.assertThat(filter.toURLQueryString()).isEqualTo("version=" + VERSION);
+    }
+
+    @Test
+    public void toURLQueryStringReleaseIdOnly() {
+        KieContainerResourceFilter filter = new KieContainerResourceFilter.Builder().releaseId(RELEASE_ID).build();
+        Assertions.assertThat(filter.toURLQueryString())
+                .isEqualTo("groupId=" + GROUP_ID + "&artifactId=" + ARTIFACT_ID + "&version=" + VERSION);
+    }
+
+    @Test
+    public void toURLQueryStringSingleStatus() {
+        KieContainerResourceFilter filter = new KieContainerResourceFilter.Builder().status(KieContainerStatus.STARTED).build();
+        Assertions.assertThat(filter.toURLQueryString()).isEqualTo("status=STARTED");
+    }
+
+    @Test
+    public void toURLQueryStringMultipleStatuses() {
+        KieContainerResourceFilter filter = new KieContainerResourceFilter.Builder()
+                .statuses(KieContainerStatus.CREATING, KieContainerStatus.STARTED, KieContainerStatus.FAILED)
+                .build();
+        Assertions.assertThat(filter.toURLQueryString()).isEqualTo("status=CREATING,STARTED,FAILED");
+    }
+
+    @Test
+    public void toURLQueryStringReleaseIdWithStatus() {
+        KieContainerResourceFilter filter = new KieContainerResourceFilter.Builder()
+                .releaseId(RELEASE_ID)
+                .status(KieContainerStatus.STARTED)
+                .build();
+        Assertions.assertThat(filter.toURLQueryString())
+                .isEqualTo("groupId=" + GROUP_ID + "&artifactId=" + ARTIFACT_ID + "&version=" + VERSION + "&status=STARTED");
+    }
+}

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/model/KieContainerStatusFilterTest.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/model/KieContainerStatusFilterTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.api.model;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class KieContainerStatusFilterTest {
+
+    @Test
+    public void parseFromNullableStringWithNull() {
+        KieContainerStatusFilter filter = KieContainerStatusFilter.parseFromNullableString(null);
+        Assertions.assertThat(filter).isEqualTo(KieContainerStatusFilter.ACCEPT_ALL);
+    }
+
+    @Test
+    public void parseFromNullableStringWithEmptyString() {
+        KieContainerStatusFilter filter = KieContainerStatusFilter.parseFromNullableString("");
+        Assertions.assertThat(filter).isEqualTo(KieContainerStatusFilter.ACCEPT_ALL);
+    }
+
+    @Test
+    public void parseFromNullableStringWithSingleStatus() {
+        KieContainerStatusFilter filter = KieContainerStatusFilter.parseFromNullableString("started");
+        Assertions.assertThat(filter).isEqualTo(new KieContainerStatusFilter(KieContainerStatus.STARTED));
+    }
+
+    @Test
+    public void parseFromNullableStringWithSingleStatusUppercase() {
+        KieContainerStatusFilter filter = KieContainerStatusFilter.parseFromNullableString("STARTED");
+        Assertions.assertThat(filter).isEqualTo(new KieContainerStatusFilter(KieContainerStatus.STARTED));
+    }
+
+    @Test
+    public void parseFromNullableStringWithMultipleStatuses() {
+        KieContainerStatusFilter filter = KieContainerStatusFilter.parseFromNullableString("creating,started,failed");
+        Assertions.assertThat(filter).isEqualTo(
+                new KieContainerStatusFilter(KieContainerStatus.CREATING, KieContainerStatus.STARTED, KieContainerStatus.FAILED));
+    }
+}

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/model/MarshallingRoundTripTest.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/model/MarshallingRoundTripTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.api.model;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.api.executor.Command;
+import org.kie.internal.runtime.manager.context.EmptyContext;
+import org.kie.server.api.commands.CommandScript;
+import org.kie.server.api.commands.DisposeContainerCommand;
+import org.kie.server.api.commands.ListContainersCommand;
+import org.kie.server.api.marshalling.Marshaller;
+import org.kie.server.api.marshalling.MarshallerFactory;
+import org.kie.server.api.marshalling.MarshallingFormat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Roundtrip tests which make sure that the input object is the same as the object created by marshalling + unmarshalling.
+ */
+@RunWith(Parameterized.class)
+public class MarshallingRoundTripTest {
+
+    @Parameterized.Parameters(name = "{index}: {0}")
+    public static Collection<Object[]> contextPath() {
+        Object[][] data = new Object[][] {
+                { createKieContainerResourceFilter()},
+                { createReleaseIdFilter() },
+                { createKieContainerResourceFilter() },
+                { createListContainersCommand() },
+                { createCommandScript() }
+        };
+        return Arrays.asList(data);
+    }
+
+
+
+    private static KieContainerStatusFilter createKieContainerStatusFilter() {
+        return new KieContainerStatusFilter();
+    }
+
+    private static ReleaseIdFilter createReleaseIdFilter() {
+        return new ReleaseIdFilter("group", "artifact", "version");
+    }
+
+    private static KieContainerResourceFilter createKieContainerResourceFilter() {
+        return new KieContainerResourceFilter(createReleaseIdFilter(), createKieContainerStatusFilter());
+    }
+
+    private static ListContainersCommand createListContainersCommand() {
+        return new ListContainersCommand(createKieContainerResourceFilter());
+    }
+
+    private static DisposeContainerCommand createDisposeContainerCommand() {
+        return new DisposeContainerCommand("some-container-id");
+    }
+
+    private static CommandScript createCommandScript() {
+        List<KieServerCommand> commands = new ArrayList<KieServerCommand>();
+        commands.add(createListContainersCommand());
+        commands.add(createDisposeContainerCommand());
+        return new CommandScript(commands);
+    }
+
+    @Parameterized.Parameter(0)
+    public Object testObject;
+
+    @Test
+    public void testJaxb() {
+        Marshaller marshaller = MarshallerFactory.getMarshaller(MarshallingFormat.JAXB, getClass().getClassLoader());
+        verifyMarshallingRoundTrip(marshaller, testObject);
+    }
+
+    @Test
+    public void testXStream() {
+        Marshaller marshaller = MarshallerFactory.getMarshaller(MarshallingFormat.XSTREAM, getClass().getClassLoader());
+        verifyMarshallingRoundTrip(marshaller, testObject);
+
+    }
+
+    @Test
+    public void testJSON() {
+        Marshaller marshaller = MarshallerFactory.getMarshaller(MarshallingFormat.JSON, getClass().getClassLoader());
+        verifyMarshallingRoundTrip(marshaller, testObject);
+    }
+
+    private void verifyMarshallingRoundTrip(Marshaller marshaller, Object inputObject) {
+        String rawContent = marshaller.marshall(inputObject);
+        Object testObjectAfterMarshallingTurnAround = marshaller.unmarshall(rawContent, inputObject.getClass());
+        Assertions.assertThat(inputObject).isEqualTo(testObjectAfterMarshallingTurnAround);
+    }
+
+ }

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/model/ReleaseIdFilterTest.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/model/ReleaseIdFilterTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.api.model;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class ReleaseIdFilterTest {
+    private static final ReleaseIdFilter FULL_FILTER = new ReleaseIdFilter("org.test", "example-artifactId", "1.0.0.Final");
+    private static final ReleaseIdFilter GROUP_ID_ARTIFACT_ID_FILTER = new ReleaseIdFilter.Builder().groupId("org.test").artifactId("example-artifactId").build();
+    private static final ReleaseIdFilter GROUP_ID_VERSION_FILTER = new ReleaseIdFilter.Builder().groupId("org.test").version("1.0.0.Final").build();
+    private static final ReleaseIdFilter ARTIFACT_ID_VERSION_FILTER = new ReleaseIdFilter.Builder().artifactId("example-artifactId").version("1.0.0.Final").build();
+    private static final ReleaseIdFilter GROUP_ID_FILTER = new ReleaseIdFilter.Builder().groupId("org.test").build();
+    private static final ReleaseIdFilter ARTIFACT_ID_FILTER = new ReleaseIdFilter.Builder().artifactId("example-artifactId").build();
+    private static final ReleaseIdFilter VERSION_FILTER = new ReleaseIdFilter.Builder().version("1.0.0.Final").build();
+
+    private static final ReleaseId MATCHING_RELEASE_ID = new ReleaseId("org.test", "example-artifactId", "1.0.0.Final");
+    private static final ReleaseId NON_MATCHING_RELEASE_ID = new ReleaseId("foo", "bar", "baz");
+
+    @Parameterized.Parameters(name = "{index}: filter={0}; releaseId={1}; expecting to match={2}")
+    public static Collection<Object[]> data() {
+        Collection<Object[]> data = new ArrayList<Object[]>(Arrays.asList(new Object[][]
+                {
+                        {FULL_FILTER, MATCHING_RELEASE_ID, true},
+                        {FULL_FILTER, NON_MATCHING_RELEASE_ID, false},
+
+                        {GROUP_ID_ARTIFACT_ID_FILTER, MATCHING_RELEASE_ID, true},
+                        {GROUP_ID_ARTIFACT_ID_FILTER, NON_MATCHING_RELEASE_ID, false},
+                        {GROUP_ID_VERSION_FILTER, MATCHING_RELEASE_ID, true},
+                        {GROUP_ID_VERSION_FILTER, NON_MATCHING_RELEASE_ID, false},
+
+                        {ARTIFACT_ID_VERSION_FILTER, MATCHING_RELEASE_ID, true},
+                        {ARTIFACT_ID_VERSION_FILTER, NON_MATCHING_RELEASE_ID, false},
+                        {GROUP_ID_FILTER, MATCHING_RELEASE_ID, true},
+                        {GROUP_ID_FILTER, NON_MATCHING_RELEASE_ID, false},
+                        {ARTIFACT_ID_FILTER, MATCHING_RELEASE_ID, true},
+                        {ARTIFACT_ID_FILTER, NON_MATCHING_RELEASE_ID, false},
+                        {VERSION_FILTER, MATCHING_RELEASE_ID, true},
+                        {VERSION_FILTER, NON_MATCHING_RELEASE_ID, false}
+                }
+        ));
+
+        return data;
+    }
+
+    @Parameterized.Parameter(0)
+    public ReleaseIdFilter filter;
+
+    @Parameterized.Parameter(1)
+    public ReleaseId releaseId;
+
+    @Parameterized.Parameter(2)
+    public boolean expectedResult;
+
+    @Test
+    public void testAccept() {
+        boolean result = filter.accept(releaseId);
+        Assertions.assertThat(result).isEqualTo(expectedResult);
+    }
+}

--- a/kie-server-parent/kie-server-api/src/test/resources/logback-test.xml
+++ b/kie-server-parent/kie-server-api/src/test/resources/logback-test.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%method:%line - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.kie" level="info"/>
+  <logger name="org.drools" level="info"/>
+  <logger name="org.jbpm" level="info"/>
+
+  <root level="warn">
+    <appender-ref ref="consoleAppender" />
+  </root>
+
+</configuration>

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/KieServicesClient.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/KieServicesClient.java
@@ -16,11 +16,12 @@
 package org.kie.server.client;
 
 import org.kie.api.command.Command;
+import org.kie.server.api.model.KieContainerResourceFilter;
+import org.kie.server.api.model.ReleaseIdFilter;
 import org.kie.server.api.commands.CommandScript;
 import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.KieContainerResourceList;
 import org.kie.server.api.model.KieScannerResource;
-import org.kie.server.api.model.KieServerConfig;
 import org.kie.server.api.model.KieServerInfo;
 import org.kie.server.api.model.KieServerStateInfo;
 import org.kie.server.api.model.ReleaseId;
@@ -35,6 +36,8 @@ public interface KieServicesClient {
     ServiceResponse<KieServerInfo> getServerInfo();
 
     ServiceResponse<KieContainerResourceList> listContainers();
+
+    ServiceResponse<KieContainerResourceList> listContainers(KieContainerResourceFilter containerFilter);
 
     ServiceResponse<KieContainerResource> createContainer(String id, KieContainerResource resource);
 

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/KieServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/KieServicesClientImpl.java
@@ -15,14 +15,10 @@
 
 package org.kie.server.client.impl;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.ServiceLoader;
-
 import org.kie.api.command.Command;
+import org.kie.server.api.model.KieContainerResourceFilter;
+import org.kie.server.api.model.KieContainerStatusFilter;
+import org.kie.server.api.model.ReleaseIdFilter;
 import org.kie.server.api.commands.CallContainerCommand;
 import org.kie.server.api.commands.CommandScript;
 import org.kie.server.api.commands.CreateContainerCommand;
@@ -50,6 +46,13 @@ import org.kie.server.client.RuleServicesClient;
 import org.kie.server.client.helper.KieServicesClientBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
 
 public class KieServicesClientImpl extends AbstractKieServicesClientImpl implements KieServicesClient {
 
@@ -143,11 +146,18 @@ public class KieServicesClientImpl extends AbstractKieServicesClientImpl impleme
 
     @Override
     public ServiceResponse<KieContainerResourceList> listContainers() {
-        if( config.isRest() ) {
-            return makeHttpGetRequestAndCreateServiceResponse( baseURI + "/containers", KieContainerResourceList.class );
+        return listContainers(KieContainerResourceFilter.ACCEPT_ALL);
+    }
+
+    @Override
+    public ServiceResponse<KieContainerResourceList> listContainers(KieContainerResourceFilter containerFilter) {
+        if (config.isRest()) {
+            String queryParams = containerFilter.toURLQueryString();
+            String uri = baseURI + "/containers" + (queryParams.isEmpty() ? "" : "?" + queryParams);
+            return makeHttpGetRequestAndCreateServiceResponse(uri, KieContainerResourceList.class);
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand) new ListContainersCommand() ) );
-            return (ServiceResponse<KieContainerResourceList>) executeJmsCommand( script ).getResponses().get( 0 );
+            CommandScript script = new CommandScript(Collections.singletonList( (KieServerCommand) new ListContainersCommand(containerFilter)));
+            return (ServiceResponse<KieContainerResourceList>) executeJmsCommand(script).getResponses().get(0);
         }
     }
 

--- a/kie-server-parent/kie-server-services/kie-server-services-common/pom.xml
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/pom.xml
@@ -108,6 +108,11 @@
       <artifactId>jackson-mapper-asl</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.thoughtworks.xstream</groupId>
+      <artifactId>xstream</artifactId>
+    </dependency>
+
     <!-- log -->
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -121,9 +126,11 @@
     </dependency>
 
     <dependency>
-      <groupId>com.thoughtworks.xstream</groupId>
-      <artifactId>xstream</artifactId>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
     </dependency>
+
   </dependencies>
 
 </project>

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieContainerCommandServiceImpl.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieContainerCommandServiceImpl.java
@@ -23,8 +23,6 @@ import java.util.regex.Pattern;
 
 import org.drools.core.command.impl.GenericCommand;
 import org.drools.core.command.runtime.BatchExecutionCommandImpl;
-import org.kie.api.builder.model.KieSessionModel;
-import org.kie.api.command.BatchExecutionCommand;
 import org.kie.api.command.Command;
 import org.kie.api.runtime.CommandExecutor;
 import org.kie.api.runtime.ExecutionResults;
@@ -139,7 +137,7 @@ public class KieContainerCommandServiceImpl implements KieContainerCommandServic
                 } else if (command instanceof GetServerInfoCommand) {
                     responses.add(this.kieServer.getInfo());
                 } else if (command instanceof ListContainersCommand) {
-                    responses.add(this.kieServer.listContainers());
+                    responses.add(this.kieServer.listContainers(((ListContainersCommand)command).getKieContainerResourceFilter()));
                 } else if (command instanceof CallContainerCommand) {
                     ServiceResponse response = callContainer(((CallContainerCommand) command).getContainerId(), ((CallContainerCommand) command).getPayload(), marshallingFormat, classType, true);
 

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
@@ -15,23 +15,6 @@
 
 package org.kie.server.services.impl;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.ServiceLoader;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import javax.naming.InitialContext;
-
 import org.drools.compiler.kie.builder.impl.InternalKieContainer;
 import org.drools.compiler.kie.builder.impl.InternalKieScanner;
 import org.drools.compiler.kproject.xml.DependencyFilter;
@@ -43,6 +26,7 @@ import org.kie.server.api.KieServerConstants;
 import org.kie.server.api.KieServerEnvironment;
 import org.kie.server.api.Version;
 import org.kie.server.api.model.KieContainerResource;
+import org.kie.server.api.model.KieContainerResourceFilter;
 import org.kie.server.api.model.KieContainerResourceList;
 import org.kie.server.api.model.KieContainerStatus;
 import org.kie.server.api.model.KieScannerResource;
@@ -51,6 +35,7 @@ import org.kie.server.api.model.KieServerInfo;
 import org.kie.server.api.model.KieServerStateInfo;
 import org.kie.server.api.model.Message;
 import org.kie.server.api.model.ReleaseId;
+import org.kie.server.api.model.ReleaseIdFilter;
 import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.api.model.ServiceResponse.ResponseType;
 import org.kie.server.api.model.Severity;
@@ -68,6 +53,22 @@ import org.kie.server.services.impl.storage.KieServerStateRepository;
 import org.kie.server.services.impl.storage.file.KieServerStateFileRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.naming.InitialContext;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class KieServerImpl {
 
@@ -301,20 +302,30 @@ public class KieServerImpl {
 
     }
 
-    public ServiceResponse<KieContainerResourceList> listContainers() {
+    public ServiceResponse<KieContainerResourceList> listContainers(KieContainerResourceFilter containerFilter) {
         try {
-            List<KieContainerResource> containers = new ArrayList<KieContainerResource>();
-            for (KieContainerInstanceImpl instance : context.getContainers()) {
-                instance.getResource().setMessages(getMessagesForContainer(instance.getContainerId()));
-                containers.add(instance.getResource());
+            List<KieContainerResource> filteredContainers = new ArrayList<KieContainerResource>();
+            for (KieContainerResource container : getContainersWithMessages()) {
+                if (containerFilter.accept(container)) {
+                    filteredContainers.add(container);
+                }
             }
-            KieContainerResourceList cil = new KieContainerResourceList(containers);
-            return new ServiceResponse<KieContainerResourceList>(ServiceResponse.ResponseType.SUCCESS, "List of created containers", cil);
+            KieContainerResourceList containerList = new KieContainerResourceList(filteredContainers);
+            return new ServiceResponse<KieContainerResourceList>(ServiceResponse.ResponseType.SUCCESS, "List of created containers", containerList);
         } catch (Exception e) {
             logger.error("Error retrieving list of containers", e);
             return new ServiceResponse<KieContainerResourceList>(ServiceResponse.ResponseType.FAILURE, "Error listing containers: " +
                     e.getClass().getName() + ": " + e.getMessage());
         }
+    }
+
+    private List<KieContainerResource> getContainersWithMessages() {
+        List<KieContainerResource> containers = new ArrayList<KieContainerResource>();
+        for (KieContainerInstanceImpl instance : context.getContainers()) {
+            instance.getResource().setMessages(getMessagesForContainer(instance.getContainerId()));
+            containers.add(instance.getResource());
+        }
+        return containers;
     }
 
     public ServiceResponse<KieContainerResource> getContainerInfo(String id) {

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/KieServerContainerCRUDIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/KieServerContainerCRUDIntegrationTest.java
@@ -15,29 +15,33 @@
 
 package org.kie.server.integrationtests.common;
 
-import java.util.List;
-import java.util.Set;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.server.api.model.KieContainerResource;
+import org.kie.server.api.model.KieContainerResourceFilter;
 import org.kie.server.api.model.KieContainerResourceList;
 import org.kie.server.api.model.KieContainerStatus;
+import org.kie.server.api.model.KieContainerStatusFilter;
 import org.kie.server.api.model.KieServerStateInfo;
 import org.kie.server.api.model.ReleaseId;
+import org.kie.server.api.model.ReleaseIdFilter;
 import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.integrationtests.category.Smoke;
 import org.kie.server.integrationtests.shared.KieServerAssert;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 import org.kie.server.integrationtests.shared.basetests.RestJmsSharedBaseIntegrationTest;
 
+import java.util.List;
+import java.util.Set;
+
 public class KieServerContainerCRUDIntegrationTest extends RestJmsSharedBaseIntegrationTest {
 
     private static ReleaseId releaseId1 = new ReleaseId("org.kie.server.testing", "container-crud-tests1", "2.1.0.GA");
     private static ReleaseId releaseId2 = new ReleaseId("org.kie.server.testing", "container-crud-tests1", "2.1.1.GA");
+    private static ReleaseId releaseId3 = new ReleaseId("org.kie.server.testing", "container-crud-tests2", "2.1.2.GA");
 
     @BeforeClass
     public static void initialize() throws Exception {
@@ -55,7 +59,7 @@ public class KieServerContainerCRUDIntegrationTest extends RestJmsSharedBaseInte
     public void testCreateContainer() throws Exception {
         ServiceResponse<KieContainerResource> reply = client.createContainer("kie1", new KieContainerResource("kie1",
                                                                                                               releaseId1));
-        Assert.assertEquals(ServiceResponse.ResponseType.SUCCESS, reply.getType());
+        KieServerAssert.assertSuccess(reply);
     }
 
     @Test
@@ -66,7 +70,8 @@ public class KieServerContainerCRUDIntegrationTest extends RestJmsSharedBaseInte
                                                                                                               "foo",
                                                                                                               "bar",
                                                                                                               "0.0.0")));
-        Assert.assertEquals(ServiceResponse.ResponseType.FAILURE, reply.getType());
+        KieServerAssert.assertFailure(reply);
+
     }
 
     @Test
@@ -76,13 +81,13 @@ public class KieServerContainerCRUDIntegrationTest extends RestJmsSharedBaseInte
                                                                                        "0.0.0"));
         ServiceResponse<KieContainerResource> reply = client.createContainer(resource.getContainerId(), resource);
 
-        Assert.assertEquals(ServiceResponse.ResponseType.FAILURE, reply.getType());
+        KieServerAssert.assertFailure(reply);
 
         // now try to re-create the container with a valid release ID
         resource.setReleaseId(releaseId1);
         reply = client.createContainer(resource.getContainerId(), resource);
 
-        Assert.assertEquals(ServiceResponse.ResponseType.SUCCESS, reply.getType());
+        KieServerAssert.assertSuccess(reply);
     }
 
     @Test
@@ -90,7 +95,7 @@ public class KieServerContainerCRUDIntegrationTest extends RestJmsSharedBaseInte
     public void testGetContainerInfo() throws Exception {
         client.createContainer("container-info", new KieContainerResource("container-info", releaseId1));
         ServiceResponse<KieContainerResource> reply = client.getContainerInfo("container-info");
-        Assert.assertEquals(ServiceResponse.ResponseType.SUCCESS, reply.getType());
+        KieServerAssert.assertSuccess(reply);
 
         KieContainerResource info = reply.getResult();
         Assert.assertEquals(KieContainerStatus.STARTED, info.getStatus());
@@ -100,7 +105,7 @@ public class KieServerContainerCRUDIntegrationTest extends RestJmsSharedBaseInte
     public void testGetContainerInfoNonExisting() throws Exception {
         ServiceResponse<KieContainerResource> reply = client.getContainerInfo("non-existing-container");
         logger.info(reply.getMsg());
-        Assert.assertEquals(ServiceResponse.ResponseType.FAILURE, reply.getType());
+        KieServerAssert.assertFailure(reply);
     }
 
     @Test
@@ -108,7 +113,7 @@ public class KieServerContainerCRUDIntegrationTest extends RestJmsSharedBaseInte
         client.createContainer("list-containers-c1", new KieContainerResource("list-containers-c1", releaseId1));
         client.createContainer("list-containers-c2", new KieContainerResource("list-containers-c2", releaseId1));
         ServiceResponse<KieContainerResourceList> reply = client.listContainers();
-        Assert.assertEquals(ServiceResponse.ResponseType.SUCCESS, reply.getType());
+        KieServerAssert.assertSuccess(reply);
         List<KieContainerResource> containers = reply.getResult().getContainers();
         Assert.assertEquals("Number of listed containers!", 2, containers.size());
         assertContainsContainer(containers, "list-containers-c1");
@@ -116,25 +121,55 @@ public class KieServerContainerCRUDIntegrationTest extends RestJmsSharedBaseInte
     }
 
     @Test
+    public void testListContainersWithSpecificStatus() throws Exception {
+        client.createContainer("list-containers-releaseId-c1", new KieContainerResource("list-containers-releaseId-c1", releaseId1));
+        // this will result in container with FAILED status
+        client.createContainer("list-containers-releaseId-c2", new KieContainerResource("list-containers-releaseId-c2", new ReleaseId("non-existing", "non-existing", "just-for-test")));
+
+        KieContainerStatusFilter statusFilter = new KieContainerStatusFilter(KieContainerStatus.FAILED);
+        ServiceResponse<KieContainerResourceList> reply = client.listContainers(new KieContainerResourceFilter(ReleaseIdFilter.ACCEPT_ALL, statusFilter));
+        KieServerAssert.assertSuccess(reply);
+        // there should be exactly one container which has status FAILED at this point
+        List<KieContainerResource> containers = reply.getResult().getContainers();
+        Assert.assertEquals("Number of listed containers!", 1, containers.size());
+        assertContainsContainer(containers, "list-containers-releaseId-c2");
+    }
+
+    @Test
+    public void testListContainersWithCustomKieContainerResourceFilter() {
+        client.createContainer("list-containers-releaseId-c1", new KieContainerResource("list-containers-releaseId-c1", releaseId1));
+        client.createContainer("list-containers-releaseId-c2", new KieContainerResource("list-containers-releaseId-c2", releaseId2));
+        client.createContainer("list-containers-releaseId-c3", new KieContainerResource("list-containers-releaseId-c3", releaseId3));
+        ReleaseIdFilter releaseIdFilter = new ReleaseIdFilter.Builder().groupId(releaseId1.getGroupId()).artifactId(releaseId1.getArtifactId()).build();
+        KieContainerStatusFilter statusFilter = KieContainerStatusFilter.ACCEPT_ALL;
+        ServiceResponse<KieContainerResourceList> reply = client.listContainers(new KieContainerResourceFilter(releaseIdFilter, statusFilter));
+        KieServerAssert.assertSuccess(reply);
+        List<KieContainerResource> containers = reply.getResult().getContainers();
+        Assert.assertEquals("Number of listed containers!", 2, containers.size());
+        assertContainsContainer(containers, "list-containers-releaseId-c1");
+        assertContainsContainer(containers, "list-containers-releaseId-c2");
+    }
+
+    @Test
     public void testUpdateReleaseIdForExistingContainer() throws Exception {
         client.createContainer("update-releaseId", new KieContainerResource("update-releaseId", releaseId1));
 
         ServiceResponse<ReleaseId> reply = client.updateReleaseId("update-releaseId", releaseId2);
-        Assert.assertEquals(ServiceResponse.ResponseType.SUCCESS, reply.getType());
+        KieServerAssert.assertSuccess(reply);
         Assert.assertEquals(releaseId2, reply.getResult());
 
         ServiceResponse<Void> disposeReply = client.disposeContainer("update-releaseId");
-        Assert.assertEquals(ServiceResponse.ResponseType.SUCCESS, disposeReply.getType());
+        KieServerAssert.assertSuccess(disposeReply);
     }
 
     @Test
     public void testDisposeContainer() throws Exception {
         client.createContainer("dispose-container", new KieContainerResource("dispose-container", releaseId1));
         ServiceResponse<Void> reply = client.disposeContainer("dispose-container");
-        Assert.assertEquals(ServiceResponse.ResponseType.SUCCESS, reply.getType());
+        KieServerAssert.assertSuccess(reply);
         // verify the container is no longer returned when calling listContainers()
         ServiceResponse<KieContainerResourceList> listReply = client.listContainers();
-        Assert.assertEquals(ServiceResponse.ResponseType.SUCCESS, listReply.getType());
+        KieServerAssert.assertSuccess(listReply);
         List<KieContainerResource> containers = listReply.getResult().getContainers();
         KieServerAssert.assertNullOrEmpty("No containers returned!", containers);
     }
@@ -142,25 +177,23 @@ public class KieServerContainerCRUDIntegrationTest extends RestJmsSharedBaseInte
     @Test
     public void testDisposeNonExistingContainer() throws Exception {
         ServiceResponse<Void> reply = client.disposeContainer("non-existing-container");
-        Assert.assertEquals(ServiceResponse.ResponseType.SUCCESS, reply.getType());
+        KieServerAssert.assertSuccess(reply);
     }
 
     @Test
     public void testUpdateReleaseIdForNotExistingContainer() throws Exception {
-
         ServiceResponse<ReleaseId> reply = client.updateReleaseId("update-releaseId", releaseId2);
-        Assert.assertEquals(ServiceResponse.ResponseType.SUCCESS, reply.getType());
+        KieServerAssert.assertSuccess(reply);
         Assert.assertEquals(releaseId2, reply.getResult());
 
         ServiceResponse<KieContainerResourceList> replyList = client.listContainers();
-        Assert.assertEquals(ServiceResponse.ResponseType.SUCCESS, replyList.getType());
+        KieServerAssert.assertSuccess(replyList);
         List<KieContainerResource> containers = replyList.getResult().getContainers();
         Assert.assertEquals("Number of listed containers!", 1, containers.size());
         assertContainsContainer(containers, "update-releaseId");
 
         ServiceResponse<Void> disposeReply = client.disposeContainer("update-releaseId");
-        Assert.assertEquals(ServiceResponse.ResponseType.SUCCESS, disposeReply.getType());
-
+        KieServerAssert.assertSuccess(disposeReply);
     }
 
     @Test
@@ -168,11 +201,11 @@ public class KieServerContainerCRUDIntegrationTest extends RestJmsSharedBaseInte
         client.createContainer("update-releaseId", new KieContainerResource("update-releaseId", releaseId1));
 
         ServiceResponse<ReleaseId> reply = client.updateReleaseId("update-releaseId", releaseId2);
-        Assert.assertEquals(ServiceResponse.ResponseType.SUCCESS, reply.getType());
+        KieServerAssert.assertSuccess(reply);
         Assert.assertEquals(releaseId2, reply.getResult());
 
         ServiceResponse<KieServerStateInfo> currentServerStateReply = client.getServerState();
-        Assert.assertEquals(ServiceResponse.ResponseType.SUCCESS, currentServerStateReply.getType());
+        KieServerAssert.assertSuccess(currentServerStateReply);
 
         KieServerStateInfo currentServerState = currentServerStateReply.getResult();
         Assert.assertNotNull(currentServerState);
@@ -187,7 +220,7 @@ public class KieServerContainerCRUDIntegrationTest extends RestJmsSharedBaseInte
         Assert.assertEquals(releaseId2, container.getResolvedReleaseId());
 
         ServiceResponse<Void> disposeReply = client.disposeContainer("update-releaseId");
-        Assert.assertEquals(ServiceResponse.ResponseType.SUCCESS, disposeReply.getType());
+        KieServerAssert.assertSuccess(disposeReply);
     }
 
     private void assertContainsContainer(List<KieContainerResource> containers, String expectedContainerId) {


### PR DESCRIPTION
 * filtering is (currently) possible based on releaseId (and
   its individual parts) and status

Backport of #563 