### PR TITLE
DROOLS-1235 MBean naming rework

### DIFF
--- a/drools-rhq-plugin/src/main/resources/META-INF/rhq-plugin.xml
+++ b/drools-rhq-plugin/src/main/resources/META-INF/rhq-plugin.xml
@@ -20,8 +20,32 @@
       </runs-inside>
       
       <plugin-configuration>
-         <c:simple-property name="objectName" readOnly="true" default="org.drools:type=DroolsManagementAgent"/>
+         <c:simple-property name="objectName" readOnly="true" default="org.kie:type=DroolsManagementAgent"/>
       </plugin-configuration>
+      
+     <service name="Kie Containers"
+        description="The Kie Container monitoring service." 
+        discovery="org.rhq.plugins.jmx.MBeanResourceDiscoveryComponent"
+        class="org.rhq.plugins.jmx.MBeanResourceComponent">
+    
+          <plugin-configuration>
+             <c:simple-property name="objectName" readOnly="true" default="org.kie:kcontainerId=%kcontainerId%"/>
+             <c:simple-property name="nameTemplate" readOnly="true" default="KieContainer {kcontainerId}"/>
+             <c:simple-property name="descriptionTemplate" readOnly="true" default="A JMX bean for Kie Container {kcontainerId}"/>
+             <c:simple-property name="kcontainerId" type="string" readOnly="true" description="The Kie Container Id"/>
+          </plugin-configuration>
+  
+        <metric property="ConfiguredReleaseIdStr"
+                description="The RelaseId configured while creating the KieContainer"
+                displayName="Configured ReleaseId"
+                dataType="trait"
+                displayType="summary" />       
+
+        <metric property="ResolvedReleaseIdStr"
+                description="The actual resolved ReleaseId"
+                displayName="Resolved ReleaseId"
+                dataType="trait"
+                displayType="summary" />        
 
        <service name="Kie Bases"
                 description="The Kie Base monitoring service."
@@ -29,7 +53,7 @@
                 class="org.rhq.plugins.jmx.MBeanResourceComponent">
     
           <plugin-configuration>
-             <c:simple-property name="objectName" readOnly="true" default="org.drools.kbases:type=%kbaseId%"/>
+             <c:simple-property name="objectName" readOnly="true" default="org.kie:kcontainerId=%kcontainerId%,kbaseId=%kbaseId%"/>
              <c:simple-property name="nameTemplate" readOnly="true" default="KieBase {kbaseId}"/>
              <c:simple-property name="descriptionTemplate" readOnly="true" default="A JMX bean for Kie Base {kbaseId}"/>
              <c:simple-property name="kbaseId" type="string" readOnly="true" description="The Kie Base Id"/>
@@ -51,7 +75,7 @@
                     class="org.rhq.plugins.jmx.MBeanResourceComponent">
         
               <plugin-configuration>
-                 <c:simple-property name="objectName" readOnly="true" default="org.drools.kbases:type=%kbaseId%,group=Sessions,sessionId=%sessionId%"/>
+                 <c:simple-property name="objectName" readOnly="true" default="org.kie:kcontainerId={kcontainerId},kbaseId={kbaseId},group=Sessions,ksessionId=%sessionId%"/>
                  <c:simple-property name="nameTemplate" readOnly="true" default="KieSession {sessionId}"/>
                  <c:simple-property name="descriptionTemplate" readOnly="true" default="A JMX bean for Kie Base {kbaseId}, Kie session {sessionId}"/>
                  <c:simple-property name="kbaseId" type="string" readOnly="true" description="The Kie Base Id"/>
@@ -128,9 +152,12 @@
                       displayType="summary" />                       
 
           
-           </service>
-       </service>
-   </service>
+           </service>  <!-- /Kie Session -->
+       </service>  <!-- /Kie Base -->
+       
+     </service>  <!-- /Kie Container -->
+       
+   </service>  <!-- /Kie Service -->
 
 
 </plugin>


### PR DESCRIPTION
This PR aligns JON/RHQ drools plugin with all modifications of DROOLS-1235.

This version has known limitations but implements the best trade-off of displaying all registered MBeans.

# This version & known limitations
This version will display all registered MBeans, but in case more than 1 KieContainer is registered, all registered KieBases will be displayed under all KieContainers, not just the one KieContainer the KieBase actually belongs to.

![image](https://cloud.githubusercontent.com/assets/1699252/17977111/a4fd8562-6af0-11e6-9797-cd2da8563f7e.png)
In the screenshot, the JVisualVM is used as correct reference: it can be noted, KieBases are repeatedly displayed under any registered KieContainer, regardless they actually belong to that KieContainer or not.

# Discarded alternative version A
With reference to this PR, L56, replace line
```<c:simple-property name="objectName" readOnly="true" default="org.kie:kcontainerId=%kcontainerId%,kbaseId=%kbaseId%"/>```
with
```<c:simple-property name="objectName" readOnly="true" default="org.kie:kcontainerId={kcontainerId},kbaseId=%kbaseId%"/>```

This should be the desired best version.

Unfortunately, it appears this desired 3 level ancestry is not working due to JON/RHQ limitations.
This discarded version displayed the first 2 levels (KieContainer, KieBase) but not the 3rd level for KieSession.

![screenshot from 2016-08-17 10-18-33](https://cloud.githubusercontent.com/assets/1699252/17977443/04e16434-6af2-11e6-8c26-eee53d6ee9ca.png)
In the screenshot, illustrating the 3 level ancestry is not working as explained.

Hence, this option was discarded.

# Discarded alternative version B
Trying to manually cascade variable `kcontainerId` to KieBase, so to have from the KieSession referencing the manually cascaded variable in the direct-parent (KieBase), instead of trying to reference the grandparent (KieContainer).

For reference [here](https://github.com/tarilabs/droolsjbpm-integration/commit/fd9174bcbcb78c1d116528abba5413fc002edff6?diff=split) but also code snippet:
```
<service name="Kie Containers"
        description="The Kie Container monitoring service." 
        discovery="org.rhq.plugins.jmx.MBeanResourceDiscoveryComponent"
        class="org.rhq.plugins.jmx.MBeanResourceComponent">
    
          <plugin-configuration>
             <c:simple-property name="objectName" readOnly="true" default="org.kie:kcontainerId=%kcontainerId%"/>
...
             <c:simple-property name="kcontainerId" type="string" readOnly="true" description="The Kie Container Id"/>
          </plugin-configuration>
  
...
    
          <plugin-configuration>
             <c:simple-property name="objectName" readOnly="true" default="org.kie:kcontainerId={kcontainerId},kbaseId=%kbaseId%"/>
...
             <c:simple-property name="kcId" readOnly="true" default="{kcontainerId}" description="x2"/>
          </plugin-configuration>
    
...
          
           <service name="Kie Sessions"
                    description="The Kie Session monitoring service."
                    discovery="org.rhq.plugins.jmx.MBeanResourceDiscoveryComponent"
                    class="org.rhq.plugins.jmx.MBeanResourceComponent">
        
              <plugin-configuration>
                 <c:simple-property name="objectName" readOnly="true" default="org.kie:kcontainerId={kcId},kbaseId={kbaseId},group=Sessions,ksessionId=%sessionId%"/>
...
```
However this trick of manually cascading the variables does not work. Moreover, it does not display at all the hierarchy of KieContainer,KieBase,KieSession - nothing displayed.

Hence, this option was discarded.