### PR TITLE
Skip deploy for testing kjar

### DIFF
--- a/drools-osgi/drools-karaf-itests-kjar/pom.xml
+++ b/drools-osgi/drools-karaf-itests-kjar/pom.xml
@@ -10,6 +10,10 @@
   <name>Drools :: Karaf Integration Tests Kjar</name>
   <version>7.0.0-SNAPSHOT</version>
 
+  <properties>
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.drools</groupId>


### PR DESCRIPTION
 * there is no need to deploy
   the kjar as it's just used for
   testing

This should fix the deploy we are seeing. However, it's just quick&dirty fix. We need to come with a better solution.

cc @mariofusco, @baldimir 