### PR TITLE
[6.5.x] kie-server-tests: remove response handler from test name

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/jms/JmsTransactionsIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/jms/JmsTransactionsIntegrationTest.java
@@ -54,7 +54,7 @@ public class JmsTransactionsIntegrationTest extends JbpmKieServerBaseIntegration
 
     private static final ReleaseId RELEASE_ID = new ReleaseId("org.kie.server.testing", "definition-project", "1.0.0.Final");
 
-    @Parameterized.Parameters(name = "{index}: {0} {2}")
+    @Parameterized.Parameters(name = "{index}: {0}")
     public static Collection<Object[]> data() {
         KieServicesConfiguration jmsConfiguration = createKieServicesJmsConfiguration();
 


### PR DESCRIPTION
Response handler doesn't implement toString() method, so it shouldn't be shown in test name.
In result it mess our internal tools which rely on test name.