### PR TITLE
[6.5.x] kie-server-tests: add solver dispose synchronization

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerSynchronization.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerSynchronization.java
@@ -178,6 +178,22 @@ public class KieServerSynchronization {
         });
     }
 
+    public static void waitForSolverDispose(final SolverServicesClient client, final String containerId, final String solverId) throws Exception {
+        waitForCondition(new WaitingCondition() {
+            @Override
+            public boolean conditionPassed() {
+                ServiceResponse<SolverInstanceList> solverListResponse = client.getSolvers(containerId);
+                SolverInstanceList solverList = solverListResponse.getResult();
+                for (SolverInstance solver : solverList.getContainers()) {
+                    if (solverId.equals(solver.getSolverId())) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        });
+    }
+
     public static void waitForSolverStatus(final SolverServicesClient client, final String containerId, final String solverId,
             final SolverInstance.SolverStatus status) throws Exception {
         waitForCondition(new WaitingCondition() {

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/jms/OptaPlannerJmsResponseHandlerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/jms/OptaPlannerJmsResponseHandlerIntegrationTest.java
@@ -165,6 +165,8 @@ public class OptaPlannerJmsResponseHandlerIntegrationTest extends OptaplannerKie
         assertThat(response);
 
         solverClient.setResponseHandler(new RequestReplyResponseHandler());
+        KieServerSynchronization.waitForSolverDispose(solverClient, CONTAINER_1_ID, SOLVER_1_ID);
+
         ServiceResponse<SolverInstanceList> solverListResponse = solverClient.getSolvers(CONTAINER_1_ID);
         assertThat(solverListResponse).isNotNull();
         SolverInstanceList solverList = solverListResponse.getResult();


### PR DESCRIPTION
To prevent synchronization issues when using FireAndForgetResponseHandler.
Test was false positive occasionally, as for example: https://kie-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/kie-all-master/job/kie-all-kie-server-matrix-master/container=wildfly10,jdk=jdk1.8,label_exp=linux%20&&%20mem4g/284/testReport/junit/org.kie.server.integrationtests.optaplanner.jms/OptaPlannerJmsResponseHandlerIntegrationTest/testSolverWithFireAndForgetResponseHandler_2__XSTREAM_/