### PR TITLE
[do not merge, 6.4.x] Reproducer for JBPM-5330 and JBPM-5331

### DIFF
--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -55,6 +55,32 @@
     <module>kie-server-integ-tests-controller</module>
   </modules>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.kie.server</groupId>
+        <artifactId>kie-server</artifactId>
+        <version>6.5.0-SNAPSHOT</version>
+        <type>war</type>
+        <classifier>ee7</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.server</groupId>
+        <artifactId>kie-server</artifactId>
+        <version>6.5.0-SNAPSHOT</version>
+        <type>war</type>
+        <classifier>ee6</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.server</groupId>
+        <artifactId>kie-server</artifactId>
+        <version>6.5.0-SNAPSHOT</version>
+        <type>war</type>
+        <classifier>webc</classifier>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <build>
     <pluginManagement>
       <plugins>


### PR DESCRIPTION
To simulate the issue run integration tests with this command: mvn clean install -Peap64x -Deap64x.download.url="insert EAP URL" -Dkie.server.version=6.5.0-SNAPSHOT

Cannot be run on WildFly due to changes in ee7 war to support WildFly10