### PR TITLE
karaf-itests: disable debug logging

### DIFF
--- a/drools-osgi/drools-karaf-itests/src/test/resources/logback-test.xml
+++ b/drools-osgi/drools-karaf-itests/src/test/resources/logback-test.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %class{36}.%method:%line - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.kie" level="info"/>
+  <logger name="org.drools" level="info"/>
+  <logger name="org.jbpm" level="info"/>
+
+  <root level="warn">
+    <appender-ref ref="consoleAppender" />
+  </root>
+
+</configuration>


### PR DESCRIPTION
 * logback defaults to DEBUG logging in case
   there is no explicit config. That in turn
   leads to bloated logs.