### PR TITLE
Properly depend on testing kjar to fix parallel builds

### DIFF
--- a/drools-osgi/drools-karaf-itests/pom.xml
+++ b/drools-osgi/drools-karaf-itests/pom.xml
@@ -11,6 +11,21 @@
   <artifactId>drools-karaf-itests</artifactId>
   <name>Drools :: Karaf Integration Tests</name>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.drools</groupId>
+        <artifactId>drools-karaf-itests-domain-model</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.drools</groupId>
+        <artifactId>drools-karaf-itests-kjar</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.drools</groupId>
@@ -20,6 +35,11 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-karaf-itests-domain-model</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-karaf-itests-kjar</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -115,11 +115,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>org.drools</groupId>
-        <artifactId>drools-karaf-itests-domain-model</artifactId>
-        <version>${project.version}</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
@mariofusco this should fix the blueprint on karaf test failures we were talking about