### PR TITLE
[6.5.x] JBPM-5277 - getTasksAssignedAsPotentialOwner doesn't allow groups searching, only actorid

### DIFF
--- a/kie-remote/kie-remote-client/src/main/java/org/kie/remote/client/jaxb/AcceptedClientCommands.java
+++ b/kie-remote/kie-remote-client/src/main/java/org/kie/remote/client/jaxb/AcceptedClientCommands.java
@@ -86,6 +86,7 @@ public class AcceptedClientCommands {
         acceptedCommands.add(GetTaskAssignedAsPotentialOwnerCommand.class);
         acceptedCommands.add(GetTaskByWorkItemIdCommand.class);
         acceptedCommands.add(GetTaskCommand.class);
+        acceptedCommands.add(GetTasksByGroupCommand.class);
         acceptedCommands.add(GetTasksByProcessInstanceIdCommand.class);
         acceptedCommands.add(GetTasksByStatusByProcessInstanceIdCommand.class);
         acceptedCommands.add(GetTasksByVariousFieldsCommand.class);

--- a/kie-remote/kie-remote-client/src/main/java/org/kie/remote/client/jaxb/JaxbCommandsRequest.java
+++ b/kie-remote/kie-remote-client/src/main/java/org/kie/remote/client/jaxb/JaxbCommandsRequest.java
@@ -74,6 +74,7 @@ import org.kie.remote.jaxb.gen.GetTaskAssignedAsPotentialOwnerCommand;
 import org.kie.remote.jaxb.gen.GetTaskByWorkItemIdCommand;
 import org.kie.remote.jaxb.gen.GetTaskCommand;
 import org.kie.remote.jaxb.gen.GetTaskContentCommand;
+import org.kie.remote.jaxb.gen.GetTasksByGroupCommand;
 import org.kie.remote.jaxb.gen.GetTasksByProcessInstanceIdCommand;
 import org.kie.remote.jaxb.gen.GetTasksByStatusByProcessInstanceIdCommand;
 import org.kie.remote.jaxb.gen.GetTasksByVariousFieldsCommand;
@@ -182,6 +183,7 @@ public class JaxbCommandsRequest {
             @XmlElement(name = "get-task-as-potential-owner", type = GetTaskAssignedAsPotentialOwnerCommand.class),
             @XmlElement(name = "get-task-by-workitemid", type = GetTaskByWorkItemIdCommand.class),
             @XmlElement(name = "get-task", type = GetTaskCommand.class),
+            @XmlElement(name = "get-tasks-by-group-command", type = GetTasksByGroupCommand.class),
             @XmlElement(name = "get-tasks-by-processinstanceid", type = GetTasksByProcessInstanceIdCommand.class),
             @XmlElement(name = "get-tasks-by-status-by-processinstanceid", type = GetTasksByStatusByProcessInstanceIdCommand.class),
             @XmlElement(name = "get-tasks-by-various", type = GetTasksByVariousFieldsCommand.class),

--- a/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/AcceptedServerCommands.java
+++ b/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/AcceptedServerCommands.java
@@ -73,6 +73,7 @@ import org.jbpm.services.task.commands.GetTaskAssignedAsPotentialOwnerCommand;
 import org.jbpm.services.task.commands.GetTaskByWorkItemIdCommand;
 import org.jbpm.services.task.commands.GetTaskCommand;
 import org.jbpm.services.task.commands.GetTaskContentCommand;
+import org.jbpm.services.task.commands.GetTasksByGroupCommand;
 import org.jbpm.services.task.commands.GetTasksByProcessInstanceIdCommand;
 import org.jbpm.services.task.commands.GetTasksByStatusByProcessInstanceIdCommand;
 import org.jbpm.services.task.commands.GetTasksByVariousFieldsCommand;
@@ -154,6 +155,7 @@ public class AcceptedServerCommands {
         acceptedCommands.add(GetTaskByWorkItemIdCommand.class);
         acceptedCommands.add(GetTaskContentCommand.class);
         acceptedCommands.add(GetTaskCommand.class);
+        acceptedCommands.add(GetTasksByGroupCommand.class);
         acceptedCommands.add(GetTasksByProcessInstanceIdCommand.class);
         acceptedCommands.add(GetTasksByStatusByProcessInstanceIdCommand.class);
         acceptedCommands.add(GetTasksByVariousFieldsCommand.class);

--- a/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/jaxb/JaxbCommandsRequest.java
+++ b/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/jaxb/JaxbCommandsRequest.java
@@ -81,6 +81,7 @@ import org.jbpm.services.task.commands.GetContentByIdForUserCommand;
 import org.jbpm.services.task.commands.GetContentMapForUserCommand;
 import org.jbpm.services.task.commands.GetTaskAssignedAsBusinessAdminCommand;
 import org.jbpm.services.task.commands.GetTaskAssignedAsPotentialOwnerCommand;
+import org.jbpm.services.task.commands.GetTasksByGroupCommand;
 import org.jbpm.services.task.commands.GetTaskByWorkItemIdCommand;
 import org.jbpm.services.task.commands.GetTaskCommand;
 import org.jbpm.services.task.commands.GetTaskContentCommand;
@@ -190,6 +191,7 @@ public class JaxbCommandsRequest {
             @XmlElement(name = "get-task-as-potential-owner", type = GetTaskAssignedAsPotentialOwnerCommand.class),
             @XmlElement(name = "get-task-by-workitemid", type = GetTaskByWorkItemIdCommand.class),
             @XmlElement(name = "get-task", type = GetTaskCommand.class),
+            @XmlElement(name = "get-tasks-by-group-command", type = GetTasksByGroupCommand.class),
             @XmlElement(name = "get-tasks-by-processinstanceid", type = GetTasksByProcessInstanceIdCommand.class),
             @XmlElement(name = "get-tasks-by-status-by-processinstanceid", type = GetTasksByStatusByProcessInstanceIdCommand.class),
             @XmlElement(name = "get-tasks-by-various", type = GetTasksByVariousFieldsCommand.class),


### PR DESCRIPTION
Cherry-pick of commit 5e9dcbdc335ce0bca0f6e8c56e05a98ecada959e from #635 (6.4.x)

Please note that this feature has not been cherry-picked to **master** branch so I am also not fixing this issue there. Should we not delete `kie-remote` module on master branch?