### PR TITLE
Allows user to specify additional Maven repositories for pax-exam tests.

### DIFF
--- a/drools-osgi/drools-karaf-itests/README
+++ b/drools-osgi/drools-karaf-itests/README
@@ -7,6 +7,9 @@ karaf.dist.file - path to karaf distribution file (if not defined, the default k
 karaf.version - Version of Karaf container. This parameter is mandatory when a custom Karaf distribution file is specified.
                 (for example Jboss Fuse 6.2. uses Karaf container version 2.4.0)
 karaf.keep.runtime.folder - keep pax exam runtime folder after the test execution is finished
+karaf.maven.repos - Add additional Maven repositories. Value of this property is added
+                    to "org.ops4j.pax.url.mvn.repositories" property in "org.ops4j.pax.url.mvn.cfg" configuration file.
+                    Uses comma as separator.
 karaf.maxpermsize - increase the maximal size of PermGen space for karaf container in Java 7
 karaf.osgi.framework - specifies base OSGi framework for Karaf (e.g. felix or equinox)
 

--- a/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/AbstractKarafIntegrationTest.java
+++ b/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/AbstractKarafIntegrationTest.java
@@ -80,6 +80,12 @@ abstract public class AbstractKarafIntegrationTest {
      */
     public static final String PROP_KARAF_FRAMEWORK = "karaf.osgi.framework";
 
+    /**
+     * Additional Maven repositories. Value of this property is added to "org.ops4j.pax.url.mvn.repositories"
+     * property in "org.ops4j.pax.url.mvn.cfg" configuration file.
+     */
+    public static final String PROP_ADDTITIONAL_MAVEN_REPOS = "karaf.maven.repos";
+
     private static final transient Logger logger = LoggerFactory.getLogger(AbstractKarafIntegrationTest.class);
 
     protected static final String DROOLS_VERSION;
@@ -160,10 +166,17 @@ abstract public class AbstractKarafIntegrationTest {
         }
         
         options.add(localMavenRepoOption());
+
+        /* Add aditional Maven repositories */
+        String additionalMavenRepositories = "";
+        if (System.getProperty(PROP_ADDTITIONAL_MAVEN_REPOS) != null) {
+            additionalMavenRepositories = "," + System.getProperty(PROP_ADDTITIONAL_MAVEN_REPOS);
+        }
         options.add(editConfigurationFilePut("etc/org.ops4j.pax.url.mvn.cfg", "org.ops4j.pax.url.mvn.repositories",
                         "http://repo1.maven.org/maven2@id=central," +
-                        "https://repository.jboss.org/nexus/content/groups/public@id=jboss-public"
-                ));
+                        "https://repository.jboss.org/nexus/content/groups/public@id=jboss-public" +
+                        additionalMavenRepositories
+            ));
 
         if (System.getProperty(PROP_KARAF_FRAMEWORK) != null) {
             options.add(editConfigurationFilePut(CustomProperties.KARAF_FRAMEWORK, System.getProperty(PROP_KARAF_FRAMEWORK)));

--- a/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/AbstractKarafIntegrationTest.java
+++ b/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/AbstractKarafIntegrationTest.java
@@ -84,7 +84,7 @@ abstract public class AbstractKarafIntegrationTest {
      * Additional Maven repositories. Value of this property is added to "org.ops4j.pax.url.mvn.repositories"
      * property in "org.ops4j.pax.url.mvn.cfg" configuration file.
      */
-    public static final String PROP_ADDTITIONAL_MAVEN_REPOS = "karaf.maven.repos";
+    public static final String PROP_ADDITIONAL_MAVEN_REPOS = "karaf.maven.repos";
 
     private static final transient Logger logger = LoggerFactory.getLogger(AbstractKarafIntegrationTest.class);
 
@@ -169,8 +169,8 @@ abstract public class AbstractKarafIntegrationTest {
 
         /* Add aditional Maven repositories */
         String additionalMavenRepositories = "";
-        if (System.getProperty(PROP_ADDTITIONAL_MAVEN_REPOS) != null) {
-            additionalMavenRepositories = "," + System.getProperty(PROP_ADDTITIONAL_MAVEN_REPOS);
+        if (System.getProperty(PROP_ADDITIONAL_MAVEN_REPOS) != null) {
+            additionalMavenRepositories = "," + System.getProperty(PROP_ADDITIONAL_MAVEN_REPOS);
         }
         options.add(editConfigurationFilePut("etc/org.ops4j.pax.url.mvn.cfg", "org.ops4j.pax.url.mvn.repositories",
                         "http://repo1.maven.org/maven2@id=central," +


### PR DESCRIPTION
Allows user to specify additional Maven repositories for pax-exam tests. This can be useful when running pax-exam tests against binaries which are not available in public Maven repositories.