### PR TITLE
[JBPM-5330] xstream marshalling: use values set by default constructo…

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/xstream/XStreamMarshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/xstream/XStreamMarshaller.java
@@ -16,11 +16,11 @@
 package org.kie.server.api.marshalling.xstream;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
 import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider;
 import com.thoughtworks.xstream.mapper.MapperWrapper;
 import org.drools.core.runtime.help.impl.XStreamXML;
 import org.kie.server.api.commands.CallContainerCommand;
@@ -78,7 +78,7 @@ public class XStreamMarshaller
 
     protected void buildMarshaller( Set<Class<?>> classes, final ClassLoader classLoader ) {
 
-        this.xstream = XStreamXML.newXStreamMarshaller( new XStream(  ) {
+        this.xstream = XStreamXML.newXStreamMarshaller( new XStream( new PureJavaReflectionProvider() ) {
 
             protected MapperWrapper wrapMapper(MapperWrapper next) {
                 return new MapperWrapper(next) {

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/CustomXstreamMarshallerBuilder.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/CustomXstreamMarshallerBuilder.java
@@ -18,6 +18,7 @@ package org.kie.server.api.marshalling;
 import java.util.Set;
 
 import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider;
 import com.thoughtworks.xstream.io.xml.DomDriver;
 import com.thoughtworks.xstream.io.xml.XmlFriendlyNameCoder;
 import org.kie.server.api.marshalling.xstream.XStreamMarshaller;
@@ -32,7 +33,7 @@ public class CustomXstreamMarshallerBuilder extends BaseMarshallerBuilder {
             return new XStreamMarshaller(classes, classLoader) {
                 @Override
                 protected void buildMarshaller(Set<Class<?>> classes, ClassLoader classLoader) {
-                    xstream = new XStream(new DomDriver("UTF-8", new XmlFriendlyNameCoder("_-", "_")));
+                    xstream = new XStream(new PureJavaReflectionProvider(), new DomDriver("UTF-8", new XmlFriendlyNameCoder("_-", "_")));
                 }
             };
         }

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/XstreamMarshallerTest.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/XstreamMarshallerTest.java
@@ -18,9 +18,12 @@ package org.kie.server.api.marshalling;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
+import org.kie.server.api.commands.ListContainersCommand;
 import org.kie.server.api.marshalling.objects.AnotherMessage;
 import org.kie.server.api.marshalling.objects.Message;
+import org.kie.server.api.model.KieContainerResourceFilter;
 
 import static org.junit.Assert.*;
 
@@ -61,4 +64,14 @@ public class XstreamMarshallerTest {
 
         assertEquals(expectedXml, testMessageString);
     }
+
+    @Test
+    public void testUnmarshallListContainersCommandWithNoFilter() {
+        String commandString = "<list-containers/>";
+        Marshaller marshaller = MarshallerFactory.getMarshaller(MarshallingFormat.XSTREAM, getClass().getClassLoader());
+        ListContainersCommand command = marshaller.unmarshall(commandString, ListContainersCommand.class);
+        // the default ACCEPT_ALL filter should be set
+        Assertions.assertThat(command.getKieContainerResourceFilter()).isEqualTo(KieContainerResourceFilter.ACCEPT_ALL);
+    }
+
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/storage/file/KieServerStateFileRepository.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/storage/file/KieServerStateFileRepository.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider;
 import org.kie.server.api.KieServerConstants;
 import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.KieServerConfig;
@@ -36,7 +37,7 @@ public class KieServerStateFileRepository implements KieServerStateRepository {
 
     private final File repositoryDir;
 
-    private XStream xs = new XStream();
+    private XStream xs = new XStream(new PureJavaReflectionProvider());
 
     private Map<String, KieServerState> knownStates = new ConcurrentHashMap<String, KieServerState>();
 


### PR DESCRIPTION
…r instead of nulls

 * XStream by default overrides the default values set by constructor
   with nulls - in case the XML string did not contain any date
   about the particular field. In this specific case, if the container
   filter was not set, it was set to null (instead of using the default
   constructor to supply the ACCEPT_ALL filter)

 * this should also align the marshalling more closely with the JAXB

This could in theory break a backwards compatibility, but I could not think of such case.

@mswiderski could you please quickly review this?