### PR TITLE
RHBPMS - 2449 - XStream marshaller can't be configured with NameCoder, RHBPMS-2569 - addJaxbClasses method should be deprecated

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/BaseMarshallerBuilder.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/BaseMarshallerBuilder.java
@@ -1,0 +1,49 @@
+/*
+* Copyright 2016 Red Hat, Inc. and/or its affiliates.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.kie.server.api.marshalling;
+
+import java.util.Set;
+
+import org.kie.server.api.marshalling.jaxb.JaxbMarshaller;
+import org.kie.server.api.marshalling.json.JSONMarshaller;
+import org.kie.server.api.marshalling.xstream.XStreamMarshaller;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Default implementation of marshaller builder
+ */
+public class BaseMarshallerBuilder implements MarshallerBuilder {
+    private static final Logger logger = LoggerFactory.getLogger(BaseMarshallerBuilder.class);
+
+    @Override
+    public Marshaller build(Set<Class<?>> classes, MarshallingFormat format, ClassLoader classLoader) {
+        switch ( format ) {
+            case XSTREAM:
+                logger.debug("About to build default instance of XStream marshaller with classes {} and class loader {}", classes, classLoader);
+                return new XStreamMarshaller( classes, classLoader );
+            case JAXB:
+                logger.debug("About to build default instance of JAXB marshaller with classes {} and class loader {}", classes, classLoader);
+                return new JaxbMarshaller(classes, classLoader);
+            case JSON:
+                logger.debug("About to build default instance of JSON marshaller with classes {} and class loader {}", classes, classLoader);
+                return new JSONMarshaller(classes, classLoader);
+            default:
+                logger.error( "Unsupported marshalling format: " + format );
+        }
+        return null;
+    }
+}

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/MarshallerBuilder.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/MarshallerBuilder.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.api.marshalling;
+
+import java.util.Set;
+
+/**
+ * Allows plugable builders for various marshallers so out of the box functionality can be enhanced
+ */
+public interface MarshallerBuilder {
+
+    /**
+     * Based on given parameters builds marshaller instance that matches given format (MarshallingFormat)
+     * @param classes optional set of custom classes - can be null
+     * @param format expected type of the marshaller
+     * @param classLoader class loader to be used for this marshaller
+     * @return new instance of marshaller
+     */
+    Marshaller build(Set<Class<?>> classes, MarshallingFormat format, ClassLoader classLoader);
+}

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/MarshallerFactory.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/MarshallerFactory.java
@@ -15,6 +15,8 @@
 
 package org.kie.server.api.marshalling;
 
+import java.util.Iterator;
+import java.util.ServiceLoader;
 import java.util.Set;
 
 import org.kie.server.api.marshalling.jaxb.JaxbMarshaller;
@@ -27,21 +29,43 @@ public class MarshallerFactory {
 
     private static final Logger logger = LoggerFactory.getLogger( MarshallerFactory.class );
 
+    private static MarshallerBuilder builder = getMarshallerBuilder();
+
+    /**
+     * Builds new marshaller for given format and class loader
+     * @param format marshaller format that marshaller should be built for
+     * @param classLoader classloader to be used by the marshaller
+     * @return new instance of the marshaller
+     */
     public static Marshaller getMarshaller(MarshallingFormat format, ClassLoader classLoader) {
         return getMarshaller(null, format, classLoader);
     }
 
+    /**
+     * Builds new marshaller for given format and class loader
+     * @param classes optional custom classes to be added to marshaller - might be null
+     * @param format marshaller format that marshaller should be built for
+     * @param classLoader classloader to be used by the marshaller
+     * @return new instance of the marshaller
+     */
     public static Marshaller getMarshaller(Set<Class<?>> classes, MarshallingFormat format, ClassLoader classLoader) {
-        switch ( format ) {
-            case XSTREAM:
-                return new XStreamMarshaller( classes, classLoader );
-            case JAXB:
-                return new JaxbMarshaller(classes, classLoader);
-            case JSON:
-                return new JSONMarshaller(classes, classLoader);
-            default:
-                logger.error( "Unsupported marshalling format: " + format );
+        return builder.build(classes, format, classLoader);
+    }
+
+    /*
+     * Helper methods
+     */
+
+    private static synchronized MarshallerBuilder getMarshallerBuilder() {
+        ServiceLoader<MarshallerBuilder> builders = ServiceLoader.load(MarshallerBuilder.class);
+        Iterator<MarshallerBuilder> it = builders.iterator();
+
+        if (it.hasNext()) {
+            MarshallerBuilder marshallerBuilder = it.next();
+            logger.debug("Found custom marshaller builder {} that is going to be used instead of the default", marshallerBuilder);
+            return marshallerBuilder;
         }
-        return null;
+
+        return new BaseMarshallerBuilder();
     }
 }

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/jaxb/JaxbMarshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/jaxb/JaxbMarshaller.java
@@ -117,8 +117,13 @@ import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore;
 import org.optaplanner.core.api.score.buildin.simpledouble.SimpleDoubleScore;
 import org.optaplanner.core.api.score.buildin.simplelong.SimpleLongScore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class JaxbMarshaller implements Marshaller {
+
+    private static final Logger logger = LoggerFactory.getLogger(JaxbMarshaller.class);
+
     public static final Class<?>[] KIE_SERVER_JAXB_CLASSES;
 
     static {
@@ -277,24 +282,36 @@ public class JaxbMarshaller implements Marshaller {
         };
     }
 
-    private final JAXBContext jaxbContext;
+    protected JAXBContext jaxbContext;
 
-    private ClassLoader classLoader;
+    protected ClassLoader classLoader;
 
     public JaxbMarshaller(Set<Class<?>> classes, ClassLoader classLoader) {
         this.classLoader = classLoader;
+
+        buildMarshaller(classes, classLoader);
+    }
+
+    protected void buildMarshaller( Set<Class<?>> classes, final ClassLoader classLoader ) {
+
         try {
+            logger.debug("Additional classes for JAXB context are {}", classes);
             Set<Class<?>> allClasses = new HashSet<Class<?>>();
 
             allClasses.addAll(Arrays.asList(KIE_SERVER_JAXB_CLASSES));
             if (classes != null) {
                 allClasses.addAll(classes);
             }
-
+            logger.debug("All classes for JAXB context are {}", allClasses);
             this.jaxbContext = JAXBContext.newInstance( allClasses.toArray(new Class[allClasses.size()]) );
         } catch ( JAXBException e ) {
+            logger.error("Error while creating JAXB Marshaller due to {}", e.getMessage(), e);
             throw new MarshallingException( "Error while creating JAXB context from default classes! " + e.getMessage(), e );
         }
+    }
+
+    protected void configureMarshaller( Set<Class<?>> classes, final ClassLoader classLoader ) {
+        // by default nothing to configure though it might be needed in case of extensions
     }
 
     @Override

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshaller.java
@@ -71,22 +71,30 @@ public class JSONMarshaller implements Marshaller {
     private static boolean formatDate = Boolean.parseBoolean(System.getProperty("org.kie.server.json.format.date", "false"));
     private static String dateFormatStr = System.getProperty("org.kie.server.json.date_format", "yyyy-MM-dd'T'hh:mm:ss.SSSZ");
 
-    private ClassLoader classLoader;
-    private final ObjectMapper objectMapper;
+    protected ClassLoader classLoader;
+    protected ObjectMapper objectMapper;
 
-    private final Set<Class<?>> classesSet;
+    protected Set<Class<?>> classesSet;
 
-    private final ObjectMapper deserializeObjectMapper;
+    protected ObjectMapper deserializeObjectMapper;
 
-    private DateFormat dateFormat = new SimpleDateFormat(dateFormatStr);
+    protected DateFormat dateFormat = new SimpleDateFormat(dateFormatStr);
 
     public JSONMarshaller(Set<Class<?>> classes, ClassLoader classLoader) {
         this.classLoader = classLoader;
+        buildMarshaller(classes, classLoader);
+
+        configureMarshaller(classes, classLoader);
+    }
+
+    protected void buildMarshaller( Set<Class<?>> classes, final ClassLoader classLoader ) {
+
         objectMapper = new ObjectMapper();
         deserializeObjectMapper = new ObjectMapper();
+    }
 
+    protected void configureMarshaller( Set<Class<?>> classes, final ClassLoader classLoader ) {
         ObjectMapper customSerializationMapper = new ObjectMapper();
-
         if (classes == null) {
             classes = new HashSet<Class<?>>();
         }
@@ -161,7 +169,6 @@ public class JSONMarshaller implements Marshaller {
         }
 
         this.classesSet = classes;
-
     }
 
     protected List<NamedType> prepareCustomClasses(Set<Class<?>> classes) {

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/xstream/XStreamMarshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/xstream/XStreamMarshaller.java
@@ -65,12 +65,19 @@ import org.optaplanner.persistence.xstream.api.score.buildin.simplelong.SimpleLo
 public class XStreamMarshaller
         implements Marshaller {
 
-    private XStream xstream;
-    private ClassLoader classLoader;
-    private Map<String, Class> classNames = new HashMap<String, Class>();
+    protected XStream xstream;
+    protected ClassLoader classLoader;
+    protected Map<String, Class> classNames = new HashMap<String, Class>();
 
-    public XStreamMarshaller( final Set<Class<?>> classes, final ClassLoader classLoader ) {
+    public XStreamMarshaller( Set<Class<?>> classes, final ClassLoader classLoader ) {
         this.classLoader = classLoader;
+        buildMarshaller(classes, classLoader);
+
+        configureMarshaller(classes, classLoader);
+    }
+
+    protected void buildMarshaller( Set<Class<?>> classes, final ClassLoader classLoader ) {
+
         this.xstream = XStreamXML.newXStreamMarshaller( new XStream(  ) {
 
             protected MapperWrapper wrapMapper(MapperWrapper next) {
@@ -86,6 +93,10 @@ public class XStreamMarshaller
                 };
             }
         });
+
+    }
+
+    protected void configureMarshaller( Set<Class<?>> classes, final ClassLoader classLoader ) {
         this.xstream.setClassLoader( classLoader );
 
         this.xstream.registerConverter(new BendableScoreXStreamConverter());

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/CustomXstreamMarshallerBuilder.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/CustomXstreamMarshallerBuilder.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.api.marshalling;
+
+import java.util.Set;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.io.xml.DomDriver;
+import com.thoughtworks.xstream.io.xml.XmlFriendlyNameCoder;
+import org.kie.server.api.marshalling.xstream.XStreamMarshaller;
+
+public class CustomXstreamMarshallerBuilder extends BaseMarshallerBuilder {
+
+    @Override
+    public Marshaller build(Set<Class<?>> classes, MarshallingFormat format, ClassLoader classLoader) {
+
+        if (format.equals(MarshallingFormat.XSTREAM)) {
+
+            return new XStreamMarshaller(classes, classLoader) {
+                @Override
+                protected void buildMarshaller(Set<Class<?>> classes, ClassLoader classLoader) {
+                    xstream = new XStream(new DomDriver("UTF-8", new XmlFriendlyNameCoder("_-", "_")));
+                }
+            };
+        }
+
+        return super.build(classes, format, classLoader);
+    }
+}

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/XstreamMarshallerTest.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/XstreamMarshallerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.api.marshalling;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+import org.kie.server.api.marshalling.objects.AnotherMessage;
+import org.kie.server.api.marshalling.objects.Message;
+
+import static org.junit.Assert.*;
+
+public class XstreamMarshallerTest {
+
+    @Test
+    public void testXstreamMarshalWithAnnotation() {
+        String expectedXml = "<org.kie.server.api.marshalling.objects.Message>\n" +
+                "  <nameWithAlias>test content</nameWithAlias>\n" +
+                "</org.kie.server.api.marshalling.objects.Message>";
+
+        Set<Class<?>> extraClasses = new HashSet<Class<?>>();
+        extraClasses.add(Message.class);
+        Marshaller marshaller = MarshallerFactory.getMarshaller(extraClasses, MarshallingFormat.XSTREAM, this.getClass().getClassLoader());
+
+        Message testMessage = new Message("test content");
+
+        String testMessageString = marshaller.marshall(testMessage);
+        assertNotNull(testMessageString);
+
+        assertEquals(expectedXml, testMessageString);
+    }
+
+    @Test
+    public void testXstreamMarshalWithCustomMarshallerBuilder() {
+        String expectedXml = "<org.kie.server.api.marshalling.objects.AnotherMessage>\n" +
+                "  <another_name>test content</another_name>\n" +
+                "</org.kie.server.api.marshalling.objects.AnotherMessage>";
+
+        Set<Class<?>> extraClasses = new HashSet<Class<?>>();
+        extraClasses.add(Message.class);
+        Marshaller marshaller = MarshallerFactory.getMarshaller(extraClasses, MarshallingFormat.XSTREAM, this.getClass().getClassLoader());
+
+        AnotherMessage testMessage = new AnotherMessage("test content");
+
+        String testMessageString = marshaller.marshall(testMessage);
+        assertNotNull(testMessageString);
+
+        assertEquals(expectedXml, testMessageString);
+    }
+}

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/objects/AnotherMessage.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/objects/AnotherMessage.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.api.marshalling.objects;
+
+public class AnotherMessage {
+
+    private String another_name;
+
+    public AnotherMessage(String name) {
+        this.another_name = name;
+    }
+
+    public String getAnother_name() {
+        return another_name;
+    }
+
+    public void setAnother_name(String another_name) {
+        this.another_name = another_name;
+    }
+}

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/objects/Message.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/objects/Message.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.api.marshalling.objects;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+public class Message {
+    @XStreamAlias("nameWithAlias")
+    private String name;
+
+    public Message(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/kie-server-parent/kie-server-api/src/test/resources/META-INF/services/org.kie.server.api.marshalling.MarshallerBuilder
+++ b/kie-server-parent/kie-server-api/src/test/resources/META-INF/services/org.kie.server.api.marshalling.MarshallerBuilder
@@ -1,0 +1,1 @@
+org.kie.server.api.marshalling.CustomXstreamMarshallerBuilder

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/KieServicesConfiguration.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/KieServicesConfiguration.java
@@ -52,13 +52,13 @@ public interface KieServicesConfiguration {
 
     boolean isRest();
 
-    Set<Class<?>> getExtraJaxbClasses();
+    Set<Class<?>> getExtraClasses();
 
-    boolean addJaxbClasses(Set<Class<?>> extraJaxbClassList);
+    boolean addExtraClasses(Set<Class<?>> extraClassList);
 
-    KieServicesConfiguration setExtraJaxbClasses(Set<Class<?>> extraJaxbClasses);
+    KieServicesConfiguration setExtraClasses(Set<Class<?>> extraClasses);
 
-    KieServicesConfiguration clearJaxbClasses();
+    KieServicesConfiguration clearExtraClasses();
 
     Transport getTransport();
 
@@ -111,5 +111,29 @@ public interface KieServicesConfiguration {
     void setHeaders(Map<String, String> headers);
 
     Map<String, String> getHeaders();
+
+    /**
+     * Deprecated use #getExtraClasses instead
+     */
+    @Deprecated
+    Set<Class<?>> getExtraJaxbClasses();
+
+    /**
+     * Deprecated use #addExtraClasses instead
+     */
+    @Deprecated
+    boolean addJaxbClasses(Set<Class<?>> extraJaxbClassList);
+
+    /**
+     * Deprecated use #setExtraClasses instead
+     */
+    @Deprecated
+    KieServicesConfiguration setExtraJaxbClasses(Set<Class<?>> extraJaxbClasses);
+
+    /**
+     * Deprecated use #clearExtraClasses instead
+     */
+    @Deprecated
+    KieServicesConfiguration clearJaxbClasses();
 
 }

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/AbstractKieServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/AbstractKieServicesClientImpl.java
@@ -80,7 +80,7 @@ public abstract class AbstractKieServicesClientImpl {
         this.config = config.clone();
         this.loadBalancer = config.getLoadBalancer() == null ? LoadBalancer.getDefault(config.getServerUrl()) : config.getLoadBalancer();
         this.classLoader = Thread.currentThread().getContextClassLoader() != null ? Thread.currentThread().getContextClassLoader() : CommandScript.class.getClassLoader();
-        this.marshaller = MarshallerFactory.getMarshaller(config.getExtraJaxbClasses(), config.getMarshallingFormat(), classLoader);
+        this.marshaller = MarshallerFactory.getMarshaller(config.getExtraClasses(), config.getMarshallingFormat(), classLoader);
         this.responseHandler = config.getResponseHandler();
     }
 
@@ -88,7 +88,7 @@ public abstract class AbstractKieServicesClientImpl {
         this.config = config.clone();
         this.loadBalancer = config.getLoadBalancer() == null ? LoadBalancer.getDefault(config.getServerUrl()) : config.getLoadBalancer();
         this.classLoader = classLoader;
-        this.marshaller = MarshallerFactory.getMarshaller( config.getExtraJaxbClasses(), config.getMarshallingFormat(), classLoader );
+        this.marshaller = MarshallerFactory.getMarshaller( config.getExtraClasses(), config.getMarshallingFormat(), classLoader );
         this.responseHandler = config.getResponseHandler();
     }
 
@@ -504,7 +504,7 @@ public abstract class AbstractKieServicesClientImpl {
             try {
 
                 // serialize request
-                marshaller = MarshallerFactory.getMarshaller( config.getExtraJaxbClasses(), config.getMarshallingFormat(), classLoader );
+                marshaller = MarshallerFactory.getMarshaller( config.getExtraClasses(), config.getMarshallingFormat(), classLoader );
                 String xmlStr = marshaller.marshall( command );
                 logger.debug("Message content to be sent '{}'", xmlStr);
                 textMsg = session.createTextMessage(xmlStr);

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/KieServicesConfigurationImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/KieServicesConfigurationImpl.java
@@ -65,7 +65,7 @@ public final class KieServicesConfigurationImpl
     private boolean jmsTransactional = false;
 
     private MarshallingFormat format           = MarshallingFormat.JAXB;
-    private Set<Class<?>>     extraJaxbClasses = new HashSet<Class<?>>();
+    private Set<Class<?>>     extraClasses = new HashSet<Class<?>>();
 
     private CredentialsProvider credentialsProvider;
 
@@ -129,9 +129,9 @@ public final class KieServicesConfigurationImpl
 
     @Override
     public void dispose() {
-        if ( extraJaxbClasses != null ) {
-            extraJaxbClasses.clear();
-            extraJaxbClasses = null;
+        if ( extraClasses != null ) {
+            extraClasses.clear();
+            extraClasses = null;
         }
         if ( connectionFactory != null ) {
             connectionFactory = null;
@@ -274,19 +274,19 @@ public final class KieServicesConfigurationImpl
     }
 
     @Override
-    public boolean addJaxbClasses(Set<Class<?>> extraJaxbClassList) {
-        return this.extraJaxbClasses.addAll( extraJaxbClassList );
+    public boolean addExtraClasses(Set<Class<?>> extraClassList) {
+        return this.extraClasses.addAll( extraClassList );
     }
 
     @Override
-    public KieServicesConfiguration clearJaxbClasses() {
-        this.extraJaxbClasses.clear();
+    public KieServicesConfiguration clearExtraClasses() {
+        this.extraClasses.clear();
         return this;
     }
 
     @Override
-    public Set<Class<?>> getExtraJaxbClasses() {
-        return this.extraJaxbClasses;
+    public Set<Class<?>> getExtraClasses() {
+        return this.extraClasses;
     }
 
     @Override
@@ -337,10 +337,10 @@ public final class KieServicesConfigurationImpl
     }
 
     @Override
-    public KieServicesConfiguration setExtraJaxbClasses(Set<Class<?>> extraJaxbClasses) {
-        this.extraJaxbClasses.clear();
+    public KieServicesConfiguration setExtraClasses(Set<Class<?>> extraJaxbClasses) {
+        this.extraClasses.clear();
         if (extraJaxbClasses != null) {
-            this.extraJaxbClasses.addAll(extraJaxbClasses);
+            this.extraClasses.addAll(extraJaxbClasses);
         }
         return this;
     }
@@ -428,11 +428,12 @@ public final class KieServicesConfigurationImpl
         return this.headers;
     }
 
+
     // Clone ---
     private KieServicesConfigurationImpl(KieServicesConfigurationImpl config) {
         this.connectionFactory = config.connectionFactory;
 
-        this.extraJaxbClasses = config.extraJaxbClasses;
+        this.extraClasses = config.extraClasses;
         this.format = config.format;
         this.requestQueue = config.requestQueue;
         this.password = config.password;
@@ -461,5 +462,32 @@ public final class KieServicesConfigurationImpl
                 "transport=" + transport +
                 ", serverUrl='" + serverUrl + '\'' +
                 '}';
+    }
+
+    /*
+     * Deprecated methods
+     */
+    @Deprecated
+    @Override
+    public Set<Class<?>> getExtraJaxbClasses() {
+        return getExtraClasses();
+    }
+
+    @Deprecated
+    @Override
+    public boolean addJaxbClasses(Set<Class<?>> extraJaxbClassList) {
+        return addExtraClasses(extraJaxbClassList);
+    }
+
+    @Deprecated
+    @Override
+    public KieServicesConfiguration setExtraJaxbClasses(Set<Class<?>> extraJaxbClasses) {
+        return setExtraClasses(extraJaxbClasses);
+    }
+
+    @Deprecated
+    @Override
+    public KieServicesConfiguration clearJaxbClasses() {
+        return clearExtraClasses();
     }
 }

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/test/java/org/kie/server/client/KieServicesClientTest.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/test/java/org/kie/server/client/KieServicesClientTest.java
@@ -147,7 +147,7 @@ public class KieServicesClientTest extends BaseKieServicesClientTest {
 
 
         config.setMarshallingFormat(MarshallingFormat.JSON);
-        config.setExtraJaxbClasses(Collections.singleton(KieContainerStatus.class));
+        config.setExtraClasses(Collections.singleton(KieContainerStatus.class));
         KieServicesClient client = KieServicesFactory.newKieServicesClient(config);
         ServiceResponse<KieServerInfo> response = client.getServerInfo();
         assertSuccess(response);

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/api/KieContainerInstance.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/api/KieContainerInstance.java
@@ -44,11 +44,11 @@ public interface KieContainerInstance {
 
     void addService(Object service);
 
-    boolean addJaxbClasses(Set<Class<?>> extraJaxbClassList);
+    boolean addExtraClasses(Set<Class<?>> extraClassList);
 
-    void clearJaxbClasses();
+    void clearExtraClasses();
 
-    Set<Class<?>> getExtraJaxbClasses();
+    Set<Class<?>> getExtraClasses();
 
     <T> T getService(Class<T> serviceType);
 

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieContainerInstanceImpl.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieContainerInstanceImpl.java
@@ -39,7 +39,7 @@ public class KieContainerInstanceImpl implements KieContainerInstance {
 
     private transient Map<String, Object> serviceContainer;
 
-    private transient Set<Class<?>> extraJaxbClasses = new HashSet<Class<?>>();
+    private transient Set<Class<?>> extraClasses = new HashSet<Class<?>>();
 
     public KieContainerInstanceImpl(String containerId, KieContainerStatus status) {
         this( containerId, status, null );
@@ -116,7 +116,7 @@ public class KieContainerInstanceImpl implements KieContainerInstance {
         synchronized ( marshallers ) {
             Marshaller marshaller = marshallers.get( format );
             if ( marshaller == null ) {
-                marshaller = MarshallerFactory.getMarshaller( getExtraJaxbClasses(), format, this.kieContainer.getClassLoader() );
+                marshaller = MarshallerFactory.getMarshaller( getExtraClasses(), format, this.kieContainer.getClassLoader() );
                 this.marshallers.put( format, marshaller );
             }
             return marshaller;
@@ -144,18 +144,18 @@ public class KieContainerInstanceImpl implements KieContainerInstance {
     }
 
     @Override
-    public boolean addJaxbClasses(Set<Class<?>> extraJaxbClassList) {
-        return this.extraJaxbClasses.addAll( extraJaxbClassList );
+    public boolean addExtraClasses(Set<Class<?>> extraJaxbClassList) {
+        return this.extraClasses.addAll( extraJaxbClassList );
     }
 
     @Override
-    public void clearJaxbClasses() {
-        this.extraJaxbClasses.clear();
+    public void clearExtraClasses() {
+        this.extraClasses.clear();
     }
 
     @Override
-    public Set<Class<?>> getExtraJaxbClasses() {
-        return this.extraJaxbClasses;
+    public Set<Class<?>> getExtraClasses() {
+        return this.extraClasses;
     }
 
     @Override

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
@@ -684,7 +684,7 @@ public class KieServerImpl {
                     }
                     logger.debug("Container {} (for release id {}) on {} ready to be updated", id, releaseId, extension);
                 }
-                kci.clearJaxbClasses();
+                kci.clearExtraClasses();
                 kci.disposeMarshallers();
                 Results results = kci.getKieContainer().updateToVersion(releaseId);
                 if (results.hasMessages(Level.ERROR)) {

--- a/kie-server-parent/kie-server-services/kie-server-services-drools/src/main/java/org/kie/server/services/drools/DroolsKieServerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-drools/src/main/java/org/kie/server/services/drools/DroolsKieServerExtension.java
@@ -112,7 +112,7 @@ public class DroolsKieServerExtension implements KieServerExtension {
             }
         }
 
-        kieContainerInstance.addJaxbClasses(extraClasses);
+        kieContainerInstance.addExtraClasses(extraClasses);
 
     }
 

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/JbpmKieServerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/JbpmKieServerExtension.java
@@ -357,7 +357,7 @@ public class JbpmKieServerExtension implements KieServerExtension {
             Set<Class<?>> customClasses = new HashSet<Class<?>>(deployedUnit.getDeployedClasses());
             // add custom classes that come from extension itself
             customClasses.add(DocumentImpl.class);
-            kieContainerInstance.addJaxbClasses(customClasses);
+            kieContainerInstance.addExtraClasses(customClasses);
 
             // add any query result mappers from kjar
             List<String> addedMappers = QueryMapperRegistry.get().discoverAndAddMappers(kieContainer.getClassLoader());

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/basetests/KieServerBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/basetests/KieServerBaseIntegrationTest.java
@@ -193,7 +193,7 @@ public abstract class KieServerBaseIntegrationTest {
         configuration.setTimeout(DEFAULT_TIMEOUT);
         configuration.setMarshallingFormat(marshallingFormat);
 
-        configuration.addJaxbClasses(new HashSet<Class<?>>(extraClasses.values()));
+        configuration.addExtraClasses(new HashSet<Class<?>>(extraClasses.values()));
         additionalConfiguration(configuration);
 
         if (extraClasses.size() > 0) {

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/pom.xml
@@ -16,21 +16,25 @@
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-core</artifactId>
       <scope>provided</scope>
+      <version>${version.org.kie}</version>
     </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-persistence-xstream</artifactId>
       <scope>provided</scope>
+      <version>${version.org.kie}</version>
     </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-persistence-jaxb</artifactId>
       <scope>provided</scope>
+      <version>${version.org.kie}</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.jackson</groupId>
       <artifactId>jackson-core-asl</artifactId>
       <scope>provided</scope>
+      <version>${version.org.codehaus.jackson}</version>
     </dependency>
   </dependencies>
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
@@ -9,22 +9,12 @@
   <properties>
     <!-- The version is set during the Maven build (this file is a filtered resource) -->
     <version.org.kie>${version.org.kie}</version.org.kie>
+    <version.org.codehaus.jackson>${version.org.codehaus.jackson}</version.org.codehaus.jackson>
     <drools.compiler.lnglevel>1.6</drools.compiler.lnglevel>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.kie</groupId>
-        <artifactId>kie-platform-bom</artifactId>
-        <version>${version.org.kie}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <build>
     <pluginManagement>
@@ -34,20 +24,6 @@
           <artifactId>kie-maven-plugin</artifactId>
           <version>${version.org.kie}</version>
           <extensions>true</extensions>
-          <dependencies>
-            <!-- needed to compile ruleflow processes -->
-            <dependency>
-              <groupId>org.jbpm</groupId>
-              <artifactId>jbpm-bpmn2</artifactId>
-              <version>${version.org.kie}</version>
-            </dependency>
-            <!-- needed to compile spreadsheet decision tables -->
-            <dependency>
-              <groupId>org.drools</groupId>
-              <artifactId>drools-decisiontables</artifactId>
-              <version>${version.org.kie}</version>
-            </dependency>
-          </dependencies>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
@etirelli in case you find a bit of time would be good to have your opinion on these two (skip the optaplanner as that is only to fix the tests... an attempt)