### PR TITLE
[JBPM-5263,RHBPMS-4086] kie-server: persist active scanner state

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerEnvironment.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerEnvironment.java
@@ -26,7 +26,7 @@ public class KieServerEnvironment {
     
     private static final Pattern VERSION_PAT = Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)([\\.-].*)?");
     private static Version version;
-    private static String serverId = System.getProperty(KieServerConstants.KIE_SERVER_ID);;
+    private static String serverId = System.getProperty(KieServerConstants.KIE_SERVER_ID);
     private static String name = System.getProperty(KieServerConstants.KIE_SERVER_ID);
 
     static {

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/KieScannerStatus.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/KieScannerStatus.java
@@ -15,7 +15,6 @@
 
 package org.kie.server.api.model;
 
-
 public enum KieScannerStatus {
     
     UNKNOWN, CREATED, STARTED, SCANNING, STOPPED, DISPOSED

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
@@ -164,12 +164,9 @@ public class KieServerImpl {
         }
     }
 
-
-
-    public KieServerRegistry getServerRegistry() { 
+    public KieServerRegistry getServerRegistry() {
         return context;
     }
-
 
     public void destroy() {
         kieServerActive.set(false);
@@ -463,36 +460,36 @@ public class KieServerImpl {
         try {
             KieContainerInstanceImpl kci = context.getContainer(id);
             if (kci != null && kci.getKieContainer() != null) {
-                ServiceResponse<KieScannerResource> result = null;
-                switch (status) {
-                    case CREATED:
-                        // create the scanner
-                        result = createScanner(id, kci);
-                        break;
-                    case STARTED:
-                        // start the scanner
-                        result = startScanner(id, resource, kci);
-                        break;
-                    case STOPPED:
-                        // stop the scanner
-                        result = stopScanner(id, resource, kci);
-                        break;
-                    case SCANNING:
-                        // scan now
-                        result = scanNow(id, resource, kci);
-                        break;
-                    case DISPOSED:
-                        // dispose
-                        result = disposeScanner(id, resource, kci);
-                        break;
-                    default:
-                        // error
-                        result = new ServiceResponse<KieScannerResource>(ServiceResponse.ResponseType.FAILURE,
-                                "Unknown status '" + status + "' for scanner on container " + id + ".");
-                        break;
+                // synchronize over the container instance to avoid inconsistent sate in case of concurrent updateScanner calls
+                synchronized (kci) {
+                    ServiceResponse<KieScannerResource> result = null;
+                    switch (status) {
+                        case CREATED:
+                            result = createScanner(id, kci);
+                            break;
+                        case STARTED:
+                            result = startScanner(id, resource, kci);
+                            break;
+                        case STOPPED:
+                            result = stopScanner(id, resource, kci);
+                            break;
+                        case SCANNING:
+                            result = scanNow(id, resource, kci);
+                            break;
+                        case DISPOSED:
+                            result = disposeScanner(id, resource, kci);
+                            break;
+                        default:
+                            // error
+                            result = new ServiceResponse<KieScannerResource>(ServiceResponse.ResponseType.FAILURE,
+                                    "Unknown status '" + status + "' for scanner on container " + id + ".");
+                            break;
+                    }
+                    KieScannerResource scannerResource = result.getResult();
+                    kci.getResource().setScanner(result.getResult()); // might be null, but that is ok
+                    storeScannerState(kci.getContainerId(), scannerResource);
+                    return result;
                 }
-                kci.getResource().setScanner( result.getResult() ); // might be null, but that is ok
-                return result;
             } else {
                 return new ServiceResponse<KieScannerResource>(ServiceResponse.ResponseType.FAILURE,
                         "Unknown container " + id + ".");
@@ -502,6 +499,22 @@ public class KieServerImpl {
             return new ServiceResponse<KieScannerResource>(ServiceResponse.ResponseType.FAILURE, "Error updating scanner for container '" + id +
                     "': " + resource + ": " + e.getClass().getName() + ": " + e.getMessage());
         }
+    }
+
+    /**
+     * Stores (persists) new scanner state for the specified KIE container.
+     *
+     * @param containerId container ID to update the scanner for
+     * @param scannerState new scanner state
+     */
+    private void storeScannerState(String containerId, KieScannerResource scannerState) {
+        KieServerState currentState = repository.load(KieServerEnvironment.getServerId());
+        for (KieContainerResource containerResource : currentState.getContainers()) {
+            if (containerId.equals(containerResource.getContainerId())) {
+                containerResource.setScanner(scannerState);
+            }
+        }
+        repository.store(KieServerEnvironment.getServerId(), currentState);
     }
 
     private ServiceResponse<KieScannerResource> startScanner(String id, KieScannerResource resource, KieContainerInstanceImpl kci) {
@@ -516,6 +529,7 @@ public class KieServerImpl {
         if (KieScannerStatus.STOPPED.equals(mapStatus(kci.getScanner().getStatus())) &&
                 resource.getPollInterval() != null) {
             kci.getScanner().start(resource.getPollInterval());
+
             messages.add(new Message(Severity.INFO, "Kie scanner successfully started with interval " + resource.getPollInterval()));
             return new ServiceResponse<KieScannerResource>(ServiceResponse.ResponseType.SUCCESS,
                     "Kie scanner successfully created.",

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/storage/KieServerState.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/storage/KieServerState.java
@@ -15,9 +15,7 @@
 
 package org.kie.server.services.impl.storage;
 
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/KieServerImplServerTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/KieServerImplServerTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.services.impl;
+
+import org.apache.commons.io.FileUtils;
+import org.assertj.core.api.Assertions;
+import org.drools.compiler.kie.builder.impl.InternalKieModule;
+import org.junit.Test;
+import org.kie.api.KieServices;
+import org.kie.api.builder.KieFileSystem;
+import org.kie.api.builder.KieModule;
+import org.kie.scanner.MavenRepository;
+import org.kie.server.api.model.KieContainerResource;
+import org.kie.server.api.model.KieScannerResource;
+import org.kie.server.api.model.KieScannerStatus;
+import org.kie.server.api.model.ReleaseId;
+import org.kie.server.services.impl.storage.KieServerState;
+import org.kie.server.services.impl.storage.KieServerStateRepository;
+import org.kie.server.services.impl.storage.file.KieServerStateFileRepository;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Set;
+
+public class KieServerImplServerTest {
+
+    private static final String KIE_SERVER_ID = "kie-server-impl-test";
+    private static final String KIE_SERVER_REPO_LOCATION = "target/";
+    private static final String GROUP_ID = "org.kie.server.test";
+    private static final String ARTIFACT_ID = "persist-scanner-state";
+    private static final String VERSION = "1.0.0.Final";
+    private static final String CONTAINER_ID = "persist-scanner-state";
+
+    @Test
+    // https://issues.jboss.org/browse/RHBPMS-4087
+    public void testPersistScannerState() {
+        System.setProperty("org.kie.server.id", KIE_SERVER_ID);
+        System.setProperty("org.kie.server.repo", KIE_SERVER_REPO_LOCATION);
+
+        KieServerImpl kieServer = new KieServerImpl();
+
+        // create empty kjar; content does not matter
+        KieServices kieServices = KieServices.Factory.get();
+        KieFileSystem kfs = kieServices.newKieFileSystem();
+        org.kie.api.builder.ReleaseId releaseId = kieServices.newReleaseId(GROUP_ID, ARTIFACT_ID, VERSION);
+        KieModule kieModule = kieServices.newKieBuilder( kfs ).buildAll().getKieModule();
+        MavenRepository.getMavenRepository().installArtifact(releaseId, (InternalKieModule)kieModule, createPomFile());
+        kieServices.getRepository().addKieModule(kieModule);
+
+        // create the container and update the
+        KieContainerResource kieContainerResource = new KieContainerResource(CONTAINER_ID, new ReleaseId(releaseId));
+        kieServer.createContainer(CONTAINER_ID, kieContainerResource);
+        KieScannerResource kieScannerResource = new KieScannerResource(KieScannerStatus.STARTED, 20000L);
+        kieServer.updateScanner(CONTAINER_ID, kieScannerResource);
+
+        KieServerStateRepository stateRepository = new KieServerStateFileRepository();
+        KieServerState state = stateRepository.load(KIE_SERVER_ID);
+        Set<KieContainerResource> containers = state.getContainers();
+        Assertions.assertThat(containers).hasSize(1);
+        KieContainerResource container = containers.iterator().next();
+        Assertions.assertThat(container.getScanner()).isEqualTo(kieScannerResource);
+
+        KieScannerResource updatedKieScannerResource = new KieScannerResource(KieScannerStatus.DISPOSED);
+        kieServer.updateScanner(CONTAINER_ID, updatedKieScannerResource);
+
+        // create new state repository instance to avoid caching via 'knownStates'
+        // this is simulates the server restart (since the status is loaded from filesystem after restart)
+        stateRepository = new KieServerStateFileRepository();
+        state = stateRepository.load(KIE_SERVER_ID);
+        containers = state.getContainers();
+        Assertions.assertThat(containers).hasSize(1);
+        container = containers.iterator().next();
+        Assertions.assertThat(container.getScanner()).isEqualTo(updatedKieScannerResource);
+    }
+
+    private File createPomFile() {
+        String pomContent = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+                "         xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd\">\n" +
+                "  <modelVersion>4.0.0</modelVersion>\n" +
+                "\n" +
+                "  <groupId>org.kie.server.test</groupId>\n" +
+                "  <artifactId>persist-scanner-state</artifactId>\n" +
+                "  <version>1.0.0.Final</version>\n" +
+                "  <packaging>pom</packaging>\n" +
+                "</project>";
+        try {
+            File file = new File("target/persist-scanner-state-1.0.0.Final.pom");
+            FileUtils.write(file, pomContent);
+            return file;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerExecutor.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerExecutor.java
@@ -50,7 +50,7 @@ public class KieServerExecutor {
         server.setPort(TestConfig.getKieServerAllocatedPort());
         server.start();
 
-        addServerSingltonResources();
+        addServerSingletonResources();
     }
     private void setKieServerProperties() {
         System.setProperty(KieServerConstants.CFG_BYPASS_AUTH_USER, "true");
@@ -70,7 +70,7 @@ public class KieServerExecutor {
             KieServerEnvironment.setServerName("KieServer");
         }
     }
-    private void addServerSingltonResources() {
+    private void addServerSingletonResources() {
         kieServer = new KieServerImpl();
         server.getDeployment().getRegistry().addSingletonResource(new KieServerRestImpl(kieServer));
 


### PR DESCRIPTION
Backport of #578 

Cherry-pick into 6.4.x is not clean. Will fix the conflicts later and create one more PR.