### PR TITLE
[DROOLS-1267] allow to submit atomic actions during a fireUntilHalt (…

### DIFF
--- a/kie-aries-blueprint/src/main/java/org/kie/aries/blueprint/factorybeans/KieImportSessionResolver.java
+++ b/kie-aries-blueprint/src/main/java/org/kie/aries/blueprint/factorybeans/KieImportSessionResolver.java
@@ -27,6 +27,7 @@ import org.kie.api.runtime.Channel;
 import org.kie.api.runtime.Environment;
 import org.kie.api.runtime.Globals;
 import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.KieSession.AtomicAction;
 import org.kie.api.runtime.KieSessionConfiguration;
 import org.kie.api.runtime.ObjectFilter;
 import org.kie.api.runtime.StatelessKieSession;
@@ -377,6 +378,11 @@ public class KieImportSessionResolver extends AbstractKieObjectsResolver impleme
     @Override
     public void fireUntilHalt( AgendaFilter agendaFilter ) {
         kieSession.fireUntilHalt( agendaFilter );
+    }
+    
+    @Override
+    public void submit(AtomicAction action) {
+        kieSession.submit( action );
     }
 
     @Override

--- a/kie-aries-blueprint/src/main/java/org/kie/aries/blueprint/factorybeans/KieSessionResolver.java
+++ b/kie-aries-blueprint/src/main/java/org/kie/aries/blueprint/factorybeans/KieSessionResolver.java
@@ -33,6 +33,7 @@ import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.KieSessionConfiguration;
 import org.kie.api.runtime.ObjectFilter;
 import org.kie.api.runtime.StatelessKieSession;
+import org.kie.api.runtime.KieSession.AtomicAction;
 import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.runtime.process.WorkItemManager;
 import org.kie.api.runtime.rule.Agenda;
@@ -444,6 +445,11 @@ public class KieSessionResolver extends AbstractKieObjectsResolver implements Ki
     @Override
     public void fireUntilHalt( AgendaFilter agendaFilter ) {
         getKieSession().fireUntilHalt(agendaFilter);
+    }
+    
+    @Override
+    public void submit(AtomicAction action) {
+        getKieSession().submit( action );
     }
 
     @Override

--- a/kie-remote/kie-remote-client/src/main/java/org/kie/services/client/api/command/KieSessionClientCommandObject.java
+++ b/kie-remote/kie-remote-client/src/main/java/org/kie/services/client/api/command/KieSessionClientCommandObject.java
@@ -31,6 +31,7 @@ import org.kie.api.runtime.Channel;
 import org.kie.api.runtime.Environment;
 import org.kie.api.runtime.Globals;
 import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.KieSession.AtomicAction;
 import org.kie.api.runtime.KieSessionConfiguration;
 import org.kie.api.runtime.ObjectFilter;
 import org.kie.api.runtime.process.ProcessInstance;
@@ -103,6 +104,11 @@ public class KieSessionClientCommandObject extends AbstractRemoteCommandObject i
 
     @Override
     public void fireUntilHalt( AgendaFilter agendaFilter ) {
+        unsupported(KieSession.class, Void.class);
+    }
+    
+    @Override
+    public void submit(AtomicAction arg0) {
         unsupported(KieSession.class, Void.class);
     }
 


### PR DESCRIPTION
…#616)

alignments for droolsjbpm-integration of Kie API change.

Analogous of #616 for the 6.5.x branch.

@mswiderski I fixed the conflict on `KieSessionClientCommandObject` which prevented to straightforward cherry pick the original commit, so with this PR should be fine now.