### PR TITLE
PLANNER-661 PLANNER-604 Execution Server: SolverInstance.score doesn't use the ScoreJaxbXmlAdapaters?

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/jaxb/JaxbMarshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/jaxb/JaxbMarshaller.java
@@ -115,19 +115,6 @@ import org.kie.server.api.model.type.JaxbByteArray;
 import org.kie.server.api.model.type.JaxbDate;
 import org.kie.server.api.model.type.JaxbList;
 import org.kie.server.api.model.type.JaxbMap;
-import org.optaplanner.core.api.score.buildin.bendable.BendableScore;
-import org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore;
-import org.optaplanner.core.api.score.buildin.bendablelong.BendableLongScore;
-import org.optaplanner.core.api.score.buildin.hardmediumsoft.HardMediumSoftScore;
-import org.optaplanner.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScore;
-import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
-import org.optaplanner.core.api.score.buildin.hardsoftbigdecimal.HardSoftBigDecimalScore;
-import org.optaplanner.core.api.score.buildin.hardsoftdouble.HardSoftDoubleScore;
-import org.optaplanner.core.api.score.buildin.hardsoftlong.HardSoftLongScore;
-import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
-import org.optaplanner.core.api.score.buildin.simplebigdecimal.SimpleBigDecimalScore;
-import org.optaplanner.core.api.score.buildin.simpledouble.SimpleDoubleScore;
-import org.optaplanner.core.api.score.buildin.simplelong.SimpleLongScore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -243,22 +230,7 @@ public class JaxbMarshaller implements Marshaller {
                 SolverInstance.class,
                 SolverInstanceList.class,
                 Message.class,
-
-                // TODO Needed to not fail SolverInstance.score but it probably corrupts the score...
-                // See https://issues.jboss.org/browse/PLANNER-604
-                SimpleScore.class,
-                SimpleLongScore.class,
-                SimpleDoubleScore.class,
-                SimpleBigDecimalScore.class,
-                HardSoftScore.class,
-                HardSoftLongScore.class,
-                HardSoftDoubleScore.class,
-                HardSoftBigDecimalScore.class,
-                HardMediumSoftScore.class,
-                HardMediumSoftLongScore.class,
-                BendableScore.class,
-                BendableLongScore.class,
-                BendableBigDecimalScore.class,
+                ScoreWrapper.class,
 
                 // Optaplanner commands
                 CreateSolverCommand.class,

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/ServiceResponse.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/ServiceResponse.java
@@ -79,7 +79,6 @@ import org.kie.server.api.model.type.JaxbLong;
 import org.kie.server.api.model.type.JaxbMap;
 import org.kie.server.api.model.type.JaxbShort;
 import org.kie.server.api.model.type.JaxbString;
-import org.optaplanner.core.api.domain.solution.Solution;
 
 @XmlRootElement(name="response")
 @XmlAccessorType(XmlAccessType.NONE)

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/instance/ScoreWrapper.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/instance/ScoreWrapper.java
@@ -1,0 +1,65 @@
+package org.kie.server.api.model.instance;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlValue;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamConverter;
+import com.thoughtworks.xstream.converters.extended.ToAttributedValueConverter;
+import org.optaplanner.core.api.score.Score;
+import org.optaplanner.core.impl.score.ScoreUtils;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XStreamConverter(value = ToAttributedValueConverter.class, strings = { "scoreString" })
+public class ScoreWrapper {
+
+    @XmlAttribute(name = "scoreClass")
+    @XStreamAlias(value = "scoreClass")
+    private Class<? extends Score> scoreClass;
+
+    @XmlValue
+    private String scoreString;
+
+    // Define default constructor to enable class marshalling/unmarshalling
+    private ScoreWrapper() {
+    }
+
+    public ScoreWrapper( Score score ) {
+        this.scoreClass = score == null ? null : score.getClass();
+        this.scoreString = score == null ? null : score.toString();
+    }
+
+    public Class<? extends Score> getScoreClass() {
+        return scoreClass;
+    }
+
+    public String getScoreString() {
+        return scoreString;
+    }
+
+    /**
+     * Returns score representation of the object.
+     *
+     * @return Score representation of the object. Returns null if the score has not been assigned by the solver yet.
+     * @throws IllegalArgumentException If <code>scoreClass</code> is not one of the out-of-box score implementations. In this case
+     *                                       clients may implement their own way to extract the score object.
+     */
+    public Score toScore() {
+        if ( scoreClass == null ) {
+            return null;
+        }
+
+        return ScoreUtils.parseScore( scoreClass, scoreString );
+    }
+
+    @Override
+    public String toString() {
+        return "ScoreWrapper{" +
+                "scoreClass='" + scoreClass + '\'' +
+                ", scoreString='" + scoreString + '\'' +
+                '}';
+    }
+
+}

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/instance/SolverInstance.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/instance/SolverInstance.java
@@ -1,13 +1,13 @@
 package org.kie.server.api.model.instance;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamConverter;
+import com.thoughtworks.xstream.converters.extended.ToAttributedValueConverter;
 import org.drools.core.xml.jaxb.util.JaxbUnknownAdapter;
-import org.optaplanner.core.api.domain.solution.Solution;
 import org.optaplanner.core.api.score.Score;
 
 import javax.xml.bind.annotation.*;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-import java.util.Arrays;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "solver-instance")
@@ -36,19 +36,17 @@ public class SolverInstance {
 
     @XmlElement(name = "score")
     @XStreamAlias("score")
-    // TODO https://issues.jboss.org/browse/PLANNER-604 this might be corrupted during marshalling and it's not tested
-    @XmlJavaTypeAdapter(JaxbUnknownAdapter.class)
-    private Score score;
+    private ScoreWrapper scoreWrapper;
 
     @XmlElement(name = "planning-problem")
     @XStreamAlias("planning-problem")
     @XmlJavaTypeAdapter(JaxbUnknownAdapter.class)
-    private Solution planningProblem;
+    private Object planningProblem;
 
     @XmlElement(name = "best-solution")
     @XStreamAlias("best-solution")
     @XmlJavaTypeAdapter(JaxbUnknownAdapter.class)
-    private Solution bestSolution;
+    private Object bestSolution;
 
     public SolverInstance() {
     }
@@ -85,27 +83,27 @@ public class SolverInstance {
         this.status = status;
     }
 
-    public Score getScore() {
-        return score;
+    public ScoreWrapper getScoreWrapper() {
+        return scoreWrapper;
     }
 
-    public void setScore(Score score) {
-        this.score = score;
+    public void setScoreWrapper( ScoreWrapper scoreWrapper ) {
+        this.scoreWrapper = scoreWrapper;
     }
 
-    public Solution getPlanningProblem() {
+    public Object getPlanningProblem() {
         return planningProblem;
     }
 
-    public void setPlanningProblem(Solution planningProblem) {
+    public void setPlanningProblem(Object planningProblem) {
         this.planningProblem = planningProblem;
     }
 
-    public Solution getBestSolution() {
+    public Object getBestSolution() {
         return bestSolution;
     }
 
-    public void setBestSolution(Solution bestSolution) {
+    public void setBestSolution(Object bestSolution) {
         this.bestSolution = bestSolution;
     }
 
@@ -116,7 +114,7 @@ public class SolverInstance {
                ", solverId='" + solverId + '\'' +
                ", solverConfigFile='" + solverConfigFile + '\'' +
                ", status=" + status +
-               ", score=" + score +
+               ", scoreWrapper=" + scoreWrapper +
                '}';
     }
 

--- a/kie-server-parent/kie-server-services/kie-server-services-optaplanner/src/main/java/org/kie/server/services/optaplanner/SolverServiceBase.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-optaplanner/src/main/java/org/kie/server/services/optaplanner/SolverServiceBase.java
@@ -16,12 +16,13 @@
 package org.kie.server.services.optaplanner;
 
 import org.kie.server.api.model.*;
+import org.kie.server.api.model.instance.ScoreWrapper;
 import org.kie.server.api.model.instance.SolverInstance;
 import org.kie.server.api.model.instance.SolverInstanceList;
 import org.kie.server.services.api.KieContainerInstance;
 import org.kie.server.services.api.KieServerRegistry;
 import org.kie.server.services.impl.KieContainerInstanceImpl;
-import org.optaplanner.core.api.domain.solution.Solution;
+import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.solver.Solver;
 import org.optaplanner.core.api.solver.SolverFactory;
 import org.slf4j.Logger;
@@ -150,7 +151,7 @@ public class SolverServiceBase {
             SolverInstanceContext sic = solvers.get( SolverInstance.getSolverInstanceKey( containerId, solverId ) );
             if( sic != null ) {
                 updateSolverInstance( sic );
-                sic.getInstance().setBestSolution((Solution) sic.getSolver().getBestSolution() );
+                sic.getInstance().setBestSolution(sic.getSolver().getBestSolution() );
                 return new ServiceResponse<SolverInstance>(ServiceResponse.ResponseType.SUCCESS,
                                                            "Best computed solution for '" + solverId + "' successfully retrieved from container '" + containerId + "'",
                                                             sic.getInstance() );
@@ -289,8 +290,9 @@ public class SolverServiceBase {
     private  void updateSolverInstance(SolverInstanceContext sic) {
         synchronized ( sic ) {
             // We keep track of the solver status ourselves, so there's no need to call buggy updateSolverStatus( sic );
-            Solution bestSolution = (Solution) sic.getSolver().getBestSolution();
-            sic.getInstance().setScore( bestSolution != null ? bestSolution.getScore() : null );
+            Score bestScore = sic.getSolver().getBestScore();
+
+            sic.getInstance().setScoreWrapper( new ScoreWrapper( bestScore ) );
         }
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/src/main/java/org/kie/server/testing/CloudBalance.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/src/main/java/org/kie/server/testing/CloudBalance.java
@@ -23,8 +23,9 @@ import java.util.List;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
 import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningScore;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
-import org.optaplanner.core.api.domain.solution.Solution;
+import org.optaplanner.core.api.domain.solution.drools.ProblemFactCollectionProperty;
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
 import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
 import org.optaplanner.core.impl.score.buildin.hardsoft.HardSoftScoreDefinition;
@@ -39,7 +40,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 @PlanningSolution
 @XStreamAlias("CloudBalance")
 @XmlRootElement @XmlAccessorType(XmlAccessType.FIELD)
-public class CloudBalance extends AbstractPersistable implements Solution<HardSoftScore> {
+public class CloudBalance extends AbstractPersistable {
 
     private List<CloudComputer> computerList;
 
@@ -50,6 +51,7 @@ public class CloudBalance extends AbstractPersistable implements Solution<HardSo
     private HardSoftScore score;
 
     @ValueRangeProvider(id = "computerRange")
+    @ProblemFactCollectionProperty
     public List<CloudComputer> getComputerList() {
         return computerList;
     }
@@ -67,6 +69,7 @@ public class CloudBalance extends AbstractPersistable implements Solution<HardSo
         this.processList = processList;
     }
 
+    @PlanningScore
     public HardSoftScore getScore() {
         return score;
     }
@@ -78,12 +81,5 @@ public class CloudBalance extends AbstractPersistable implements Solution<HardSo
     // ************************************************************************
     // Complex methods
     // ************************************************************************
-
-    public Collection<? extends Object> getProblemFacts() {
-        List<Object> facts = new ArrayList<Object>();
-        facts.addAll(computerList);
-        // Do not add the planning entity's (processList) because that will be done automatically
-        return facts;
-    }
 
 }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/src/main/resources/META-INF/cloudbalance-solver.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/src/main/resources/META-INF/cloudbalance-solver.xml
@@ -6,7 +6,6 @@
 
   <!-- Score configuration -->
   <scoreDirectorFactory>
-    <scoreDefinitionType>HARD_SOFT</scoreDefinitionType>
     <ksessionName>cloudBalancingKsession</ksessionName> <!-- Or delete this line and set a default ksession in kmodule.xml-->
     <initializingScoreTrend>ONLY_DOWN</initializingScoreTrend>
   </scoreDirectorFactory>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/jms/OptaPlannerJmsResponseHandlerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/jms/OptaPlannerJmsResponseHandlerIntegrationTest.java
@@ -44,7 +44,6 @@ import org.kie.server.integrationtests.category.JMSOnly;
 import org.kie.server.integrationtests.optaplanner.OptaplannerKieServerBaseIntegrationTest;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 import org.kie.server.integrationtests.shared.KieServerSynchronization;
-import org.optaplanner.core.api.domain.solution.Solution;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
@@ -174,14 +173,14 @@ public class OptaPlannerJmsResponseHandlerIntegrationTest extends OptaplannerKie
         assertThat(solverList.getContainers()).isNullOrEmpty();
     }
 
-    public Solution loadPlanningProblem(int computerListSize, int processListSize) {
-        Solution problem = null;
+    public Object loadPlanningProblem(int computerListSize, int processListSize) {
+        Object problem = null;
         try {
             Class<?> cbgc = kieContainer.getClassLoader().loadClass(CLASS_CLOUD_GENERATOR);
             Object cbgi = cbgc.newInstance();
 
             Method method = cbgc.getMethod("createCloudBalance", int.class, int.class);
-            problem = (Solution) method.invoke(cbgi, computerListSize, processListSize);
+            problem = method.invoke(cbgi, computerListSize, processListSize);
         } catch (Exception e) {
             e.printStackTrace();
             fail("Exception trying to create cloud balance unsolved problem.");


### PR DESCRIPTION
Introduce ScoreWrapper to make sure the unmarshaller has enough information to convert string representation of the score into object representation.

Provide toScore() method with the support of out-of-box score implementations.

This PR also includes removal of deprecated Solution interface occurrences.

@ge0ffrey Could you please have a look at this?
