### PR TITLE
Reorganize imported BOMs to avoid unnecessary dependencies

### DIFF
--- a/kie-eap-integration/pom.xml
+++ b/kie-eap-integration/pom.xml
@@ -26,6 +26,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.dashbuilder</groupId>
+        <artifactId>dashbuilder-bom</artifactId>
+        <version>${version.org.dashbuilder}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.kie</groupId>
         <artifactId>kie-eap-config</artifactId>
         <version>${version.org.kie}</version>

--- a/kie-identity-session-provider/pom.xml
+++ b/kie-identity-session-provider/pom.xml
@@ -11,6 +11,25 @@
   <artifactId>kie-identity-session-provider</artifactId>
   <name>KIE Identity And Session Provider</name>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.jboss.errai.bom</groupId>
+        <artifactId>errai-internal-bom</artifactId>
+        <version>${version.org.jboss.errai}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.uberfire</groupId>
+        <artifactId>uberfire-bom</artifactId>
+        <version>${version.org.uberfire}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.kie</groupId>
@@ -29,7 +48,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
-    
     <!-- specs -->
     <dependency>
       <groupId>javax.enterprise</groupId>

--- a/kie-server-parent/pom.xml
+++ b/kie-server-parent/pom.xml
@@ -25,4 +25,16 @@
     <module>kie-server-tests</module>
   </modules>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.dashbuilder</groupId>
+        <artifactId>dashbuilder-bom</artifactId>
+        <version>${version.org.dashbuilder}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -93,27 +93,9 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>org.uberfire</groupId>
-        <artifactId>uberfire-bom</artifactId>
-        <version>${version.org.uberfire}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.dashbuilder</groupId>
-        <artifactId>dashbuilder-bom</artifactId>
-        <version>${version.org.dashbuilder}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.errai.bom</groupId>
-        <artifactId>errai-internal-bom</artifactId>
-        <version>${version.org.jboss.errai}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
+
+
+
       <dependency>
         <groupId>org.kie</groupId>
         <artifactId>kie-karaf-itests-domain-model</artifactId>


### PR DESCRIPTION
@mbiarnes @mariofusco this should in theory fix the issues with the OSGi blueprint test failures. 