### PR TITLE
droolsjbpm-integration-tests module temporarily disabled in build.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,8 @@
     <module>kie-security</module>
     <!-- The Android examples require Android SDK to be installed, so they are excluded from the default build -->
     <!-- <module>drools-examples-android</module> -->
-    <module>droolsjbpm-integration-tests</module>
+    <!-- Temporarily disabled due to nexus-staging-maven-plugin bug of Rule "sources-staging" failures -->
+    <!-- <module>droolsjbpm-integration-tests</module> -->
   </modules>
 
   <dependencyManagement>


### PR DESCRIPTION
for master upstream