### PR TITLE
[6.5.x] JBPM-5228 - Add more tests for 'fire and forget' feature

### DIFF
--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/AbstractKieServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/AbstractKieServicesClientImpl.java
@@ -27,8 +27,6 @@ import java.util.UUID;
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
 import javax.jms.JMSException;
-import javax.jms.Message;
-import javax.jms.MessageConsumer;
 import javax.jms.MessageProducer;
 import javax.jms.Queue;
 import javax.jms.Session;
@@ -47,10 +45,8 @@ import org.kie.server.api.marshalling.MarshallingException;
 import org.kie.server.api.marshalling.MarshallingFormat;
 import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.api.model.ServiceResponsesList;
-import org.kie.server.client.KieServicesClient;
 import org.kie.server.client.KieServicesConfiguration;
 import org.kie.server.client.KieServicesException;
-import org.kie.server.client.impl.KieServicesClientImpl;
 import org.kie.server.client.jms.ResponseHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -127,7 +123,15 @@ public abstract class AbstractKieServicesClientImpl {
         this.owner = owner;
     }
 
+    public ResponseHandler getResponseHandler() {
+        return responseHandler;
+    }
+
     public void setResponseHandler(ResponseHandler responseHandler) {
+        if (config.getTransport() == KieServicesConfiguration.Transport.REST) {
+            throw new UnsupportedOperationException("Response handlers can only be configured for JMS client");
+        }
+
         this.responseHandler = responseHandler;
     }
 

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/KieServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/KieServicesClientImpl.java
@@ -17,8 +17,6 @@ package org.kie.server.client.impl;
 
 import org.kie.api.command.Command;
 import org.kie.server.api.model.KieContainerResourceFilter;
-import org.kie.server.api.model.KieContainerStatusFilter;
-import org.kie.server.api.model.ReleaseIdFilter;
 import org.kie.server.api.commands.CallContainerCommand;
 import org.kie.server.api.commands.CommandScript;
 import org.kie.server.api.commands.CreateContainerCommand;
@@ -44,6 +42,8 @@ import org.kie.server.client.KieServicesConfiguration;
 import org.kie.server.client.KieServicesException;
 import org.kie.server.client.RuleServicesClient;
 import org.kie.server.client.helper.KieServicesClientBuilder;
+import org.kie.server.client.jms.RequestReplyResponseHandler;
+import org.kie.server.client.jms.ResponseHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,7 +56,7 @@ import java.util.ServiceLoader;
 
 public class KieServicesClientImpl extends AbstractKieServicesClientImpl implements KieServicesClient {
 
-    private static Logger logger = LoggerFactory.getLogger( KieServicesClientImpl.class );
+    private static Logger logger = LoggerFactory.getLogger(KieServicesClientImpl.class);
 
     private static final ServiceLoader<KieServicesClientBuilder> clientBuilders = ServiceLoader.load(KieServicesClientBuilder.class, KieServicesClientImpl.class.getClassLoader());
     private static List<KieServicesClientBuilder> loadedClientBuilders = loadClientBuilders();   // load it only once to make sure it's thread safe
@@ -81,11 +81,7 @@ public class KieServicesClientImpl extends AbstractKieServicesClientImpl impleme
         List<String> serverCapabilities = config.getCapabilities();
 
         if (serverCapabilities == null) {
-            // no explicit capabilities configuration given fetch them from kieServer
-            kieServerInfo = getServerInfo().getResult();
-            logger.debug("KieServicesClient connected to: {} version {}", kieServerInfo.getServerId(), kieServerInfo.getVersion());
-            serverCapabilities = kieServerInfo.getCapabilities();
-            logger.debug("Supported capabilities by the server: {}", serverCapabilities);
+            serverCapabilities = getCapabilitiesFromServer();
         }
         if (serverCapabilities != null && !serverCapabilities.isEmpty()) {
             // process available client builders
@@ -123,6 +119,26 @@ public class KieServicesClientImpl extends AbstractKieServicesClientImpl impleme
 
     }
 
+    private List<String> getCapabilitiesFromServer() {
+        ResponseHandler responseHandler = getResponseHandler();
+        if (config.isJms() && !(responseHandler instanceof RequestReplyResponseHandler)) {
+            setResponseHandler(new RequestReplyResponseHandler());
+            kieServerInfo = getServerInfo().getResult();
+            setResponseHandler(responseHandler);
+        } else {
+            kieServerInfo = getServerInfo().getResult();
+        }
+
+        logger.debug("KieServicesClient connected to: {} version {}", kieServerInfo.getServerId(), kieServerInfo.getVersion());
+        List<String> capabilities = kieServerInfo.getCapabilities();
+        logger.debug("Supported capabilities by the server: {}", capabilities);
+
+        return capabilities;
+    }
+
+    private KieServerInfo getServerInfoInTransaction() {
+        throw new IllegalStateException("Cannot get capabilities from server in a transaction");
+    }
 
     @Override
     public <T> T getServicesClient(Class<T> serviceClient) {
@@ -136,11 +152,12 @@ public class KieServicesClientImpl extends AbstractKieServicesClientImpl impleme
 
     @Override
     public ServiceResponse<KieServerInfo> getServerInfo() {
-        if( config.isRest() ) {
-            return makeHttpGetRequestAndCreateServiceResponse( baseURI, KieServerInfo.class );
+        if (config.isRest()) {
+            return makeHttpGetRequestAndCreateServiceResponse(baseURI, KieServerInfo.class);
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand) new GetServerInfoCommand() ) );
-            return (ServiceResponse<KieServerInfo>) executeJmsCommand( script ).getResponses().get( 0 );
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new GetServerInfoCommand()));
+            ServiceResponse<KieServerInfo> response = (ServiceResponse<KieServerInfo>) executeJmsCommand(script).getResponses().get(0);
+            return getResponseOrNullIfNoResponse(response);
         }
     }
 
@@ -156,91 +173,103 @@ public class KieServicesClientImpl extends AbstractKieServicesClientImpl impleme
             String uri = baseURI + "/containers" + (queryParams.isEmpty() ? "" : "?" + queryParams);
             return makeHttpGetRequestAndCreateServiceResponse(uri, KieContainerResourceList.class);
         } else {
-            CommandScript script = new CommandScript(Collections.singletonList( (KieServerCommand) new ListContainersCommand(containerFilter)));
-            return (ServiceResponse<KieContainerResourceList>) executeJmsCommand(script).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new ListContainersCommand(containerFilter)));
+            ServiceResponse<KieContainerResourceList> response = (ServiceResponse<KieContainerResourceList>) executeJmsCommand(script).getResponses().get(0);
+            return getResponseOrNullIfNoResponse(response);
         }
     }
 
     @Override
     public ServiceResponse<KieContainerResource> createContainer(String id, KieContainerResource resource) {
-        if( config.isRest() ) {
-            return makeHttpPutRequestAndCreateServiceResponse( baseURI + "/containers/" + id, resource, KieContainerResource.class );
+        if (config.isRest()) {
+            return makeHttpPutRequestAndCreateServiceResponse(baseURI + "/containers/" + id, resource, KieContainerResource.class);
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand) new CreateContainerCommand( resource ) ) );
-            return (ServiceResponse<KieContainerResource>) executeJmsCommand( script, null, null, id ).getResponses().get( 0 );
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new CreateContainerCommand(resource)));
+            ServiceResponse<KieContainerResource> response = (ServiceResponse<KieContainerResource>) executeJmsCommand(script, null, null, id).getResponses().get(0);
+            return getResponseOrNullIfNoResponse(response);
         }
     }
 
     @Override
     public ServiceResponse<KieContainerResource> getContainerInfo(String id) {
-        if( config.isRest() ) {
-            return makeHttpGetRequestAndCreateServiceResponse( baseURI + "/containers/" + id, KieContainerResource.class );
+        if (config.isRest()) {
+            return makeHttpGetRequestAndCreateServiceResponse(baseURI + "/containers/" + id, KieContainerResource.class);
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand) new GetContainerInfoCommand( id ) ) );
-            return (ServiceResponse<KieContainerResource>) executeJmsCommand( script, null, null, id ).getResponses().get( 0 );
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new GetContainerInfoCommand(id)));
+            ServiceResponse<KieContainerResource> response = (ServiceResponse<KieContainerResource>) executeJmsCommand(script, null, null, id).getResponses().get(0);
+            return getResponseOrNullIfNoResponse(response);
         }
     }
 
     @Override
     public ServiceResponse<Void> disposeContainer(String id) {
-        if( config.isRest() ) {
-            return makeHttpDeleteRequestAndCreateServiceResponse( baseURI + "/containers/" + id, Void.class );
+        if (config.isRest()) {
+            return makeHttpDeleteRequestAndCreateServiceResponse(baseURI + "/containers/" + id, Void.class);
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand) new DisposeContainerCommand( id ) ) );
-            return (ServiceResponse<Void>) executeJmsCommand( script, null, null, id ).getResponses().get( 0 );
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DisposeContainerCommand(id)));
+            ServiceResponse<Void> response = (ServiceResponse<Void>) executeJmsCommand(script, null, null, id).getResponses().get(0);
+            return getResponseOrNullIfNoResponse(response);
         }
     }
 
     @Override
     public ServiceResponsesList executeScript(CommandScript script) {
-        if( config.isRest() ) {
-            return makeHttpPostRequestAndCreateCustomResponse( baseURI + "/config", script, ServiceResponsesList.class );
+        if (config.isRest()) {
+            return makeHttpPostRequestAndCreateCustomResponse(baseURI + "/config", script, ServiceResponsesList.class);
         } else {
-            return executeJmsCommand( script );
+            ServiceResponsesList responsesList = executeJmsCommand(script);
+            if (!responsesList.getResponses().isEmpty() && shouldReturnWithNullResponse(responsesList.getResponses().get(0))) {
+                return null;
+            }
+            return responsesList;
         }
     }
 
     @Override
     public ServiceResponse<KieScannerResource> getScannerInfo(String id) {
-        if( config.isRest() ) {
-            return makeHttpGetRequestAndCreateServiceResponse( baseURI + "/containers/" + id + "/scanner", KieScannerResource.class );
+        if (config.isRest()) {
+            return makeHttpGetRequestAndCreateServiceResponse(baseURI + "/containers/" + id + "/scanner", KieScannerResource.class);
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand) new GetScannerInfoCommand( id ) ) );
-            return (ServiceResponse<KieScannerResource>) executeJmsCommand( script, null, null, id ).getResponses().get( 0 );
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new GetScannerInfoCommand(id)));
+            ServiceResponse<KieScannerResource> response = (ServiceResponse<KieScannerResource>) executeJmsCommand(script, null, null, id).getResponses().get(0);
+            return getResponseOrNullIfNoResponse(response);
         }
     }
 
     @Override
     public ServiceResponse<KieScannerResource> updateScanner(String id, KieScannerResource resource) {
-        if( config.isRest() ) {
+        if (config.isRest()) {
             return makeHttpPostRequestAndCreateServiceResponse(
                     baseURI + "/containers/" + id + "/scanner", resource,
-                    KieScannerResource.class );
+                    KieScannerResource.class);
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand) new UpdateScannerCommand( id, resource ) ) );
-            return (ServiceResponse<KieScannerResource>) executeJmsCommand( script, null, null, id ).getResponses().get( 0 );
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new UpdateScannerCommand(id, resource)));
+            ServiceResponse<KieScannerResource> response = (ServiceResponse<KieScannerResource>) executeJmsCommand(script, null, null, id).getResponses().get(0);
+            return getResponseOrNullIfNoResponse(response);
         }
     }
 
     @Override
     public ServiceResponse<ReleaseId> updateReleaseId(String id, ReleaseId releaseId) {
-        if( config.isRest() ) {
+        if (config.isRest()) {
             return makeHttpPostRequestAndCreateServiceResponse(
                     baseURI + "/containers/" + id + "/release-id", releaseId,
-                    ReleaseId.class );
+                    ReleaseId.class);
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand) new UpdateReleaseIdCommand( id, releaseId ) ) );
-            return (ServiceResponse<ReleaseId>) executeJmsCommand( script, null, null, id ).getResponses().get( 0 );
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new UpdateReleaseIdCommand(id, releaseId)));
+            ServiceResponse<ReleaseId> response = (ServiceResponse<ReleaseId>) executeJmsCommand(script, null, null, id).getResponses().get(0);
+            return getResponseOrNullIfNoResponse(response);
         }
     }
 
     @Override
     public ServiceResponse<KieServerStateInfo> getServerState() {
-        if( config.isRest() ) {
+        if (config.isRest()) {
             return makeHttpGetRequestAndCreateServiceResponse(baseURI + "/state", KieServerStateInfo.class);
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand) new GetServerStateCommand() ) );
-            return (ServiceResponse<KieServerStateInfo>) executeJmsCommand( script).getResponses().get( 0 );
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new GetServerStateCommand()));
+            ServiceResponse<KieServerStateInfo> response = (ServiceResponse<KieServerStateInfo>) executeJmsCommand(script).getResponses().get(0);
+            return getResponseOrNullIfNoResponse(response);
         }
     }
 
@@ -248,33 +277,37 @@ public class KieServicesClientImpl extends AbstractKieServicesClientImpl impleme
 
     /**
      * This method is deprecated on KieServicesClient as it was moved to RuleServicesClient
+     *
      * @see RuleServicesClient#executeCommands(String, String)
      * @deprecated
      */
     @Deprecated
     @Override
     public ServiceResponse<String> executeCommands(String id, String payload) {
-        if( config.isRest() ) {
+        if (config.isRest()) {
             return makeBackwardCompatibleHttpPostRequestAndCreateServiceResponse(baseURI + "/containers/instances/" + id, payload, String.class);
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand) new CallContainerCommand( id, payload ) ) );
-            return (ServiceResponse<String>) executeJmsCommand( script, null, null, id ).getResponses().get( 0 );
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new CallContainerCommand(id, payload)));
+            ServiceResponse<String> response = (ServiceResponse<String>) executeJmsCommand(script, null, null, id).getResponses().get(0);
+            return getResponseOrNullIfNoResponse(response);
         }
     }
 
     /**
      * This method is deprecated on KieServicesClient as it was moved to RuleServicesClient
+     *
      * @see RuleServicesClient#executeCommands(String, Command)
      * @deprecated
      */
     @Deprecated
     @Override
     public ServiceResponse<String> executeCommands(String id, Command<?> cmd) {
-        if( config.isRest() ) {
-            return makeBackwardCompatibleHttpPostRequestAndCreateServiceResponse(baseURI + "/containers/instances/" + id, cmd, String.class, getHeaders(cmd) );
+        if (config.isRest()) {
+            return makeBackwardCompatibleHttpPostRequestAndCreateServiceResponse(baseURI + "/containers/instances/" + id, cmd, String.class, getHeaders(cmd));
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand) new CallContainerCommand( id, serialize(cmd) ) ) );
-            return (ServiceResponse<String>) executeJmsCommand( script, cmd.getClass().getName(), null, id ).getResponses().get( 0 );
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new CallContainerCommand(id, serialize(cmd))));
+            ServiceResponse<String> response = (ServiceResponse<String>) executeJmsCommand(script, cmd.getClass().getName(), null, id).getResponses().get(0);
+            return getResponseOrNullIfNoResponse(response);
         }
     }
 
@@ -289,7 +322,7 @@ public class KieServicesClientImpl extends AbstractKieServicesClientImpl impleme
 
     @Override
     public void setClassLoader(ClassLoader classLoader) {
-        this.marshaller.setClassLoader( classLoader );
+        this.marshaller.setClassLoader(classLoader);
     }
 
     @Override
@@ -313,7 +346,6 @@ public class KieServicesClientImpl extends AbstractKieServicesClientImpl impleme
         }
     }
 
-
     private synchronized static List<KieServicesClientBuilder> loadClientBuilders() {
         List<KieServicesClientBuilder> builders = new ArrayList<KieServicesClientBuilder>();
         for (KieServicesClientBuilder builder : clientBuilders) {
@@ -322,4 +354,12 @@ public class KieServicesClientImpl extends AbstractKieServicesClientImpl impleme
 
         return builders;
     }
+
+    private <T> ServiceResponse<T> getResponseOrNullIfNoResponse(ServiceResponse<T> response) {
+        if (shouldReturnWithNullResponse(response)) {
+            return null;
+        }
+        return response;
+    }
+
 }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/pom.xml
@@ -66,7 +66,7 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
-    <!-- REST --> 
+    <!-- REST -->
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-test-tjws</artifactId>
@@ -76,7 +76,7 @@
       <artifactId>resteasy-jaxrs</artifactId>
     </dependency>
 
-   <!--  Stay with httpcomponents: it will save us pain (as opposed to changing from resteasy to cxf to cxf 3.0, etc. --> 
+    <!--  Stay with httpcomponents: it will save us pain (as opposed to changing from resteasy to cxf to cxf 3.0, etc. -->
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
@@ -108,18 +108,22 @@
       <groupId>org.codehaus.jackson</groupId>
       <artifactId>jackson-xc</artifactId>
     </dependency>
-    
+
     <!-- test -->
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
 
     <!-- Cargo dependencies -->
     <dependency>
-     <groupId>org.codehaus.cargo</groupId>
-     <artifactId>cargo-core-uberjar</artifactId>
+      <groupId>org.codehaus.cargo</groupId>
+      <artifactId>cargo-core-uberjar</artifactId>
     </dependency>
 
     <dependency>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/category/Transactional.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/category/Transactional.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2016 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.server.integrationtests.category;
+
+public interface Transactional {
+}

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerAssert.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerAssert.java
@@ -17,6 +17,7 @@ package org.kie.server.integrationtests.shared;
 
 import java.util.Collection;
 import java.util.regex.Pattern;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -66,4 +67,5 @@ public class KieServerAssert {
             assertTrue("String is not empty.", result.trim().isEmpty());
         }
     }
+
 }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerSynchronization.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerSynchronization.java
@@ -18,17 +18,31 @@ package org.kie.server.integrationtests.shared;
 import java.util.Calendar;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
+
+import org.kie.api.command.Command;
 import org.kie.api.executor.STATUS;
+import org.kie.api.runtime.ExecutionResults;
 import org.kie.server.api.model.KieContainerResource;
+import org.kie.server.api.model.KieContainerResourceFilter;
 import org.kie.server.api.model.KieContainerResourceList;
 import org.kie.server.api.model.KieContainerStatus;
+import org.kie.server.api.model.KieScannerResource;
+import org.kie.server.api.model.KieScannerStatus;
+import org.kie.server.api.model.ReleaseId;
+import org.kie.server.api.model.ReleaseIdFilter;
 import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.api.model.instance.ProcessInstance;
 import org.kie.server.api.model.instance.RequestInfoInstance;
+import org.kie.server.api.model.instance.SolverInstance;
+import org.kie.server.api.model.instance.SolverInstanceList;
+import org.kie.server.api.model.instance.TaskInstance;
 import org.kie.server.client.JobServicesClient;
 import org.kie.server.client.KieServicesClient;
 import org.kie.server.client.ProcessServicesClient;
 import org.kie.server.client.QueryServicesClient;
+import org.kie.server.client.RuleServicesClient;
+import org.kie.server.client.SolverServicesClient;
+import org.kie.server.client.UserTaskServicesClient;
 
 public class KieServerSynchronization {
 
@@ -37,13 +51,12 @@ public class KieServerSynchronization {
 
     public static void waitForJobToFinish(final JobServicesClient jobServicesClient, final Long jobId) throws Exception {
         waitForCondition(new WaitingCondition() {
-
             @Override
             public boolean conditionPassed() {
                 RequestInfoInstance result = jobServicesClient.getRequestById(jobId, false, false);
 
                 // If job finished (to one of final states) then return.
-                if(STATUS.CANCELLED.toString().equals(result.getStatus()) ||
+                if (STATUS.CANCELLED.toString().equals(result.getStatus()) ||
                         STATUS.DONE.toString().equals(result.getStatus()) ||
                         STATUS.ERROR.toString().equals(result.getStatus())) {
                     return true;
@@ -91,8 +104,8 @@ public class KieServerSynchronization {
                 ProcessInstance processInstance = processClient.getProcessInstance(containerId, processInstanceId);
 
                 // If process instance is finished (to one of final states) then return.
-                if(((Integer)org.kie.api.runtime.process.ProcessInstance.STATE_COMPLETED).equals(processInstance.getState()) ||
-                        ((Integer)org.kie.api.runtime.process.ProcessInstance.STATE_ABORTED).equals(processInstance.getState())) {
+                if (((Integer) org.kie.api.runtime.process.ProcessInstance.STATE_COMPLETED).equals(processInstance.getState()) ||
+                        ((Integer) org.kie.api.runtime.process.ProcessInstance.STATE_ABORTED).equals(processInstance.getState())) {
                     return true;
                 }
                 return false;
@@ -115,6 +128,88 @@ public class KieServerSynchronization {
         });
     }
 
+    public static void waitForContainerWithReleaseId(final KieServicesClient client, final ReleaseId releaseId) throws Exception {
+        waitForCondition(new WaitingCondition() {
+            @Override
+            public boolean conditionPassed() {
+                ReleaseIdFilter releaseIdFilter = new ReleaseIdFilter(releaseId);
+                KieContainerResourceFilter resourceFilter = new KieContainerResourceFilter(releaseIdFilter);
+
+                ServiceResponse<KieContainerResourceList> containersList = client.listContainers(resourceFilter);
+                List<KieContainerResource> containers = containersList.getResult().getContainers();
+                return containers != null && !containers.isEmpty();
+            }
+        });
+    }
+
+    public static void waitForContainerWithScannerStatus(final KieServicesClient client, final KieScannerStatus scannerStatus) throws Exception {
+        waitForCondition(new WaitingCondition() {
+            @Override
+            public boolean conditionPassed() {
+                ServiceResponse<KieContainerResourceList> containersList = client.listContainers();
+                List<KieContainerResource> containers = containersList.getResult().getContainers();
+                if (containers != null) {
+                    for (KieContainerResource container : containers) {
+                        KieScannerResource scanner = container.getScanner();
+                        if (scanner != null && scannerStatus.equals(scanner.getStatus())) {
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            }
+        });
+    }
+
+    public static void waitForSolver(final SolverServicesClient client, final String containerId, final String solverId) throws Exception {
+        waitForCondition(new WaitingCondition() {
+            @Override
+            public boolean conditionPassed() {
+                ServiceResponse<SolverInstanceList> solverListResponse = client.getSolvers(containerId);
+                SolverInstanceList solverList = solverListResponse.getResult();
+                for (SolverInstance solver : solverList.getContainers()) {
+                    if (solverId.equals(solver.getSolverId())) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        });
+    }
+
+    public static void waitForSolverStatus(final SolverServicesClient client, final String containerId, final String solverId,
+                                           final SolverInstance.SolverStatus status) throws Exception {
+        waitForCondition(new WaitingCondition() {
+            @Override
+            public boolean conditionPassed() {
+                ServiceResponse<SolverInstance> solverResponse = client.getSolverState(containerId, solverId);
+                return status.equals(solverResponse.getResult().getStatus());
+            }
+        });
+    }
+
+    public static void waitForCommandResult(final RuleServicesClient client, final String containerId,
+                                            final Command command, final String identifier, final Object value) throws Exception {
+        waitForCondition(new WaitingCondition() {
+            @Override
+            public boolean conditionPassed() {
+                ServiceResponse<ExecutionResults> response = client.executeCommandsWithResults(containerId, command);
+                ExecutionResults result = response.getResult();
+                return value.equals(result.getValue(identifier));
+            }
+        });
+    }
+
+    public static void waitForTaskStatus(final UserTaskServicesClient client, final Long taskId, final String status) throws Exception {
+        waitForCondition(new WaitingCondition() {
+            @Override
+            public boolean conditionPassed() {
+                TaskInstance task = client.findTaskById(taskId);
+                return status.equals(task.getStatus());
+            }
+        });
+    }
+
     private static void waitForCondition(WaitingCondition condition) throws Exception {
         long timeoutTime = Calendar.getInstance().getTimeInMillis() + SERVICE_TIMEOUT;
         while (Calendar.getInstance().getTimeInMillis() < timeoutTime) {
@@ -124,7 +219,7 @@ public class KieServerSynchronization {
             }
             Thread.sleep(TIMEOUT_BETWEEN_CALLS);
         }
-        throw new TimeoutException("Timeout while waiting for process instance to finish.");
+        throw new TimeoutException("Timeout while waiting for condition to be true.");
     }
 
     private interface WaitingCondition {

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/jms/ContainerJmsResponseHandlerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/jms/ContainerJmsResponseHandlerIntegrationTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package org.kie.server.integrationtests.common.jms;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runners.Parameterized;
+import org.kie.server.api.marshalling.Marshaller;
+import org.kie.server.api.marshalling.MarshallerFactory;
+import org.kie.server.api.marshalling.MarshallingFormat;
+import org.kie.server.api.model.KieContainerResource;
+import org.kie.server.api.model.KieContainerResourceList;
+import org.kie.server.api.model.KieScannerResource;
+import org.kie.server.api.model.KieScannerStatus;
+import org.kie.server.api.model.KieServerStateInfo;
+import org.kie.server.api.model.ReleaseId;
+import org.kie.server.api.model.ServiceResponse;
+import org.kie.server.client.KieServicesClient;
+import org.kie.server.client.KieServicesConfiguration;
+import org.kie.server.client.jms.AsyncResponseHandler;
+import org.kie.server.client.jms.BlockingResponseCallback;
+import org.kie.server.client.jms.FireAndForgetResponseHandler;
+import org.kie.server.client.jms.ResponseCallback;
+import org.kie.server.integrationtests.category.JMSOnly;
+import org.kie.server.integrationtests.shared.KieServerDeployer;
+import org.kie.server.integrationtests.shared.KieServerSynchronization;
+import org.kie.server.integrationtests.shared.basetests.RestJmsSharedBaseIntegrationTest;
+
+import static org.assertj.core.api.Assertions.*;
+
+@Category({JMSOnly.class})
+public class ContainerJmsResponseHandlerIntegrationTest extends RestJmsSharedBaseIntegrationTest {
+
+    private static final ReleaseId RELEASE_ID_1 = new ReleaseId("org.kie.server.testing", "container-crud-tests1", "2.1.0.GA");
+    private static final ReleaseId RELEASE_ID_2 = new ReleaseId("org.kie.server.testing", "container-crud-tests1", "2.1.1.GA");
+
+    @Parameterized.Parameters(name = "{index}: {0}")
+    public static Collection<Object[]> data() {
+        KieServicesConfiguration jmsConfiguration = createKieServicesJmsConfiguration();
+
+        return new ArrayList<Object[]>(Arrays.asList(new Object[][]{
+                {MarshallingFormat.JAXB, jmsConfiguration},
+                {MarshallingFormat.JSON, jmsConfiguration},
+                {MarshallingFormat.XSTREAM, jmsConfiguration}
+        }));
+    }
+
+    private KieServicesClient asyncClient;
+    private ResponseCallback responseCallback;
+
+    private KieServicesClient fireAndForgetClient;
+
+    @BeforeClass
+    public static void initialize() throws Exception {
+        KieServerDeployer.createAndDeployKJar(RELEASE_ID_1);
+        KieServerDeployer.createAndDeployKJar(RELEASE_ID_2);
+    }
+
+    @Before
+    public void setupClients() throws Exception {
+        asyncClient = createDefaultClient();
+        Marshaller marshaller = MarshallerFactory.getMarshaller(new HashSet<Class<?>>(extraClasses.values()),
+                configuration.getMarshallingFormat(), asyncClient.getClassLoader());
+        responseCallback = new BlockingResponseCallback(marshaller);
+        asyncClient.setResponseHandler(new AsyncResponseHandler(responseCallback));
+
+        fireAndForgetClient = createDefaultClient();
+        fireAndForgetClient.setResponseHandler(new FireAndForgetResponseHandler());
+    }
+
+    @Before
+    public void setupKieServer() throws Exception {
+        disposeAllContainers();
+    }
+
+    @Test
+    public void testContainerWithAsyncResponseHandler() {
+        String containerId = "asyncContainer";
+
+        ServiceResponse<?> response = asyncClient.createContainer(containerId, new KieContainerResource(containerId, RELEASE_ID_1));
+        assertThat(response).isNull();
+        KieContainerResource container = responseCallback.get(KieContainerResource.class);
+        assertThat(container).isNotNull();
+        assertThat(container.getContainerId()).isEqualTo(containerId);
+        assertThat(container.getReleaseId()).isEqualTo(RELEASE_ID_1);
+
+        response = asyncClient.getServerState();
+        assertThat(response).isNull();
+        KieServerStateInfo serverState = responseCallback.get(KieServerStateInfo.class);
+        assertThat(serverState).isNotNull();
+        assertThat(serverState.getContainers()).hasSize(1);
+        container = serverState.getContainers().iterator().next();
+        assertThat(container.getReleaseId()).isEqualTo(RELEASE_ID_1);
+
+        response = asyncClient.updateReleaseId(containerId, RELEASE_ID_2);
+        assertThat(response).isNull();
+        ReleaseId releaseId = responseCallback.get(ReleaseId.class);
+        assertThat(releaseId).isEqualTo(RELEASE_ID_2);
+
+        response = asyncClient.getContainerInfo(containerId);
+        assertThat(response).isNull();
+        container = responseCallback.get(KieContainerResource.class);
+        assertThat(container.getReleaseId()).isEqualTo(RELEASE_ID_2);
+
+        response = asyncClient.disposeContainer(containerId);
+        assertThat(response).isNull();
+        responseCallback.get(Void.class);
+
+        response = asyncClient.listContainers();
+        assertThat(response).isNull();
+        KieContainerResourceList containerList = responseCallback.get(KieContainerResourceList.class);
+        assertThat(containerList.getContainers()).isNullOrEmpty();
+    }
+
+    @Test
+    public void testContainerWithFireAndForgetResponseHandler() throws Exception {
+        String containerId = "fireAndForgetContainer";
+
+        ServiceResponse<?> response = fireAndForgetClient.createContainer(containerId, new KieContainerResource(containerId, RELEASE_ID_1));
+        assertThat(response).isNull();
+        KieServerSynchronization.waitForKieServerSynchronization(client, 1);
+
+        response = fireAndForgetClient.updateReleaseId(containerId, RELEASE_ID_2);
+        assertThat(response).isNull();
+        KieServerSynchronization.waitForContainerWithReleaseId(client, RELEASE_ID_2);
+
+        response = fireAndForgetClient.disposeContainer(containerId);
+        assertThat(response).isNull();
+        KieServerSynchronization.waitForKieServerSynchronization(client, 0);
+    }
+
+    @Test
+    public void testScannerWithAsyncResponseHandler() {
+        String containerId = "asyncScannerContainer";
+        createContainer(containerId, RELEASE_ID_1);
+
+        ServiceResponse<?> response = asyncClient.updateScanner(containerId, new KieScannerResource(KieScannerStatus.STARTED, 10000L));
+        assertThat(response).isNull();
+        KieScannerResource scanner = responseCallback.get(KieScannerResource.class);
+        assertThat(scanner.getStatus()).isEqualTo(KieScannerStatus.STARTED);
+
+        response = asyncClient.updateScanner(containerId, new KieScannerResource(KieScannerStatus.STOPPED, 10000L));
+        assertThat(response).isNull();
+        scanner = responseCallback.get(KieScannerResource.class);
+        assertThat(scanner.getStatus()).isEqualTo(KieScannerStatus.STOPPED);
+
+        response = asyncClient.updateScanner(containerId, new KieScannerResource(KieScannerStatus.DISPOSED, 10000L));
+        assertThat(response).isNull();
+        scanner = responseCallback.get(KieScannerResource.class);
+        assertThat(scanner.getStatus()).isEqualTo(KieScannerStatus.DISPOSED);
+    }
+
+    @Test
+    public void testScannerWithFireAndForgetResponseHandler() throws Exception {
+        String containerId = "fireAndForgetScannerContainer";
+        createContainer(containerId, RELEASE_ID_1);
+
+        ServiceResponse<?> response = fireAndForgetClient.updateScanner(containerId, new KieScannerResource(KieScannerStatus.STARTED, 10000L));
+        assertThat(response).isNull();
+        KieServerSynchronization.waitForContainerWithScannerStatus(client, KieScannerStatus.STARTED);
+
+        response = asyncClient.updateScanner(containerId, new KieScannerResource(KieScannerStatus.STOPPED, 10000L));
+        assertThat(response).isNull();
+        KieServerSynchronization.waitForContainerWithScannerStatus(client, KieScannerStatus.STOPPED);
+
+        response = asyncClient.updateScanner(containerId, new KieScannerResource(KieScannerStatus.DISPOSED, 10000L));
+        assertThat(response).isNull();
+        KieServerSynchronization.waitForContainerWithScannerStatus(client, KieScannerStatus.DISPOSED);
+    }
+
+}

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/pom.xml
@@ -159,6 +159,12 @@
       <type>war</type>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/jms/DroolsJmsResponseHandlerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/jms/DroolsJmsResponseHandlerIntegrationTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package org.kie.server.integrationtests.drools.jms;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+
+import org.drools.core.runtime.impl.ExecutionResultImpl;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runners.Parameterized;
+import org.kie.api.command.BatchExecutionCommand;
+import org.kie.api.command.Command;
+import org.kie.api.runtime.ExecutionResults;
+import org.kie.server.api.marshalling.Marshaller;
+import org.kie.server.api.marshalling.MarshallerFactory;
+import org.kie.server.api.marshalling.MarshallingFormat;
+import org.kie.server.api.model.ReleaseId;
+import org.kie.server.api.model.ServiceResponse;
+import org.kie.server.client.KieServicesConfiguration;
+import org.kie.server.client.jms.AsyncResponseHandler;
+import org.kie.server.client.jms.BlockingResponseCallback;
+import org.kie.server.client.jms.FireAndForgetResponseHandler;
+import org.kie.server.client.jms.RequestReplyResponseHandler;
+import org.kie.server.client.jms.ResponseCallback;
+import org.kie.server.client.jms.ResponseHandler;
+import org.kie.server.integrationtests.category.JMSOnly;
+import org.kie.server.integrationtests.drools.DroolsKieServerBaseIntegrationTest;
+import org.kie.server.integrationtests.shared.KieServerDeployer;
+import org.kie.server.integrationtests.shared.KieServerSynchronization;
+
+import static org.assertj.core.api.Assertions.*;
+
+@Category({JMSOnly.class})
+public class DroolsJmsResponseHandlerIntegrationTest extends DroolsKieServerBaseIntegrationTest {
+
+    private static ReleaseId releaseId = new ReleaseId("org.kie.server.testing", "ruleflow-group", "1.0.0.Final");
+
+    private static final String CONTAINER_ID = "ruleflow";
+    private static final String KIE_SESSION = "defaultKieSession";
+    private static final String PROCESS_ID = "simple-ruleflow";
+    private static final String LIST_NAME = "list";
+    private static final String LIST_OUTPUT_NAME = "output-list";
+
+    @Parameterized.Parameters(name = "{index}: {0}")
+    public static Collection<Object[]> data() {
+        KieServicesConfiguration jmsConfiguration = createKieServicesJmsConfiguration();
+
+        return new ArrayList<Object[]>(Arrays.asList(new Object[][]{
+                {MarshallingFormat.JAXB, jmsConfiguration},
+                {MarshallingFormat.JSON, jmsConfiguration},
+                {MarshallingFormat.XSTREAM, jmsConfiguration}
+        }));
+    }
+
+    @BeforeClass
+    public static void buildAndDeployArtifacts() {
+        KieServerDeployer.buildAndDeployCommonMavenParent();
+        KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/ruleflow-group").getFile());
+    }
+
+    @Before
+    public void cleanContainers() {
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId);
+    }
+
+    @Test
+    public void testExecuteSimpleRuleFlowProcessWithAsyncResponseHandler() {
+        Marshaller marshaller = MarshallerFactory.getMarshaller(new HashSet<Class<?>>(extraClasses.values()),
+                configuration.getMarshallingFormat(), client.getClassLoader());
+        ResponseCallback responseCallback = new BlockingResponseCallback(marshaller);
+        ResponseHandler asyncResponseHandler = new AsyncResponseHandler(responseCallback);
+        ruleClient.setResponseHandler(asyncResponseHandler);
+
+        List<Command<?>> commands = new ArrayList<Command<?>>();
+        commands.add(commandsFactory.newSetGlobal(LIST_NAME, new ArrayList<String>(), LIST_OUTPUT_NAME));
+        commands.add(commandsFactory.newStartProcess(PROCESS_ID));
+        commands.add(commandsFactory.newFireAllRules());
+        commands.add(commandsFactory.newGetGlobal(LIST_NAME, LIST_OUTPUT_NAME));
+        BatchExecutionCommand batchExecution = commandsFactory.newBatchExecution(commands, KIE_SESSION);
+
+        ServiceResponse<?> response = ruleClient.executeCommandsWithResults(CONTAINER_ID, batchExecution);
+        assertThat(response).isNull();
+        ExecutionResults result = responseCallback.get(ExecutionResultImpl.class);
+
+        List<String> outcome = (List<String>) result.getValue(LIST_OUTPUT_NAME);
+        assertThat(outcome).isNotNull();
+        assertThat(outcome).containsExactly("Rule from first ruleflow group executed",
+                "Rule from second ruleflow group executed");
+    }
+
+    @Test
+    public void testExecuteSimpleRuleFlowProcessWithFireAndForgetResponseHandler() throws Exception {
+        List<Command<?>> commands = new ArrayList<Command<?>>();
+        commands.add(commandsFactory.newSetGlobal(LIST_NAME, new ArrayList<String>(), LIST_OUTPUT_NAME));
+        commands.add(commandsFactory.newStartProcess(PROCESS_ID));
+        commands.add(commandsFactory.newFireAllRules());
+
+        BatchExecutionCommand batchExecution = commandsFactory.newBatchExecution(commands, KIE_SESSION);
+
+        ruleClient.setResponseHandler(new FireAndForgetResponseHandler());
+        ServiceResponse<?> response = ruleClient.executeCommandsWithResults(CONTAINER_ID, batchExecution);
+        assertThat(response).isNull();
+
+        ruleClient.setResponseHandler(new RequestReplyResponseHandler());
+        Command getGlobalCommand = commandsFactory.newGetGlobal(LIST_NAME, LIST_OUTPUT_NAME);
+        List<String> value = new ArrayList<String>();
+        value.add("Rule from first ruleflow group executed");
+        value.add("Rule from second ruleflow group executed");
+        KieServerSynchronization.waitForCommandResult(ruleClient, CONTAINER_ID, getGlobalCommand, LIST_OUTPUT_NAME, value);
+    }
+
+}

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
@@ -175,6 +175,12 @@
       <artifactId>subethasmtp-wiser</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/jms/JmsResponseHandlerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/jms/JmsResponseHandlerIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,24 +18,34 @@ package org.kie.server.integrationtests.jbpm.jms;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runners.Parameterized;
+import org.kie.api.KieServices;
+import org.kie.api.task.model.Status;
 import org.kie.server.api.marshalling.Marshaller;
 import org.kie.server.api.marshalling.MarshallerFactory;
 import org.kie.server.api.marshalling.MarshallingFormat;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.api.model.ServiceResponsesList;
+import org.kie.server.api.model.definition.QueryDefinition;
 import org.kie.server.api.model.instance.ProcessInstance;
 import org.kie.server.api.model.instance.ProcessInstanceList;
+import org.kie.server.api.model.instance.TaskInstance;
 import org.kie.server.api.model.instance.TaskSummary;
 import org.kie.server.api.model.instance.TaskSummaryList;
+import org.kie.server.client.KieServicesClient;
 import org.kie.server.client.KieServicesConfiguration;
+import org.kie.server.client.KieServicesFactory;
+import org.kie.server.client.ProcessServicesClient;
+import org.kie.server.client.QueryServicesClient;
 import org.kie.server.client.jms.AsyncResponseHandler;
 import org.kie.server.client.jms.BlockingResponseCallback;
 import org.kie.server.client.jms.FireAndForgetResponseHandler;
@@ -46,24 +56,23 @@ import org.kie.server.integrationtests.category.JMSOnly;
 import org.kie.server.integrationtests.jbpm.JbpmKieServerBaseIntegrationTest;
 import org.kie.server.integrationtests.shared.KieServerAssert;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
+import org.kie.server.integrationtests.shared.KieServerSynchronization;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 @Category({JMSOnly.class})
 public class JmsResponseHandlerIntegrationTest extends JbpmKieServerBaseIntegrationTest {
 
     private static final ReleaseId RELEASE_ID = new ReleaseId("org.kie.server.testing", "definition-project", "1.0.0.Final");
 
-    @Parameterized.Parameters(name = "{index}: {0} {1}")
+    @Parameterized.Parameters(name = "{index}: {0}")
     public static Collection<Object[]> data() {
         KieServicesConfiguration jmsConfiguration = createKieServicesJmsConfiguration();
-        Collection<Object[]> parameterData = new ArrayList<Object[]>(Arrays.asList(new Object[][]
-                        {
-                                {MarshallingFormat.JAXB, jmsConfiguration} ,
-                                {MarshallingFormat.JSON, jmsConfiguration},
-                                {MarshallingFormat.XSTREAM, jmsConfiguration}
-                        }
-        ));
+        Collection<Object[]> parameterData = new ArrayList<Object[]>(Arrays.asList(new Object[][]{
+                {MarshallingFormat.JAXB, jmsConfiguration},
+                {MarshallingFormat.JSON, jmsConfiguration},
+                {MarshallingFormat.XSTREAM, jmsConfiguration}
+        }));
 
         return parameterData;
     }
@@ -72,8 +81,16 @@ public class JmsResponseHandlerIntegrationTest extends JbpmKieServerBaseIntegrat
     public static void buildAndDeployArtifacts() {
         KieServerDeployer.buildAndDeployCommonMavenParent();
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project").getFile());
+        KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/query-definition-project").getFile());
+
+        kieContainer = KieServices.Factory.get().newKieContainer(RELEASE_ID);
 
         createContainer(CONTAINER_ID, RELEASE_ID);
+    }
+
+    @Override
+    protected void addExtraCustomClasses(Map<String, Class<?>> extraClasses) throws Exception {
+        extraClasses.put(PERSON_CLASS_NAME, Class.forName(PERSON_CLASS_NAME, true, kieContainer.getClassLoader()));
     }
 
     @Test
@@ -88,65 +105,87 @@ public class JmsResponseHandlerIntegrationTest extends JbpmKieServerBaseIntegrat
         testStartProcessResponseHandler(new AsyncResponseHandler(callback));
         // now let's check if response has arrived
         ServiceResponsesList response = callback.get();
-        assertNotNull(response);
-        assertNotNull(response.getResponses());
-        assertEquals(1, response.getResponses().size());
+        assertThat(response).isNotNull();
+        assertThat(response.getResponses()).isNotNull().hasSize(1);
         KieServerAssert.assertSuccess(response.getResponses().get(0));
 
         ServiceResponse serviceResponse = response.getResponses().get(0);
         Object result = serviceResponse.getResult();
-        assertNotNull(result);
-
+        assertThat(result).isNotNull();
     }
 
     @Test
     public void testStartProcessUseOfAsyncResponseHandlerWithMarshaller() throws Exception {
-        Marshaller marshaller = MarshallerFactory.getMarshaller(new HashSet<Class<?>>(extraClasses.values()), configuration.getMarshallingFormat(), client.getClassLoader());
-        ResponseCallback callback = new BlockingResponseCallback(marshaller);
+        ResponseCallback callback = new BlockingResponseCallback(createMarshaller());
 
         testStartProcessResponseHandler(new AsyncResponseHandler(callback));
         // now let's check if response has arrived
         Long processInstanceId = callback.get(Long.class);
-        assertNotNull(processInstanceId);
-        assertTrue(processInstanceId.longValue() > 0);
+        assertThat(processInstanceId).isNotNull().isPositive();
     }
 
     @Test
     public void testGetProcessInstancesUseOfAsyncResponseHandlerWithMarshaller() throws Exception {
-        Marshaller marshaller = MarshallerFactory.getMarshaller(new HashSet<Class<?>>(extraClasses.values()), configuration.getMarshallingFormat(), client.getClassLoader());
-        ResponseCallback callback = new BlockingResponseCallback(marshaller);
+        ResponseCallback callback = new BlockingResponseCallback(createMarshaller());
 
         testGetProcessInstancesResponseHandler(new AsyncResponseHandler(callback));
         // now let's check if response has arrived
         Long processInstanceId = callback.get(Long.class);
-        assertNotNull(processInstanceId);
-        assertTrue(processInstanceId.longValue() > 0);
+        assertThat(processInstanceId).isNotNull().isPositive();
 
         ProcessInstanceList processInstanceList = callback.get(ProcessInstanceList.class);
-        assertNotNull(processInstanceList);
-
-        List<ProcessInstance> instances = processInstanceList.getItems();
-        assertNotNull(instances);
-        assertEquals(1, instances.size());
+        assertThat(processInstanceList).isNotNull();
+        assertThat(processInstanceList.getItems()).isNotNull().hasSize(1);
     }
 
     @Test
     public void testGetTasksUseOfAsyncResponseHandlerWithMarshaller() throws Exception {
-        Marshaller marshaller = MarshallerFactory.getMarshaller(new HashSet<Class<?>>(extraClasses.values()), configuration.getMarshallingFormat(), client.getClassLoader());
-        ResponseCallback callback = new BlockingResponseCallback(marshaller);
+        ResponseCallback callback = new BlockingResponseCallback(createMarshaller());
 
         testGetTaskResponseHandler(new AsyncResponseHandler(callback));
         // now let's check if response has arrived
         Long processInstanceId = callback.get(Long.class);
-        assertNotNull(processInstanceId);
-        assertTrue(processInstanceId.longValue() > 0);
+        assertThat(processInstanceId).isNotNull().isPositive();
 
         TaskSummaryList taskSummaryList = callback.get(TaskSummaryList.class);
-        assertNotNull(taskSummaryList);
+        assertThat(taskSummaryList).isNotNull();
+        assertThat(taskSummaryList.getItems()).isNotNull().hasSize(1);
+    }
 
-        List<TaskSummary> tasks = taskSummaryList.getItems();
-        assertNotNull(tasks);
-        assertEquals(1, tasks.size());
+    @Test
+    public void testStartAndCompleteTaskUseOfFireAndForgetResponseHandler() throws Exception {
+        testStartAndCompleteTask(new FireAndForgetResponseHandler());
+    }
+
+    @Test
+    public void testStartAndCompleteTaskUseOfAsyncResponseHandler() throws Exception {
+        ResponseCallback callback = new BlockingResponseCallback(null);
+        testStartAndCompleteTask(new AsyncResponseHandler(callback));
+    }
+
+    @Test
+    public void testQueryRegistrationUseOfFireAndForgetResponseHandler() {
+        testQueryRegistration(new FireAndForgetResponseHandler());
+    }
+
+    @Test
+    public void testQueryRegistrationUseOfAsyncResponseHandler() {
+        ResponseCallback callback = new BlockingResponseCallback(null);
+        testQueryRegistration(new AsyncResponseHandler(callback));
+    }
+
+    @Test
+    public void testGlobalConfigurationOfFireAndForgetResponseHandler() throws Exception {
+        testStartProcessWithGlobalConfiguration(new FireAndForgetResponseHandler());
+    }
+
+    @Test
+    public void testGlobalConfigurationOfAsyncResponseHandler() throws Exception {
+        ResponseCallback callback = new BlockingResponseCallback(createMarshaller());
+        testStartProcessWithGlobalConfiguration(new AsyncResponseHandler(callback));
+
+        Long processInstanceId = callback.get(Long.class);
+        assertThat(processInstanceId).isNotNull().isPositive();
     }
 
     /*
@@ -155,21 +194,23 @@ public class JmsResponseHandlerIntegrationTest extends JbpmKieServerBaseIntegrat
 
     private void testStartProcessResponseHandler(ResponseHandler responseHandler) throws Exception {
         List<ProcessInstance> processInstances = queryClient.findProcessInstances(0, 100);
-        assertEquals(0, processInstances.size());
+        assertThat(processInstances).isEmpty();
 
         // change response handler for processClient others are not affected
         processClient.setResponseHandler(responseHandler);
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK);
         // since we use fire and forget there will always be null response
-        assertNull(processInstanceId);
+        assertThat(processInstanceId).isNull();
 
-        delay();
+        queryClient.setResponseHandler(new RequestReplyResponseHandler());
+        KieServerSynchronization.waitForProcessInstanceStart(queryClient, CONTAINER_ID);
+
         // Process should be started completely async - fire and forget.
         processInstances = queryClient.findProcessInstances(0, 100);
-        assertEquals(1, processInstances.size());
+        assertThat(processInstances).hasSize(1);
 
         ProcessInstance pi = processInstances.get(0);
-        assertEquals(org.kie.api.runtime.process.ProcessInstance.STATE_ACTIVE, pi.getState().intValue());
+        assertThat(pi.getState()).isEqualTo(org.kie.api.runtime.process.ProcessInstance.STATE_ACTIVE);
 
         // set to reqreply so it finishes the test properly
         processClient.setResponseHandler(new RequestReplyResponseHandler());
@@ -178,30 +219,31 @@ public class JmsResponseHandlerIntegrationTest extends JbpmKieServerBaseIntegrat
 
     private void testGetProcessInstancesResponseHandler(ResponseHandler responseHandler) throws Exception {
         List<ProcessInstance> processInstances = queryClient.findProcessInstances(0, 100);
-        assertEquals(0, processInstances.size());
+        assertThat(processInstances).isEmpty();
 
         // change response handler for processClient others are not affected
         processClient.setResponseHandler(responseHandler);
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK);
         // since we use fire and forget there will always be null response
-        assertNull(processInstanceId);
+        assertThat(processInstanceId).isNull();
 
-        delay();
+        queryClient.setResponseHandler(new RequestReplyResponseHandler());
+        KieServerSynchronization.waitForProcessInstanceStart(queryClient, CONTAINER_ID);
+
         // change response handler for queryClient others are not affected
         queryClient.setResponseHandler(responseHandler);
         // Process should be started completely async - fire and forget.
         processInstances = queryClient.findProcessInstances(0, 100);
-        assertNull(processInstances);
+        assertThat(processInstances).isNull();
 
         // set it back for the sake of verification
         queryClient.setResponseHandler(new RequestReplyResponseHandler());
         // Process should be started completely async - fire and forget.
         processInstances = queryClient.findProcessInstances(0, 100);
-        assertNotNull(processInstances);
-        assertEquals(1, processInstances.size());
+        assertThat(processInstances).isNotNull().hasSize(1);
 
         ProcessInstance pi = processInstances.get(0);
-        assertEquals(org.kie.api.runtime.process.ProcessInstance.STATE_ACTIVE, pi.getState().intValue());
+        assertThat(pi.getState()).isEqualTo(org.kie.api.runtime.process.ProcessInstance.STATE_ACTIVE);
 
         // set to reqreply so it finishes the test properly
         processClient.setResponseHandler(new RequestReplyResponseHandler());
@@ -210,44 +252,131 @@ public class JmsResponseHandlerIntegrationTest extends JbpmKieServerBaseIntegrat
 
     private void testGetTaskResponseHandler(ResponseHandler responseHandler) throws Exception {
         List<ProcessInstance> processInstances = queryClient.findProcessInstances(0, 100);
-        assertEquals(0, processInstances.size());
+        assertThat(processInstances).isEmpty();
 
         // change response handler for processClient others are not affected
         processClient.setResponseHandler(responseHandler);
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK);
         // since we use fire and forget there will always be null response
-        assertNull(processInstanceId);
+        assertThat(processInstanceId).isNull();
 
-        delay();
         // set it back for the sake of verification
         queryClient.setResponseHandler(new RequestReplyResponseHandler());
+        KieServerSynchronization.waitForProcessInstanceStart(queryClient, CONTAINER_ID);
+
         // Process should be started completely async - fire and forget.
         processInstances = queryClient.findProcessInstances(0, 100);
-        assertNotNull(processInstances);
-        assertEquals(1, processInstances.size());
+        assertThat(processInstances).isNotNull().hasSize(1);
 
         ProcessInstance pi = processInstances.get(0);
-        assertEquals(org.kie.api.runtime.process.ProcessInstance.STATE_ACTIVE, pi.getState().intValue());
+        assertThat(pi.getState()).isEqualTo(org.kie.api.runtime.process.ProcessInstance.STATE_ACTIVE);
 
         // change response handler for taskClient others are not affected
         taskClient.setResponseHandler(responseHandler);
         List<TaskSummary> tasks = taskClient.findTasksAssignedAsPotentialOwner(USER_YODA, 0, 10);
-        assertNull(tasks);
+        assertThat(tasks).isNull();
 
         // set to reqreply so it finishes the test properly
         processClient.setResponseHandler(new RequestReplyResponseHandler());
         processClient.abortProcessInstance(CONTAINER_ID, pi.getId());
     }
 
-    /*
-     * since these tests are about async processing on the server we need to introduce delay,
-     * even though it might not be reliable...
-     */
-    private void delay() {
-        try {
-            Thread.sleep(500);
-        } catch (InterruptedException e) {
-            logger.debug("InterruptedException caught while delaying execution...");
-        }
+    private void testStartAndCompleteTask(ResponseHandler responseHandler) throws Exception {
+        Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK);
+        assertThat(processInstanceId).isNotNull();
+
+        List<ProcessInstance> processInstances = queryClient.findProcessInstances(0, 100);
+        assertThat(processInstances).isNotNull().hasSize(1);
+        assertThat(processInstances.get(0)).isNotNull();
+        assertThat(processInstances.get(0).getState()).isEqualTo(org.kie.api.runtime.process.ProcessInstance.STATE_ACTIVE);
+
+        List<TaskSummary> tasks = taskClient.findTasksAssignedAsPotentialOwner(USER_YODA, 0, 10);
+        assertThat(tasks).hasSize(1);
+
+        Long taskId = tasks.get(0).getId();
+        taskClient.setResponseHandler(responseHandler);
+        taskClient.startTask(CONTAINER_ID, taskId, USER_YODA);
+        taskClient.completeTask(CONTAINER_ID, taskId, USER_YODA, new HashMap<String, Object>());
+
+        taskClient.setResponseHandler(new RequestReplyResponseHandler());
+        KieServerSynchronization.waitForTaskStatus(taskClient, taskId, Status.Completed.name());
+
+        tasks = taskClient.findTasksAssignedAsPotentialOwner(USER_YODA, 0, 10);
+        assertThat(tasks).hasSize(1);
+
+        taskId = tasks.get(0).getId();
+        taskClient.setResponseHandler(responseHandler);
+        taskClient.startTask(CONTAINER_ID, taskId, USER_YODA);
+        taskClient.completeTask(CONTAINER_ID, taskId, USER_YODA, new HashMap<String, Object>());
+
+        KieServerSynchronization.waitForProcessInstanceToFinish(processClient, CONTAINER_ID, processInstanceId);
     }
+
+    private void testQueryRegistration(ResponseHandler responseHandler) {
+        Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("stringData", "waiting for signal");
+        parameters.put("personData", createPersonInstance(CONTAINER_ID));
+
+        processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK, parameters);
+
+        QueryDefinition query = new QueryDefinition();
+        query.setName("getTasksByState");
+        query.setSource(System.getProperty("org.kie.server.persistence.ds", "jdbc/jbpm-ds"));
+        query.setExpression("select * from AuditTaskImpl where status = 'Reserved'");
+        query.setTarget("CUSTOM");
+
+        queryClient.setResponseHandler(responseHandler);
+        queryClient.registerQuery(query);
+
+        queryClient.setResponseHandler(new RequestReplyResponseHandler());
+        List<TaskInstance> tasks = queryClient.query(query.getName(), QueryServicesClient.QUERY_MAP_TASK, 0, 10, TaskInstance.class);
+        assertThat(tasks).isNotNull().hasSize(1);
+        Long taskId = tasks.get(0).getId();
+
+        query.setExpression("select * from AuditTaskImpl where status = 'InProgress'");
+
+        queryClient.setResponseHandler(responseHandler);
+        queryClient.replaceQuery(query);
+
+        queryClient.setResponseHandler(new RequestReplyResponseHandler());
+        tasks = queryClient.query(query.getName(), QueryServicesClient.QUERY_MAP_TASK, 0, 10, TaskInstance.class);
+        assertThat(tasks).isNotNull().isEmpty();
+
+        taskClient.startTask(CONTAINER_ID, taskId, USER_YODA);
+
+        queryClient.setResponseHandler(new RequestReplyResponseHandler());
+        tasks = queryClient.query(query.getName(), QueryServicesClient.QUERY_MAP_TASK, 0, 10, TaskInstance.class);
+        assertThat(tasks).isNotNull().hasSize(1);
+        assertThat(tasks.get(0).getId()).isEqualTo(taskId);
+
+        queryClient.setResponseHandler(responseHandler);
+        queryClient.unregisterQuery(query.getName());
+
+        queryClient.setResponseHandler(new RequestReplyResponseHandler());
+        List<QueryDefinition> queries = queryClient.getQueries(0, 10);
+        assertThat(queries).isNotNull().isEmpty();
+    }
+
+    private void testStartProcessWithGlobalConfiguration(ResponseHandler responseHandler) throws Exception {
+        KieServicesConfiguration jmsConfiguration = createKieServicesJmsConfiguration();
+        jmsConfiguration.setMarshallingFormat(marshallingFormat);
+        jmsConfiguration.setResponseHandler(responseHandler);
+
+        KieServicesClient kieServicesClient = KieServicesFactory.newKieServicesClient(jmsConfiguration);
+        ProcessServicesClient fireAndForgetProcessClient = kieServicesClient.getServicesClient(ProcessServicesClient.class);
+
+        Long processInstanceId = fireAndForgetProcessClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK);
+        assertThat(processInstanceId).isNull();
+
+        queryClient.setResponseHandler(new RequestReplyResponseHandler());
+        KieServerSynchronization.waitForProcessInstanceStart(queryClient, CONTAINER_ID);
+
+        abortAllProcesses();
+    }
+
+    private Marshaller createMarshaller() {
+        return MarshallerFactory.getMarshaller(new HashSet<Class<?>>(extraClasses.values()),
+                configuration.getMarshallingFormat(), client.getClassLoader());
+    }
+
 }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/jms/JmsTransactionsIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/jms/JmsTransactionsIntegrationTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package org.kie.server.integrationtests.jbpm.jms;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import javax.transaction.UserTransaction;
+
+import bitronix.tm.TransactionManagerServices;
+import bitronix.tm.resource.jms.PoolingConnectionFactory;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runners.Parameterized;
+import org.kie.server.api.KieServerConstants;
+import org.kie.server.api.marshalling.MarshallingFormat;
+import org.kie.server.api.model.ReleaseId;
+import org.kie.server.api.model.instance.ProcessInstance;
+import org.kie.server.client.KieServicesClient;
+import org.kie.server.client.KieServicesConfiguration;
+import org.kie.server.client.KieServicesFactory;
+import org.kie.server.client.ProcessServicesClient;
+import org.kie.server.client.jms.AsyncResponseHandler;
+import org.kie.server.client.jms.BlockingResponseCallback;
+import org.kie.server.client.jms.FireAndForgetResponseHandler;
+import org.kie.server.client.jms.ResponseHandler;
+import org.kie.server.integrationtests.category.JMSOnly;
+import org.kie.server.integrationtests.category.Transactional;
+import org.kie.server.integrationtests.jbpm.JbpmKieServerBaseIntegrationTest;
+import org.kie.server.integrationtests.shared.KieServerDeployer;
+
+import static org.assertj.core.api.Assertions.*;
+
+@Category({JMSOnly.class, Transactional.class})
+public class JmsTransactionsIntegrationTest extends JbpmKieServerBaseIntegrationTest {
+
+    private static final ReleaseId RELEASE_ID = new ReleaseId("org.kie.server.testing", "definition-project", "1.0.0.Final");
+
+    @Parameterized.Parameters(name = "{index}: {0} {2}")
+    public static Collection<Object[]> data() {
+        KieServicesConfiguration jmsConfiguration = createKieServicesJmsConfiguration();
+
+        return new ArrayList<Object[]>(Arrays.asList(new Object[][]{
+                {MarshallingFormat.JAXB, jmsConfiguration, new FireAndForgetResponseHandler()},
+                {MarshallingFormat.JAXB, jmsConfiguration, new AsyncResponseHandler(new BlockingResponseCallback(null))},
+                {MarshallingFormat.JSON, jmsConfiguration, new FireAndForgetResponseHandler()},
+                {MarshallingFormat.JSON, jmsConfiguration, new AsyncResponseHandler(new BlockingResponseCallback(null))},
+                {MarshallingFormat.XSTREAM, jmsConfiguration, new FireAndForgetResponseHandler()},
+                {MarshallingFormat.XSTREAM, jmsConfiguration, new AsyncResponseHandler(new BlockingResponseCallback(null))}
+        }));
+    }
+
+    @Parameterized.Parameter(2)
+    public ResponseHandler responseHandler;
+
+    private PoolingConnectionFactory connectionFactory;
+    private UserTransaction transaction;
+
+    @BeforeClass
+    public static void buildAndDeployArtifacts() {
+        KieServerDeployer.buildAndDeployCommonMavenParent();
+        KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project").getFile());
+
+        createContainer(CONTAINER_ID, RELEASE_ID);
+    }
+
+    private ProcessServicesClient createTransactionalProcessClient(List<String> capabilities) throws Exception {
+        TransactionManagerServices.getConfiguration().setJournal("null").setGracefulShutdownInterval(2);
+        transaction = TransactionManagerServices.getTransactionManager();
+
+        KieServicesConfiguration jmsConfiguration = createKieServicesJmsConfiguration();
+        KieServerXAConnectionFactory.connectionFactory = jmsConfiguration.getConnectionFactory();
+
+        connectionFactory = new PoolingConnectionFactory();
+        connectionFactory.setClassName("org.kie.server.integrationtests.jbpm.jms.KieServerXAConnectionFactory");
+        connectionFactory.setUniqueName("cf");
+        connectionFactory.setMaxPoolSize(5);
+        connectionFactory.setAllowLocalTransactions(true);
+        connectionFactory.init();
+        jmsConfiguration.setConnectionFactory(connectionFactory);
+
+        jmsConfiguration.setCapabilities(capabilities);
+        jmsConfiguration.setJmsTransactional(true);
+        jmsConfiguration.setResponseHandler(responseHandler);
+
+        KieServicesClient kieServicesClient = KieServicesFactory.newKieServicesClient(jmsConfiguration);
+        return kieServicesClient.getServicesClient(ProcessServicesClient.class);
+    }
+
+    @After
+    public void releaseResources() {
+        if (connectionFactory != null) {
+            connectionFactory.close();
+        }
+        TransactionManagerServices.getTransactionManager().shutdown();
+    }
+
+    @Test
+    public void testTransactionCommit() throws Exception {
+        List<String> capabilities = new ArrayList<String>();
+        capabilities.add(KieServerConstants.CAPABILITY_BPM);
+        ProcessServicesClient transactionalProcessClient = createTransactionalProcessClient(capabilities);
+
+        transaction.begin();
+
+        Long processInstanceId = transactionalProcessClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK);
+        assertThat(processInstanceId).isNull();
+
+        transaction.commit();
+
+        List<ProcessInstance> processInstances = queryClient.findProcessInstances(0, 10);
+        assertThat(processInstances).isNotNull().hasSize(1);
+        assertThat(processInstances.get(0).getProcessId()).isEqualTo(PROCESS_ID_USERTASK);
+    }
+
+    @Test
+    public void testTransactionRollback() throws Exception {
+        List<String> capabilities = new ArrayList<String>();
+        capabilities.add(KieServerConstants.CAPABILITY_BPM);
+        ProcessServicesClient transactionalProcessClient = createTransactionalProcessClient(capabilities);
+
+        transaction.begin();
+
+        Long processInstanceId = transactionalProcessClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK);
+        assertThat(processInstanceId).isNull();
+
+        transaction.rollback();
+
+        List<ProcessInstance> processInstances = queryClient.findProcessInstances(0, 10);
+        assertThat(processInstances).isNotNull().isEmpty();
+    }
+
+}

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/jms/KieServerXAConnectionFactory.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/jms/KieServerXAConnectionFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package org.kie.server.integrationtests.jbpm.jms;
+
+import java.lang.reflect.Method;
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSException;
+import javax.jms.XAConnection;
+import javax.jms.XAConnectionFactory;
+
+import org.kie.server.integrationtests.config.TestConfig;
+
+/**
+ * XAConnectionFactory wrapper for connection factories.
+ * <p>
+ * It invokes createXAConnection(String, String) method using reflection since there is no common interface with this
+ * method in different JMS client implementations but they all provide this method.
+ */
+public class KieServerXAConnectionFactory implements XAConnectionFactory {
+
+    public static ConnectionFactory connectionFactory;
+
+    @Override
+    public XAConnection createXAConnection() throws JMSException {
+        return createXAConnection(TestConfig.getUsername(), TestConfig.getPassword());
+    }
+
+    @Override
+    public XAConnection createXAConnection(String userName, String password) throws JMSException {
+        try {
+            Method method = connectionFactory.getClass().getMethod("createXAConnection", String.class, String.class);
+            return (XAConnection) method.invoke(connectionFactory, userName, password);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+}

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/pom.xml
@@ -147,6 +147,12 @@
       <type>war</type>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/jms/OptaPlannerJmsResponseHandlerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/jms/OptaPlannerJmsResponseHandlerIntegrationTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package org.kie.server.integrationtests.optaplanner.jms;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runners.Parameterized;
+import org.kie.api.KieServices;
+import org.kie.server.api.marshalling.Marshaller;
+import org.kie.server.api.marshalling.MarshallerFactory;
+import org.kie.server.api.marshalling.MarshallingFormat;
+import org.kie.server.api.model.ReleaseId;
+import org.kie.server.api.model.ServiceResponse;
+import org.kie.server.api.model.instance.SolverInstance;
+import org.kie.server.api.model.instance.SolverInstanceList;
+import org.kie.server.client.KieServicesConfiguration;
+import org.kie.server.client.jms.AsyncResponseHandler;
+import org.kie.server.client.jms.BlockingResponseCallback;
+import org.kie.server.client.jms.FireAndForgetResponseHandler;
+import org.kie.server.client.jms.RequestReplyResponseHandler;
+import org.kie.server.client.jms.ResponseCallback;
+import org.kie.server.client.jms.ResponseHandler;
+import org.kie.server.integrationtests.category.JMSOnly;
+import org.kie.server.integrationtests.optaplanner.OptaplannerKieServerBaseIntegrationTest;
+import org.kie.server.integrationtests.shared.KieServerDeployer;
+import org.kie.server.integrationtests.shared.KieServerSynchronization;
+import org.optaplanner.core.api.domain.solution.Solution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+@Category({JMSOnly.class})
+public class OptaPlannerJmsResponseHandlerIntegrationTest extends OptaplannerKieServerBaseIntegrationTest {
+
+    private static final ReleaseId RELEASE_ID = new ReleaseId("org.kie.server.testing", "cloudbalance", "1.0.0.Final");
+
+    private static final String CONTAINER_1_ID = "cloudbalance";
+    private static final String SOLVER_1_ID = "cloudsolver";
+    private static final String SOLVER_1_CONFIG = "META-INF/cloudbalance-solver.xml";
+
+    private static final String CLASS_CLOUD_BALANCE = "org.kie.server.testing.CloudBalance";
+    private static final String CLASS_CLOUD_COMPUTER = "org.kie.server.testing.CloudComputer";
+    private static final String CLASS_CLOUD_PROCESS = "org.kie.server.testing.CloudProcess";
+    private static final String CLASS_CLOUD_GENERATOR = "org.kie.server.testing.CloudBalancingGenerator";
+
+    @Parameterized.Parameters(name = "{index}: {0}")
+    public static Collection<Object[]> data() {
+        KieServicesConfiguration jmsConfiguration = createKieServicesJmsConfiguration();
+
+        return new ArrayList<Object[]>(Arrays.asList(new Object[][]{
+                {MarshallingFormat.JAXB, jmsConfiguration},
+                {MarshallingFormat.JSON, jmsConfiguration},
+                {MarshallingFormat.XSTREAM, jmsConfiguration}
+        }));
+    }
+
+    @BeforeClass
+    public static void deployArtifacts() {
+        KieServerDeployer.buildAndDeployCommonMavenParent();
+        KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/cloudbalance").getFile());
+
+        kieContainer = KieServices.Factory.get().newKieContainer(RELEASE_ID);
+
+        createContainer(CONTAINER_1_ID, RELEASE_ID);
+    }
+
+    @Override
+    protected void addExtraCustomClasses(Map<String, Class<?>> extraClasses) throws Exception {
+        extraClasses.put(CLASS_CLOUD_BALANCE, Class.forName(CLASS_CLOUD_BALANCE, true, kieContainer.getClassLoader()));
+        extraClasses.put(CLASS_CLOUD_COMPUTER, Class.forName(CLASS_CLOUD_COMPUTER, true, kieContainer.getClassLoader()));
+        extraClasses.put(CLASS_CLOUD_PROCESS, Class.forName(CLASS_CLOUD_PROCESS, true, kieContainer.getClassLoader()));
+    }
+
+    @Test
+    public void testSolverWithAsyncResponseHandler() throws Exception {
+        Marshaller marshaller = MarshallerFactory.getMarshaller(new HashSet<Class<?>>(extraClasses.values()),
+                configuration.getMarshallingFormat(), client.getClassLoader());
+        ResponseCallback responseCallback = new BlockingResponseCallback(marshaller);
+        ResponseHandler asyncResponseHandler = new AsyncResponseHandler(responseCallback);
+        solverClient.setResponseHandler(asyncResponseHandler);
+
+        ServiceResponse<?> response = solverClient.createSolver(CONTAINER_1_ID, SOLVER_1_ID, SOLVER_1_CONFIG);
+        assertThat(response);
+        SolverInstance solver = responseCallback.get(SolverInstance.class);
+        assertThat(solver).isNotNull();
+        assertThat(solver.getContainerId()).isEqualTo(CONTAINER_1_ID);
+        assertThat(solver.getSolverId()).isEqualTo(SOLVER_1_ID);
+
+        response = solverClient.getSolvers(CONTAINER_1_ID);
+        assertThat(response);
+        SolverInstanceList solverList = responseCallback.get(SolverInstanceList.class);
+        assertThat(solverList).isNotNull();
+        assertThat(solverList.getContainers()).isNotNull().isNotEmpty().hasSize(1);
+        solver = solverList.getContainers().get(0);
+        assertThat(solver.getSolverId()).isEqualTo(SOLVER_1_ID);
+        assertThat(solver.getStatus()).isEqualTo(SolverInstance.SolverStatus.NOT_SOLVING);
+
+        solver = new SolverInstance();
+        solver.setStatus(SolverInstance.SolverStatus.SOLVING);
+        solver.setPlanningProblem(loadPlanningProblem(5, 15));
+        response = solverClient.updateSolverState(CONTAINER_1_ID, SOLVER_1_ID, solver);
+        assertThat(response);
+        solver = responseCallback.get(SolverInstance.class);
+        assertThat(solver.getSolverId()).isEqualTo(SOLVER_1_ID);
+        assertThat(solver.getStatus()).isEqualTo(SolverInstance.SolverStatus.SOLVING);
+
+        response = solverClient.getSolverState(CONTAINER_1_ID, SOLVER_1_ID);
+        assertThat(response);
+        solver = responseCallback.get(SolverInstance.class);
+        assertThat(solver.getSolverId()).isEqualTo(SOLVER_1_ID);
+        assertThat(solver.getStatus()).isEqualTo(SolverInstance.SolverStatus.SOLVING);
+
+        response = solverClient.disposeSolver(CONTAINER_1_ID, SOLVER_1_ID);
+        assertThat(response);
+        responseCallback.get(SolverInstance.class);
+
+        response = solverClient.getSolvers(CONTAINER_1_ID);
+        assertThat(response);
+        solverList = responseCallback.get(SolverInstanceList.class);
+        assertThat(solverList).isNotNull();
+        assertThat(solverList.getContainers()).isNullOrEmpty();
+    }
+
+    @Test
+    public void testSolverWithFireAndForgetResponseHandler() throws Exception {
+        solverClient.setResponseHandler(new FireAndForgetResponseHandler());
+        ServiceResponse<?> response = solverClient.createSolver(CONTAINER_1_ID, SOLVER_1_ID, SOLVER_1_CONFIG);
+        assertThat(response);
+
+        solverClient.setResponseHandler(new RequestReplyResponseHandler());
+        KieServerSynchronization.waitForSolver(solverClient, CONTAINER_1_ID, SOLVER_1_ID);
+
+        solverClient.setResponseHandler(new FireAndForgetResponseHandler());
+        SolverInstance solver = new SolverInstance();
+        solver.setStatus(SolverInstance.SolverStatus.SOLVING);
+        solver.setPlanningProblem(loadPlanningProblem(5, 15));
+        response = solverClient.updateSolverState(CONTAINER_1_ID, SOLVER_1_ID, solver);
+        assertThat(response);
+
+        solverClient.setResponseHandler(new RequestReplyResponseHandler());
+        KieServerSynchronization.waitForSolverStatus(solverClient, CONTAINER_1_ID, SOLVER_1_ID, SolverInstance.SolverStatus.SOLVING);
+
+        solverClient.setResponseHandler(new FireAndForgetResponseHandler());
+        response = solverClient.disposeSolver(CONTAINER_1_ID, SOLVER_1_ID);
+        assertThat(response);
+
+        solverClient.setResponseHandler(new RequestReplyResponseHandler());
+        ServiceResponse<SolverInstanceList> solverListResponse = solverClient.getSolvers(CONTAINER_1_ID);
+        assertThat(solverListResponse).isNotNull();
+        SolverInstanceList solverList = solverListResponse.getResult();
+        assertThat(solverList).isNotNull();
+        assertThat(solverList.getContainers()).isNullOrEmpty();
+    }
+
+    public Solution loadPlanningProblem(int computerListSize, int processListSize) {
+        Solution problem = null;
+        try {
+            Class<?> cbgc = kieContainer.getClassLoader().loadClass(CLASS_CLOUD_GENERATOR);
+            Object cbgi = cbgc.newInstance();
+
+            Method method = cbgc.getMethod("createCloudBalance", int.class, int.class);
+            problem = (Solution) method.invoke(cbgi, computerListSize, processListSize);
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Exception trying to create cloud balance unsolved problem.");
+        }
+        return problem;
+    }
+
+}

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -996,7 +996,7 @@
         <kie.server.controller.context>kie-server-controller-${project.version}-ee7</kie.server.controller.context>
         <org.kie.server.persistence.ds>jdbc/jbpm</org.kie.server.persistence.ds>
         <cargo.container.id>weblogic121x</cargo.container.id>
-        <failsafe.excluded.groups>org.kie.server.integrationtests.category.Email</failsafe.excluded.groups>
+        <failsafe.excluded.groups>org.kie.server.integrationtests.category.Email,org.kie.server.integrationtests.category.Transactional</failsafe.excluded.groups>
       </properties>
       <build>
         <pluginManagement>
@@ -1123,7 +1123,7 @@
         <kie.server.connection.factory>jms/cf/KIE.SERVER.REQUEST</kie.server.connection.factory>
         <org.kie.server.persistence.ds>jdbc/jbpm</org.kie.server.persistence.ds>
         <cargo.container.id>websphere85x</cargo.container.id>
-        <failsafe.excluded.groups>org.kie.server.integrationtests.category.Email,org.kie.server.integrationtests.category.RemotelyControlled</failsafe.excluded.groups>
+        <failsafe.excluded.groups>org.kie.server.integrationtests.category.Email,org.kie.server.integrationtests.category.RemotelyControlled,org.kie.server.integrationtests.category.Transactional</failsafe.excluded.groups>
       </properties>
       <build>
         <pluginManagement>


### PR DESCRIPTION
I have added more tests for 'fire and forget' feature. I tried to cover various methods from different `*ServicesClient` implementations.

Some tests are failing and I think those are potential bugs. Please, look at failed tests when the build is finished and tell me your opinion.