### PR TITLE
DROOLS-1269 - RHQ / JON plug-in display wrong hierarchy and repeatedly nesting KieSession under KieBase

### DIFF
--- a/drools-rhq-plugin/pom.xml
+++ b/drools-rhq-plugin/pom.xml
@@ -13,5 +13,47 @@
 
   <name>Drools RHQ JMX Plugin</name>
   <description>RHQ/JOPR plugin that monitors Drools defined MBeans</description>
-
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+         <groupId>org.rhq</groupId>
+         <artifactId>rhq-jmx-plugin</artifactId>
+         <version>${version.org.rhq}</version>
+         <scope>provided</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <dependencies>
+      <dependency>
+         <groupId>org.rhq</groupId>
+         <artifactId>rhq-jmx-plugin</artifactId>
+         <scope>provided</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.rhq</groupId>
+         <artifactId>rhq-core-plugin-api</artifactId>
+         <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.rhq</groupId>
+        <artifactId>rhq-core-domain</artifactId>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jcl-over-slf4j</artifactId>
+        <scope>provided</scope>
+      </dependency>
+   </dependencies>
+   <build>
+   <plugins>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <source>1.6</source>
+            <target>1.6</target>
+          </configuration>
+        </plugin>
+   </plugins>
+   </build>
 </project>

--- a/drools-rhq-plugin/src/main/java/org/drools/rhq/plugin/ExposeKCIDValueFromParentDiscoveryComponent.java
+++ b/drools-rhq-plugin/src/main/java/org/drools/rhq/plugin/ExposeKCIDValueFromParentDiscoveryComponent.java
@@ -1,0 +1,26 @@
+package org.drools.rhq.plugin;
+
+import org.rhq.plugins.jmx.JMXComponent;
+import org.rhq.plugins.jmx.MBeanResourceDiscoveryComponent;
+import org.rhq.core.domain.configuration.Configuration;
+import org.rhq.core.domain.resource.ResourceType;
+import org.rhq.core.pluginapi.inventory.DiscoveredResourceDetails;
+
+import java.util.Set;
+
+public class ExposeKCIDValueFromParentDiscoveryComponent extends MBeanResourceDiscoveryComponent {
+
+    public Set<DiscoveredResourceDetails> performDiscovery(Configuration pluginConfiguration,
+                                                           JMXComponent parentResourceComponent, ResourceType resourceType, boolean skipUnknownProps) {
+        Set<DiscoveredResourceDetails> services = super.performDiscovery(
+                pluginConfiguration, parentResourceComponent, resourceType, skipUnknownProps);
+
+        String kcId = this.discoveryContext.getParentResourceContext()
+                .getPluginConfiguration().getSimpleValue("kcontainerId");
+        for (DiscoveredResourceDetails service: services) {
+            service.getPluginConfiguration().setSimpleValue("kcId", kcId);
+        }
+
+        return services;
+    }
+}

--- a/drools-rhq-plugin/src/main/resources/META-INF/rhq-plugin.xml
+++ b/drools-rhq-plugin/src/main/resources/META-INF/rhq-plugin.xml
@@ -40,11 +40,11 @@
 
        <service name="Kie Bases"
                 description="The Kie Base monitoring service."
-                discovery="org.rhq.plugins.jmx.MBeanResourceDiscoveryComponent"
+                discovery="org.drools.rhq.plugin.ExposeKCIDValueFromParentDiscoveryComponent"
                 class="org.rhq.plugins.jmx.MBeanResourceComponent">
     
           <plugin-configuration>
-             <c:simple-property name="objectName" readOnly="true" default="org.kie:kcontainerId=%kcontainerId%,kbaseId=%kbaseId%"/>
+             <c:simple-property name="objectName" readOnly="true" default="org.kie:kcontainerId={kcontainerId},kbaseId=%kbaseId%"/>
              <c:simple-property name="nameTemplate" readOnly="true" default="KieBase {kbaseId}"/>
              <c:simple-property name="descriptionTemplate" readOnly="true" default="A JMX bean for Kie Base {kbaseId}"/>
              <c:simple-property name="kbaseId" type="string" readOnly="true" description="The Kie Base Id"/>
@@ -66,7 +66,7 @@
                     class="org.rhq.plugins.jmx.MBeanResourceComponent">
         
               <plugin-configuration>
-                 <c:simple-property name="objectName" readOnly="true" default="org.kie:kcontainerId={kcontainerId},kbaseId={kbaseId},ksessionType=Stateful,ksessionName=%sessionId%"/>
+                 <c:simple-property name="objectName" readOnly="true" default="org.kie:kcontainerId={kcId},kbaseId={kbaseId},ksessionType=Stateful,ksessionName=%sessionId%"/>
                  <c:simple-property name="nameTemplate" readOnly="true" default="KieSession {sessionId}"/>
                  <c:simple-property name="descriptionTemplate" readOnly="true" default="A JMX bean for Kie Base {kbaseId}, Kie session {sessionId}"/>
                  <c:simple-property name="kbaseId" type="string" readOnly="true" description="The Kie Base Id"/>
@@ -151,7 +151,7 @@
                     class="org.rhq.plugins.jmx.MBeanResourceComponent">
         
               <plugin-configuration>
-                 <c:simple-property name="objectName" readOnly="true" default="org.kie:kcontainerId={kcontainerId},kbaseId={kbaseId},ksessionType=Stateless,ksessionName=%sessionId%"/>
+                 <c:simple-property name="objectName" readOnly="true" default="org.kie:kcontainerId={kcId},kbaseId={kbaseId},ksessionType=Stateless,ksessionName=%sessionId%"/>
                  <c:simple-property name="nameTemplate" readOnly="true" default="KieSession {sessionId}"/>
                  <c:simple-property name="descriptionTemplate" readOnly="true" default="A JMX bean for Kie Base {kbaseId}, Kie session {sessionId}"/>
                  <c:simple-property name="kbaseId" type="string" readOnly="true" description="The Kie Base Id"/>


### PR DESCRIPTION
Fixed for correct nesting and correct hierarchy display by cascading
manually the {kcontainId} variable. Specifically, the hiearchy now is:
```
KieContainer
 + KieBase
    + KieSession
```
The KieBase: take the `{kcontainId}` variable from the parent, and
re-exposes it as a new variable "kcId", at the level of the KieBase
itself. In turn, now the KieSession can access to `{kcId}` variable,
effectively and for any pragmatic effect representing the KieContainer
from the grand-parent.

Functional test result on RHQ / JON : 
![image](https://cloud.githubusercontent.com/assets/1699252/18196955/dfb6a5c6-70f4-11e6-86fc-2a22c1ac89e7.png)
In the screenshot, the JVisualVM is show the correct nesting of the KieSession under their respective KieBases. Now the hierarchy is correctly reflected on the RHQ/JON plug-in, and the KieSession are correctly nested only under the KieBase they actually belongs to.

Depends on #617 for DROOLS-1236 .