### PR TITLE
[JBPM-5327,RHBPMS-4273] use correct jaxb impl version

### DIFF
--- a/kie-server-parent/kie-server-api/pom.xml
+++ b/kie-server-parent/kie-server-api/pom.xml
@@ -84,6 +84,17 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION

 * the version 2.2.11 should be used everywhere. This is the one we
   support. In case no jaxb impl is available on classpath, JDK will
   use the one available together with the JDK installation (which is
   slightly different for each JDK version). So using own version makes
   sure we always test and run against the exactly same libs

Forward-port of #663 