### PR TITLE
[6.5.x] kie-server-tests: test improvement for Oracle RAC

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/BARuntimeDataServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/BARuntimeDataServiceIntegrationTest.java
@@ -114,8 +114,13 @@ public class BARuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegr
             List<TaskSummary> tasks = taskClient.findTasksAssignedAsBusinessAdministrator(USER_ADMINISTRATOR, 0, 10, "t.taskData.processInstanceId", true);
             assertNotNull(tasks);
             assertEquals(2, tasks.size());
-            assertEquals(processInstanceId, tasks.get(0).getProcessInstanceId());
-            assertEquals(processInstanceId2, tasks.get(1).getProcessInstanceId());
+            if (processInstanceId < processInstanceId2) {
+                assertEquals(processInstanceId, tasks.get(0).getProcessInstanceId());
+                assertEquals(processInstanceId2, tasks.get(1).getProcessInstanceId());
+            } else {
+                assertEquals(processInstanceId2, tasks.get(0).getProcessInstanceId());
+                assertEquals(processInstanceId, tasks.get(1).getProcessInstanceId());
+            }
 
             List<String> status = new ArrayList<String>();
             status.add(Status.Reserved.toString());
@@ -123,8 +128,13 @@ public class BARuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegr
             tasks = taskClient.findTasksAssignedAsBusinessAdministrator(USER_ADMINISTRATOR, status, 0, 10, "t.taskData.processInstanceId", false);
             assertNotNull(tasks);
             assertEquals(2, tasks.size());
-            assertEquals(processInstanceId2, tasks.get(0).getProcessInstanceId());
-            assertEquals(processInstanceId, tasks.get(1).getProcessInstanceId());
+            if (processInstanceId < processInstanceId2) {
+                assertEquals(processInstanceId2, tasks.get(0).getProcessInstanceId());
+                assertEquals(processInstanceId, tasks.get(1).getProcessInstanceId());
+            } else {
+                assertEquals(processInstanceId, tasks.get(0).getProcessInstanceId());
+                assertEquals(processInstanceId2, tasks.get(1).getProcessInstanceId());
+            }
         } finally {
             processClient.abortProcessInstance(CONTAINER_ID, processInstanceId);
             processClient.abortProcessInstance(CONTAINER_ID, processInstanceId2);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/RuntimeDataServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/RuntimeDataServiceIntegrationTest.java
@@ -16,6 +16,7 @@
 package org.kie.server.integrationtests.jbpm;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -880,12 +881,20 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
             List<ProcessInstance> returnedProcessInstances = queryClient.findProcessInstancesByCorrelationKey(partKey, 0, 10, SORT_BY_INSTANCE_PROCESS_ID, false);
             assertNotNull(returnedProcessInstances);
 
-            assertEquals(PROCESS_ID_SIGNAL_PROCESS, returnedProcessInstances.get(0).getProcessId());
-            assertEquals(processInstanceSignalId, returnedProcessInstances.get(0).getId());
-            assertEquals(secondBusinessKey, returnedProcessInstances.get(0).getCorrelationKey());
-            assertEquals(PROCESS_ID_EVALUATION, returnedProcessInstances.get(1).getProcessId());
-            assertEquals(processInstanceEvalutionId, returnedProcessInstances.get(1).getId());
-            assertEquals(firstBusinessKey, returnedProcessInstances.get(1).getCorrelationKey());
+            ProcessInstance resturnedSignalProcess, returnedEvaluation;
+            if (processInstanceEvalutionId < processInstanceSignalId) {
+                resturnedSignalProcess = returnedProcessInstances.get(0);
+                returnedEvaluation = returnedProcessInstances.get(1);
+            } else {
+                resturnedSignalProcess = returnedProcessInstances.get(1);
+                returnedEvaluation = returnedProcessInstances.get(0);
+            }
+            assertEquals(PROCESS_ID_SIGNAL_PROCESS, resturnedSignalProcess.getProcessId());
+            assertEquals(processInstanceSignalId, resturnedSignalProcess.getId());
+            assertEquals(secondBusinessKey, resturnedSignalProcess.getCorrelationKey());
+            assertEquals(PROCESS_ID_EVALUATION, returnedEvaluation.getProcessId());
+            assertEquals(processInstanceEvalutionId, returnedEvaluation.getId());
+            assertEquals(firstBusinessKey, returnedEvaluation.getCorrelationKey());
         } finally {
             processClient.abortProcessInstance(CONTAINER_ID, processInstanceEvalutionId);
             processClient.abortProcessInstance(CONTAINER_ID, processInstanceSignalId);
@@ -995,7 +1004,7 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
         }
 
         try {
-            List<ProcessInstance> instances = queryClient.findProcessInstancesByVariableAndValue("stringData", "waiting%", null, 0, 10);
+            List<ProcessInstance> instances = queryClient.findProcessInstancesByVariableAndValue("stringData", "waiting%", null, 0, 50);
             assertNotNull(instances);
             assertEquals(5, instances.size());
 
@@ -1038,7 +1047,8 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
         }
 
         try {
-            List<ProcessInstance> instances = queryClient.findProcessInstancesByVariableAndValue("stringData", "waiting%", null, 0, 3, SORT_BY_PROCESS_ID, true);
+            List status = Arrays.asList(org.kie.api.runtime.process.ProcessInstance.STATE_ACTIVE);
+            List<ProcessInstance> instances = queryClient.findProcessInstancesByVariableAndValue("stringData", "waiting%", status, 0, 3, SORT_BY_PROCESS_ID, true);
             assertNotNull(instances);
             assertEquals(3, instances.size());
             for (ProcessInstance instance : instances) {
@@ -1046,7 +1056,7 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
                 assertEquals(PROCESS_ID_SIGNAL_PROCESS, instance.getProcessId());
             }
 
-            instances = queryClient.findProcessInstancesByVariableAndValue("stringData", "waiting%", null, 1, 3, SORT_BY_PROCESS_ID, true);
+            instances = queryClient.findProcessInstancesByVariableAndValue("stringData", "waiting%", status, 1, 3, SORT_BY_PROCESS_ID, true);
             assertNotNull(instances);
             assertEquals(2, instances.size());
             for (ProcessInstance instance : instances) {
@@ -1054,7 +1064,7 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
                 assertEquals(PROCESS_ID_USERTASK, instance.getProcessId());
             }
 
-            instances = queryClient.findProcessInstancesByVariableAndValue("stringData", "waiting%", null, 0, 10, SORT_BY_PROCESS_ID, false);
+            instances = queryClient.findProcessInstancesByVariableAndValue("stringData", "waiting%", status, 0, 10, SORT_BY_PROCESS_ID, false);
             assertNotNull(instances);
             assertEquals(5, instances.size());
             for (int i = 0; i < instances.size(); i++) {
@@ -1302,13 +1312,22 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
             //latest task is from second process
             TaskSummary task = tasks.get(0);
-            TaskSummary expectedTaskSummary = createDefaultTaskSummary(processInstanceId2);
+            TaskSummary expectedTaskSummary;
+            if (processInstanceId2 > processInstanceId) {
+                expectedTaskSummary = createDefaultTaskSummary(processInstanceId2);
+            } else {
+                expectedTaskSummary = createDefaultTaskSummary(processInstanceId);
+            }
             assertTaskSummary(expectedTaskSummary, task);
 
             task = tasks.get(1);
-            expectedTaskSummary = createDefaultTaskSummary(processInstanceId);
+            expectedTaskSummary = null;
+            if (processInstanceId2 > processInstanceId) {
+                expectedTaskSummary = createDefaultTaskSummary(processInstanceId);
+            } else {
+                expectedTaskSummary = createDefaultTaskSummary(processInstanceId2);
+            }
             assertTaskSummary(expectedTaskSummary, task);
-
         } finally {
             processClient.abortProcessInstance(CONTAINER_ID, processInstanceId);
             processClient.abortProcessInstance(CONTAINER_ID, processInstanceId2);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/UserTaskServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/UserTaskServiceIntegrationTest.java
@@ -1061,13 +1061,23 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
 
             taskList = taskClient.findTasksByVariableAndValue(USER_YODA, "_string", "john is working on it", status, 0, 10, "processInstanceId", true);
             assertEquals(2, taskList.size());
-            assertEquals(processInstanceId, taskList.get(0).getProcessInstanceId());
-            assertEquals(processInstanceId2, taskList.get(1).getProcessInstanceId());
+            if (processInstanceId < processInstanceId2) {
+                assertEquals(processInstanceId, taskList.get(0).getProcessInstanceId());
+                assertEquals(processInstanceId2, taskList.get(1).getProcessInstanceId());
+            } else {
+                assertEquals(processInstanceId2, taskList.get(0).getProcessInstanceId());
+                assertEquals(processInstanceId, taskList.get(1).getProcessInstanceId());
+            }
 
             taskList = taskClient.findTasksByVariableAndValue(USER_YODA, "_string", "john is working on it", status, 0, 10, "processInstanceId", false);
             assertEquals(2, taskList.size());
-            assertEquals(processInstanceId2, taskList.get(0).getProcessInstanceId());
-            assertEquals(processInstanceId, taskList.get(1).getProcessInstanceId());
+            if (processInstanceId < processInstanceId2) {
+                assertEquals(processInstanceId2, taskList.get(0).getProcessInstanceId());
+                assertEquals(processInstanceId, taskList.get(1).getProcessInstanceId());
+            } else {
+                assertEquals(processInstanceId, taskList.get(0).getProcessInstanceId());
+                assertEquals(processInstanceId2, taskList.get(1).getProcessInstanceId());
+            }
         } finally {
             processClient.abortProcessInstance(CONTAINER_ID, processInstanceId);
             processClient.abortProcessInstance(CONTAINER_ID, processInstanceId2);


### PR DESCRIPTION
Some tests failed on Oracle RAC database due id ordering from db.