### PR TITLE
[JBPM-5327,RHBPMS-4273] fix tests on JDK6 - use correct jaxb impl ver…

### DIFF
--- a/kie-server-parent/kie-server-api/pom.xml
+++ b/kie-server-parent/kie-server-api/pom.xml
@@ -72,6 +72,17 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
…sion

 * the version 2.2.11 should be used everywhere. This is the one we
   support. In case no jaxb impl is available on classpath, JDK will
   use the one available together with the JDK installation (which is
   slightly different for each JDK version). So using own version makes
   sure we always test and run against the exactly same libs