### PR TITLE
kie-server-tests: fix response handler tests on slow databases

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerSynchronization.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerSynchronization.java
@@ -19,6 +19,7 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BooleanSupplier;
+import java.util.stream.Collectors;
 
 import org.kie.api.command.Command;
 import org.kie.api.executor.STATUS;
@@ -32,6 +33,7 @@ import org.kie.server.api.model.KieScannerStatus;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ReleaseIdFilter;
 import org.kie.server.api.model.ServiceResponse;
+import org.kie.server.api.model.definition.QueryDefinition;
 import org.kie.server.api.model.instance.ProcessInstance;
 import org.kie.server.api.model.instance.RequestInfoInstance;
 import org.kie.server.api.model.instance.SolverInstance;
@@ -175,6 +177,22 @@ public class KieServerSynchronization {
             TaskInstance task = client.findTaskById(taskId);
             return status.equals(task.getStatus());
         });
+    }
+
+    public static void waitForQuery(final QueryServicesClient client, final QueryDefinition query) throws Exception {
+        waitForCondition(() -> !client.getQueries(0, 10).stream()
+                .filter(q -> query.getName().equals(q.getName()) && query.getExpression().equals(q.getExpression()))
+                .collect(Collectors.toList())
+                .isEmpty()
+        );
+    }
+
+    public static void waitForQueryRemoval(final QueryServicesClient client, final QueryDefinition query) throws Exception {
+        waitForCondition(() -> client.getQueries(0, 10).stream()
+                .filter(q -> query.getName().equals(q.getName()))
+                .collect(Collectors.toList())
+                .isEmpty()
+        );
     }
 
     /**

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/jms/JmsResponseHandlerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/jms/JmsResponseHandlerIntegrationTest.java
@@ -15,6 +15,8 @@
 
 package org.kie.server.integrationtests.jbpm.jms;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -58,8 +60,6 @@ import org.kie.server.integrationtests.shared.KieServerAssert;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 import org.kie.server.integrationtests.shared.KieServerSynchronization;
 
-import static org.assertj.core.api.Assertions.*;
-
 @Category({JMSOnly.class})
 public class JmsResponseHandlerIntegrationTest extends JbpmKieServerBaseIntegrationTest {
 
@@ -68,7 +68,7 @@ public class JmsResponseHandlerIntegrationTest extends JbpmKieServerBaseIntegrat
     @Parameterized.Parameters(name = "{index}: {0}")
     public static Collection<Object[]> data() {
         KieServicesConfiguration jmsConfiguration = createKieServicesJmsConfiguration();
-        Collection<Object[]> parameterData = new ArrayList<Object[]>(Arrays.asList(new Object[][]{
+        Collection<Object[]> parameterData = new ArrayList<>(Arrays.asList(new Object[][]{
                 {MarshallingFormat.JAXB, jmsConfiguration},
                 {MarshallingFormat.JSON, jmsConfiguration},
                 {MarshallingFormat.XSTREAM, jmsConfiguration}
@@ -164,12 +164,12 @@ public class JmsResponseHandlerIntegrationTest extends JbpmKieServerBaseIntegrat
     }
 
     @Test
-    public void testQueryRegistrationUseOfFireAndForgetResponseHandler() {
+    public void testQueryRegistrationUseOfFireAndForgetResponseHandler() throws Exception {
         testQueryRegistration(new FireAndForgetResponseHandler());
     }
 
     @Test
-    public void testQueryRegistrationUseOfAsyncResponseHandler() {
+    public void testQueryRegistrationUseOfAsyncResponseHandler() throws Exception {
         ResponseCallback callback = new BlockingResponseCallback(null);
         testQueryRegistration(new AsyncResponseHandler(callback));
     }
@@ -312,7 +312,7 @@ public class JmsResponseHandlerIntegrationTest extends JbpmKieServerBaseIntegrat
         KieServerSynchronization.waitForProcessInstanceToFinish(processClient, CONTAINER_ID, processInstanceId);
     }
 
-    private void testQueryRegistration(ResponseHandler responseHandler) {
+    private void testQueryRegistration(ResponseHandler responseHandler) throws Exception {
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("stringData", "waiting for signal");
         parameters.put("personData", createPersonInstance(CONTAINER_ID));
@@ -329,6 +329,8 @@ public class JmsResponseHandlerIntegrationTest extends JbpmKieServerBaseIntegrat
         queryClient.registerQuery(query);
 
         queryClient.setResponseHandler(new RequestReplyResponseHandler());
+        KieServerSynchronization.waitForQuery(queryClient, query);
+
         List<TaskInstance> tasks = queryClient.query(query.getName(), QueryServicesClient.QUERY_MAP_TASK, 0, 10, TaskInstance.class);
         assertThat(tasks).isNotNull().hasSize(1);
         Long taskId = tasks.get(0).getId();
@@ -339,6 +341,8 @@ public class JmsResponseHandlerIntegrationTest extends JbpmKieServerBaseIntegrat
         queryClient.replaceQuery(query);
 
         queryClient.setResponseHandler(new RequestReplyResponseHandler());
+        KieServerSynchronization.waitForQuery(queryClient, query);
+
         tasks = queryClient.query(query.getName(), QueryServicesClient.QUERY_MAP_TASK, 0, 10, TaskInstance.class);
         assertThat(tasks).isNotNull().isEmpty();
 
@@ -353,8 +357,7 @@ public class JmsResponseHandlerIntegrationTest extends JbpmKieServerBaseIntegrat
         queryClient.unregisterQuery(query.getName());
 
         queryClient.setResponseHandler(new RequestReplyResponseHandler());
-        List<QueryDefinition> queries = queryClient.getQueries(0, 10);
-        assertThat(queries).isNotNull().isEmpty();
+        KieServerSynchronization.waitForQueryRemoval(queryClient, query);
     }
 
     private void testStartProcessWithGlobalConfiguration(ResponseHandler responseHandler) throws Exception {
@@ -375,7 +378,7 @@ public class JmsResponseHandlerIntegrationTest extends JbpmKieServerBaseIntegrat
     }
 
     private Marshaller createMarshaller() {
-        return MarshallerFactory.getMarshaller(new HashSet<Class<?>>(extraClasses.values()),
+        return MarshallerFactory.getMarshaller(new HashSet<>(extraClasses.values()),
                 configuration.getMarshallingFormat(), client.getClassLoader());
     }
 


### PR DESCRIPTION
Here is the same fix for `master` branch as the one introduced in pull-request #655 for `6.5.x`.