### PR TITLE
droolsjbpm-integration-tests module temporarily disabled in build.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,8 @@
     <module>drools-android</module>
     <!-- The Android examples require Android SDK to be installed, so they are excluded from the default build -->
     <!-- <module>drools-examples-android</module> -->
-    <module>droolsjbpm-integration-tests</module>
+    <!-- Temporarily disabled due to nexus-staging-maven-plugin bug of Rule "sources-staging" failures -->
+    <!-- <module>droolsjbpm-integration-tests</module> -->
   </modules>
 
   <dependencyManagement>


### PR DESCRIPTION
for 6.5.x branch