### PR TITLE
JBPM-5293 - Remove Lists of group names from 'getGroupsForUser( ... )…

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/jbpm/util/FixedUserGroupCallbackImpl.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/jbpm/util/FixedUserGroupCallbackImpl.java
@@ -33,7 +33,7 @@ public class FixedUserGroupCallbackImpl implements UserGroupCallback {
     }
 
     @Override
-    public List<String> getGroupsForUser(String s, List<String> list, List<String> list1) {
+    public List<String> getGroupsForUser(String s) {
         ArrayList<String> groups = new ArrayList<String>();
 
         // User john is assigned in group engineering


### PR DESCRIPTION
…' method signature in UserGroupCallback interface

depends on https://github.com/droolsjbpm/jbpm/pull/652

@krisv @psiroky  and the last one from this work.