### PR TITLE
[JBPM-5288,RHBPMS-4087] process scanner config when creating new kieC…

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
@@ -71,7 +71,7 @@ import org.slf4j.LoggerFactory;
 
 public class KieServerImpl {
 
-    private static final Logger             logger               = LoggerFactory.getLogger(KieServerImpl.class);
+    private static final Logger logger = LoggerFactory.getLogger(KieServerImpl.class);
 
     private static final ServiceLoader<KieServerExtension> serverExtensions = ServiceLoader.load(KieServerExtension.class);
 
@@ -80,7 +80,6 @@ public class KieServerImpl {
     private String kieServerLocation = System.getProperty(KieServerConstants.KIE_SERVER_LOCATION, "http://localhost:8230/kie-server/services/rest/server");
 
     private final KieServerRegistry context;
-    private final ContainerManager containerManager;
 
     private final KieServerStateRepository repository;
     private volatile AtomicBoolean kieServerActive = new AtomicBoolean(false);
@@ -89,13 +88,17 @@ public class KieServerImpl {
     private Map<String, List<Message>> containerMessages = new ConcurrentHashMap<String, List<Message>>();
 
     public KieServerImpl() {
-        this.repository = new KieServerStateFileRepository();
+        this(new KieServerStateFileRepository());
+    }
+
+    public KieServerImpl(KieServerStateRepository stateRepository) {
+        this.repository = stateRepository;
 
         this.context = new KieServerRegistryImpl();
         this.context.registerIdentityProvider(new JACCIdentityProvider());
         this.context.registerStateRepository(repository);
 
-        this.containerManager = getContainerManager();
+        ContainerManager containerManager = getContainerManager();
 
         KieServerState currentState = repository.load(KieServerEnvironment.getServerId());
 
@@ -249,9 +252,18 @@ public class KieServerImpl {
                                 logger.debug("Container {} (for release id {}) {} initialization: DONE", containerId, releaseId, extension);
                             }
 
+                            if (container.getScanner() != null) {
+                                ServiceResponse<KieScannerResource> scannerResponse = configureScanner(containerId, ci, container.getScanner());
+                                if (ResponseType.FAILURE.equals(scannerResponse.getType())) {
+                                    String errorMessage = "Failed to create scanner for container " + containerId + " with module " + releaseId + ".";
+                                    messages.add(new Message(Severity.ERROR, errorMessage));
+                                    ci.getResource().setStatus(KieContainerStatus.FAILED);
+                                    return new ServiceResponse<KieContainerResource>(ServiceResponse.ResponseType.FAILURE, errorMessage);
+                                }
+                            }
+
                             ci.getResource().setStatus(KieContainerStatus.STARTED);
                             logger.info("Container {} (for release id {}) successfully started", containerId, releaseId);
-
 
                             // store the current state of the server
                             KieServerState currentState = repository.load(KieServerEnvironment.getServerId());
@@ -259,6 +271,7 @@ public class KieServerImpl {
                             currentState.getContainers().add(container);
 
                             repository.store(KieServerEnvironment.getServerId(), currentState);
+
                             messages.add(new Message(Severity.INFO, "Container " + containerId + " successfully created with module " + releaseId + "."));
 
                             return new ServiceResponse<KieContainerResource>(ServiceResponse.ResponseType.SUCCESS, "Container " + containerId + " successfully deployed with module " + releaseId + ".", ci.getResource());
@@ -431,7 +444,7 @@ public class KieServerImpl {
         if (scanner != null) {
             info = new KieScannerResource(mapStatus(scanner.getStatus()), scanner.getPollingInterval());
         } else {
-            info = new KieScannerResource( KieScannerStatus.DISPOSED);
+            info = new KieScannerResource(KieScannerStatus.DISPOSED);
         }
         return info;
     }
@@ -441,35 +454,12 @@ public class KieServerImpl {
             logger.error("Error updating scanner for container " + id + ". Status is null: " + resource);
             return new ServiceResponse<KieScannerResource>(ServiceResponse.ResponseType.FAILURE, "Error updating scanner for container " + id + ". Status is null: " + resource);
         }
-        KieScannerStatus status = resource.getStatus();
         try {
             KieContainerInstanceImpl kci = context.getContainer(id);
             if (kci != null && kci.getKieContainer() != null) {
                 // synchronize over the container instance to avoid inconsistent sate in case of concurrent updateScanner calls
                 synchronized (kci) {
-                    ServiceResponse<KieScannerResource> result = null;
-                    switch (status) {
-                        case CREATED:
-                            result = createScanner(id, kci);
-                            break;
-                        case STARTED:
-                            result = startScanner(id, resource, kci);
-                            break;
-                        case STOPPED:
-                            result = stopScanner(id, resource, kci);
-                            break;
-                        case SCANNING:
-                            result = scanNow(id, resource, kci);
-                            break;
-                        case DISPOSED:
-                            result = disposeScanner(id, resource, kci);
-                            break;
-                        default:
-                            // error
-                            result = new ServiceResponse<KieScannerResource>(ServiceResponse.ResponseType.FAILURE,
-                                    "Unknown status '" + status + "' for scanner on container " + id + ".");
-                            break;
-                    }
+                    ServiceResponse<KieScannerResource> result = configureScanner(id, kci, resource);
                     KieScannerResource scannerResource = result.getResult();
                     kci.getResource().setScanner(result.getResult()); // might be null, but that is ok
                     storeScannerState(kci.getContainerId(), scannerResource);
@@ -484,6 +474,36 @@ public class KieServerImpl {
             return new ServiceResponse<KieScannerResource>(ServiceResponse.ResponseType.FAILURE, "Error updating scanner for container '" + id +
                     "': " + resource + ": " + e.getClass().getName() + ": " + e.getMessage());
         }
+    }
+
+    private ServiceResponse<KieScannerResource> configureScanner(String containerId, KieContainerInstanceImpl kci,
+                                                                 KieScannerResource scannerResource) {
+        KieScannerStatus scannerStatus = scannerResource.getStatus();
+        ServiceResponse<KieScannerResource> result;
+
+        switch (scannerStatus) {
+            case CREATED:
+                result = createScanner(containerId, kci);
+                break;
+            case STARTED:
+                result = startScanner(containerId, scannerResource, kci);
+                break;
+            case STOPPED:
+                result = stopScanner(containerId, scannerResource, kci);
+                break;
+            case SCANNING:
+                result = scanNow(containerId, scannerResource, kci);
+                break;
+            case DISPOSED:
+                result = disposeScanner(containerId, scannerResource, kci);
+                break;
+            default:
+                // error
+                result = new ServiceResponse<KieScannerResource>(ResponseType.FAILURE,
+                        "Unknown status '" + scannerStatus + "' for scanner on container " + containerId + ".");
+                break;
+        }
+        return result;
     }
 
     /**

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/KieServerImplTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/KieServerImplTest.java
@@ -16,8 +16,12 @@
 package org.kie.server.services.impl;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.assertj.core.api.Assertions;
 import org.drools.compiler.kie.builder.impl.InternalKieModule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieFileSystem;
@@ -28,6 +32,7 @@ import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.KieScannerResource;
 import org.kie.server.api.model.KieScannerStatus;
 import org.kie.server.api.model.ReleaseId;
+import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.services.impl.storage.KieServerState;
 import org.kie.server.services.impl.storage.KieServerStateRepository;
 import org.kie.server.services.impl.storage.file.KieServerStateFileRepository;
@@ -37,38 +42,44 @@ import java.io.IOException;
 import java.util.Date;
 import java.util.Set;
 
-public class KieServerImplServerTest {
+public class KieServerImplTest {
 
+    private static final File REPOSITORY_DIR = new File("target/repository-dir");
     private static final String KIE_SERVER_ID = "kie-server-impl-test";
-    private static final String KIE_SERVER_REPO_LOCATION = "target/";
     private static final String GROUP_ID = "org.kie.server.test";
-    private static final String ARTIFACT_ID = "persist-scanner-state";
     private static final String VERSION = "1.0.0.Final";
-    private static final String CONTAINER_ID = "persist-scanner-state";
+
+    private KieServerImpl kieServer;
+    private org.kie.api.builder.ReleaseId releaseId;
+
+    @Before
+    public void setupKieServerImpl() throws Exception {
+        System.setProperty("org.kie.server.id", KIE_SERVER_ID);
+        FileUtils.deleteDirectory(REPOSITORY_DIR);
+        FileUtils.forceMkdir(REPOSITORY_DIR);
+        KieServerEnvironment.setServerId(KIE_SERVER_ID);
+        kieServer = new KieServerImpl(new KieServerStateFileRepository(REPOSITORY_DIR));
+    }
+
+    @After
+    public void cleanUp() {
+        if (kieServer != null) {
+            kieServer.destroy();
+        }
+    }
 
     @Test
     // https://issues.jboss.org/browse/RHBPMS-4087
     public void testPersistScannerState() {
-        KieServerEnvironment.setServerId(KIE_SERVER_ID);
-        System.setProperty("org.kie.server.repo", KIE_SERVER_REPO_LOCATION);
-
-        KieServerImpl kieServer = new KieServerImpl();
-
-        // create empty kjar; content does not matter
-        KieServices kieServices = KieServices.Factory.get();
-        KieFileSystem kfs = kieServices.newKieFileSystem();
-        org.kie.api.builder.ReleaseId releaseId = kieServices.newReleaseId(GROUP_ID, ARTIFACT_ID, VERSION);
-        KieModule kieModule = kieServices.newKieBuilder( kfs ).buildAll().getKieModule();
-        MavenRepository.getMavenRepository().installArtifact(releaseId, (InternalKieModule)kieModule, createPomFile());
-        kieServices.getRepository().addKieModule(kieModule);
-
-        // create the container and update the
-        KieContainerResource kieContainerResource = new KieContainerResource(CONTAINER_ID, new ReleaseId(releaseId));
-        kieServer.createContainer(CONTAINER_ID, kieContainerResource);
+        String containerId = "persist-scanner-state";
+        createEmptyKjar(containerId);
+        // create the container and update the scanner
+        KieContainerResource kieContainerResource = new KieContainerResource(containerId, new ReleaseId(releaseId));
+        kieServer.createContainer(containerId, kieContainerResource);
         KieScannerResource kieScannerResource = new KieScannerResource(KieScannerStatus.STARTED, 20000L);
-        kieServer.updateScanner(CONTAINER_ID, kieScannerResource);
+        kieServer.updateScanner(containerId, kieScannerResource);
 
-        KieServerStateRepository stateRepository = new KieServerStateFileRepository();
+        KieServerStateRepository stateRepository = new KieServerStateFileRepository(REPOSITORY_DIR);
         KieServerState state = stateRepository.load(KIE_SERVER_ID);
         Set<KieContainerResource> containers = state.getContainers();
         Assertions.assertThat(containers).hasSize(1);
@@ -76,11 +87,11 @@ public class KieServerImplServerTest {
         Assertions.assertThat(container.getScanner()).isEqualTo(kieScannerResource);
 
         KieScannerResource updatedKieScannerResource = new KieScannerResource(KieScannerStatus.DISPOSED);
-        kieServer.updateScanner(CONTAINER_ID, updatedKieScannerResource);
+        kieServer.updateScanner(containerId, updatedKieScannerResource);
 
         // create new state repository instance to avoid caching via 'knownStates'
-        // this is simulates the server restart (since the status is loaded from filesystem after restart)
-        stateRepository = new KieServerStateFileRepository();
+        // this simulates the server restart (since the status is loaded from filesystem after restart)
+        stateRepository = new KieServerStateFileRepository(REPOSITORY_DIR);
         state = stateRepository.load(KIE_SERVER_ID);
         containers = state.getContainers();
         Assertions.assertThat(containers).hasSize(1);
@@ -88,19 +99,46 @@ public class KieServerImplServerTest {
         Assertions.assertThat(container.getScanner()).isEqualTo(updatedKieScannerResource);
     }
 
-    private File createPomFile() {
+    @Test
+    // https://issues.jboss.org/browse/JBPM-5288
+    public void testCreateScannerWhenCreatingContainer() {
+        String containerId = "scanner-state-when-creating-container";
+        createEmptyKjar(containerId);
+
+        // create the container (provide scanner info as well)
+        KieContainerResource kieContainerResource = new KieContainerResource(containerId, new ReleaseId(releaseId));
+        KieScannerResource kieScannerResource = new KieScannerResource(KieScannerStatus.STARTED, 20000L);
+        kieContainerResource.setScanner(kieScannerResource);
+        kieServer.createContainer(containerId, kieContainerResource);
+
+        ServiceResponse<KieContainerResource> response = kieServer.getContainerInfo(containerId);
+        Assertions.assertThat(response.getType()).isEqualTo(ServiceResponse.ResponseType.SUCCESS);
+        Assertions.assertThat(response.getResult().getScanner()).isEqualTo(kieScannerResource);
+    }
+
+    private void createEmptyKjar(String artifactId) {
+        // create empty kjar; content does not matter
+        KieServices kieServices = KieServices.Factory.get();
+        KieFileSystem kfs = kieServices.newKieFileSystem();
+        releaseId = kieServices.newReleaseId(GROUP_ID, artifactId, VERSION);
+        KieModule kieModule = kieServices.newKieBuilder( kfs ).buildAll().getKieModule();
+        MavenRepository.getMavenRepository().installArtifact(releaseId, (InternalKieModule)kieModule, createPomFile(artifactId));
+        kieServices.getRepository().addKieModule(kieModule);
+    }
+
+    private File createPomFile(String artifactId) {
         String pomContent = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                 "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
                 "         xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd\">\n" +
                 "  <modelVersion>4.0.0</modelVersion>\n" +
                 "\n" +
                 "  <groupId>org.kie.server.test</groupId>\n" +
-                "  <artifactId>persist-scanner-state</artifactId>\n" +
+                "  <artifactId>" + artifactId + "</artifactId>\n" +
                 "  <version>1.0.0.Final</version>\n" +
                 "  <packaging>pom</packaging>\n" +
                 "</project>";
         try {
-            File file = new File("target/persist-scanner-state-1.0.0.Final.pom");
+            File file = new File("target/" + artifactId + "-1.0.0.Final.pom");
             FileUtils.write(file, pomContent);
             return file;
         } catch (IOException e) {

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/KieServerStateTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/KieServerStateTest.java
@@ -15,12 +15,13 @@
 
 package org.kie.server.services.impl;
 
+import java.io.File;
 import java.util.UUID;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 import org.kie.server.api.KieServerConstants;
 import org.kie.server.api.model.KieServerConfig;
@@ -30,14 +31,14 @@ import org.kie.server.services.impl.storage.file.KieServerStateFileRepository;
 
 public class KieServerStateTest {
 
-    @BeforeClass
-    public static void setupOnce() {
-        System.setProperty(KieServerConstants.KIE_SERVER_STATE_REPO, "./target");
-    }
+    private static final File REPOSITORY_DIR = new File("target/repository-dir");
 
-    @AfterClass
-    public static void cleanupOnce() {
-        System.clearProperty(KieServerConstants.KIE_SERVER_STATE_REPO);
+    @Before
+    public void setup() throws Exception {
+        // make sure we start with an empty repository directory
+        // (just in case the same directory would be used by different test as well)
+        FileUtils.deleteDirectory(REPOSITORY_DIR);
+        FileUtils.forceMkdir(REPOSITORY_DIR);
     }
 
     @After
@@ -49,7 +50,7 @@ public class KieServerStateTest {
 
     @Test
     public void testLoadKieServerState() {
-        KieServerStateRepository repository = new KieServerStateFileRepository();
+        KieServerStateRepository repository = new KieServerStateFileRepository(REPOSITORY_DIR);
 
         String serverId = UUID.randomUUID().toString();
 
@@ -68,7 +69,7 @@ public class KieServerStateTest {
 
         repository.store(serverId, state);
 
-        repository = new KieServerStateFileRepository();
+        repository = new KieServerStateFileRepository(REPOSITORY_DIR);
         state = repository.load(serverId);
         Assert.assertNotNull(state);
 
@@ -81,7 +82,7 @@ public class KieServerStateTest {
 
     @Test
     public void testLoadKieServerStateWithProperties() {
-        KieServerStateFileRepository repository = new KieServerStateFileRepository();
+        KieServerStateFileRepository repository = new KieServerStateFileRepository(REPOSITORY_DIR);
 
         System.setProperty(KieServerConstants.CFG_PERSISTANCE_DIALECT, "org.hibernate.dialect.PostgreSQLDialect");
         System.setProperty(KieServerConstants.CFG_PERSISTANCE_DS, "jdbc/jbpm");


### PR DESCRIPTION
…ontainer

 * refactored some classes to make them easier to test

@jakubschwan this is needed in order to completely fix RHBPMS-4087. Without this the scanner config is not actually read during the startup (it is stored in the XML config, but ignored).