### PR TITLE
[do not merge yet] JBPM-4646: extend Case test coverage

### DIFF
--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/CaseServicesClient.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/CaseServicesClient.java
@@ -31,6 +31,15 @@ import org.kie.server.api.model.instance.ProcessInstance;
 
 public interface CaseServicesClient {
 
+    public static final String SORT_BY_CASE_DEFINITION_ID = "CaseId";
+    public static final String SORT_BY_CASE_DEFINITION_NAME = "CaseName";
+    public static final String SORT_BY_CASE_DEFINITION_DEPLOYMENT_ID = "Project";
+
+    public static final String SORT_BY_CASE_INSTANCE_ID = "CorrelationKey";
+    public static final String SORT_BY_CASE_INSTANCE_NAME = "ProcessName";
+
+    public static final String SORT_BY_PROCESS_INSTANCE_ID = "ProcessInstanceId";
+
     String startCase(String containerId, String caseDefinitionId);
 
     String startCase(String containerId, String caseDefinitionId, CaseFile caseFile);
@@ -85,7 +94,11 @@ public interface CaseServicesClient {
 
     List<ProcessInstance> getActiveProcessInstances(String containerId, String caseId, Integer page, Integer pageSize);
 
+    List<ProcessInstance> getActiveProcessInstances(String containerId, String caseId, Integer page, Integer pageSize, String sort, boolean sortOrder);
+
     List<ProcessInstance> getProcessInstances(String containerId, String caseId, List<Integer> status, Integer page, Integer pageSize);
+
+    List<ProcessInstance> getProcessInstances(String containerId, String caseId, List<Integer> status, Integer page, Integer pageSize, String sort, boolean sortOrder);
 
     void assignUserToRole(String containerId, String caseId, String roleName, String user);
 
@@ -107,17 +120,33 @@ public interface CaseServicesClient {
 
     List<CaseInstance> getCaseInstances(List<Integer> status, Integer page, Integer pageSize);
 
+    List<CaseInstance> getCaseInstances(Integer page, Integer pageSize, String sort, boolean sortOrder);
+
+    List<CaseInstance> getCaseInstances(List<Integer> status, Integer page, Integer pageSize, String sort, boolean sortOrder);
+
     List<CaseInstance> getCaseInstancesOwnedBy(String owner, List<Integer> status, Integer page, Integer pageSize);
+
+    List<CaseInstance> getCaseInstancesOwnedBy(String owner, List<Integer> status, Integer page, Integer pageSize, String sort, boolean sortOrder);
 
     List<CaseInstance> getCaseInstancesByContainer(String containerId, List<Integer> status, Integer page, Integer pageSize);
 
+    List<CaseInstance> getCaseInstancesByContainer(String containerId, List<Integer> status, Integer page, Integer pageSize, String sort, boolean sortOrder);
+
     List<CaseInstance> getCaseInstancesByDefinition(String containerId, String caseDefinitionId, List<Integer> status, Integer page, Integer pageSize);
+
+    List<CaseInstance> getCaseInstancesByDefinition(String containerId, String caseDefinitionId, List<Integer> status, Integer page, Integer pageSize, String sort, boolean sortOrder);
 
     List<CaseDefinition> getCaseDefinitionsByContainer(String containerId, Integer page, Integer pageSize);
 
-    List<CaseDefinition> getCaseDefinitions(String filter, Integer page, Integer pageSize);
+    List<CaseDefinition> getCaseDefinitionsByContainer(String containerId, Integer page, Integer pageSize, String sort, boolean sortOrder);
 
     List<CaseDefinition> getCaseDefinitions(Integer page, Integer pageSize);
+
+    List<CaseDefinition> getCaseDefinitions(String filter, Integer page, Integer pageSize);
+
+    List<CaseDefinition> getCaseDefinitions(Integer page, Integer pageSize, String sort, boolean sortOrder);
+
+    List<CaseDefinition> getCaseDefinitions(String filter, Integer page, Integer pageSize, String sort, boolean sortOrder);
 
     CaseDefinition getCaseDefinition(String containerId, String caseDefinitionId);
 }

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/AbstractKieServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/AbstractKieServicesClientImpl.java
@@ -707,6 +707,18 @@ public abstract class AbstractKieServicesClientImpl {
         return queryString.toString();
     }
 
+    protected String getSortingQueryString(String inQueryString, String sort, boolean sortOrder) {
+        StringBuilder queryString = new StringBuilder(inQueryString);
+        if (queryString.length() == 0) {
+            queryString.append("?");
+        } else {
+            queryString.append("&");
+        }
+        queryString.append("sort=" + sort).append("&sortOrder=" + sortOrder);
+
+        return queryString.toString();
+    }
+
     protected String getAdditionalParams(String inQueryString, String name, List<?> values) {
         StringBuilder queryString = new StringBuilder(inQueryString);
 

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/CaseServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/CaseServicesClientImpl.java
@@ -535,7 +535,17 @@ public class CaseServicesClientImpl extends AbstractKieServicesClientImpl implem
     }
 
     @Override
+    public List<ProcessInstance> getActiveProcessInstances(String containerId, String caseId, Integer page, Integer pageSize, String sort, boolean sortOrder) {
+        return getProcessInstances(containerId, caseId, null, page, pageSize, sort, sortOrder);
+    }
+
+    @Override
     public List<ProcessInstance> getProcessInstances(String containerId, String caseId, List<Integer> status, Integer page, Integer pageSize) {
+        return getProcessInstances(containerId, caseId, status, page, pageSize, "", true);
+    }
+
+    @Override
+    public List<ProcessInstance> getProcessInstances(String containerId, String caseId, List<Integer> status, Integer page, Integer pageSize, String sort, boolean sortOrder) {
         ProcessInstanceList list = null;
         if( config.isRest() ) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
@@ -544,13 +554,14 @@ public class CaseServicesClientImpl extends AbstractKieServicesClientImpl implem
 
             String queryString = getPagingQueryString("", page, pageSize);
             queryString = getAdditionalParams(queryString, "status", status);
+            queryString = getSortingQueryString(queryString, sort, sortOrder);
 
             list = makeHttpGetRequestAndCreateCustomResponse(
                     build(loadBalancer.getUrl(), CASE_URI + "/" + CASE_PROCESS_INSTANCES_GET_URI, valuesMap) + queryString, ProcessInstanceList.class);
 
         } else {
             CommandScript script = new CommandScript( Collections.singletonList(
-                    (KieServerCommand) new DescriptorCommand("CaseQueryService", "getProcessInstancesForCase", new Object[]{containerId, caseId, safeList(status), page, pageSize})) );
+                    (KieServerCommand) new DescriptorCommand("CaseQueryService", "getProcessInstancesForCase", new Object[]{containerId, caseId, safeList(status), page, pageSize, sort, sortOrder})) );
             ServiceResponse<ProcessInstanceList> response = (ServiceResponse<ProcessInstanceList>)
                     executeJmsCommand( script, DescriptorCommand.class.getName(), KieServerConstants.CAPABILITY_CASE ).getResponses().get(0);
 
@@ -687,24 +698,35 @@ public class CaseServicesClientImpl extends AbstractKieServicesClientImpl implem
 
     @Override
     public List<CaseInstance> getCaseInstances(Integer page, Integer pageSize) {
-        return getCaseInstances(null, page, pageSize);
+        return getCaseInstances(null, page, pageSize, "", true);
     }
 
     @Override
     public List<CaseInstance> getCaseInstances(List<Integer> status, Integer page, Integer pageSize) {
+        return getCaseInstances(status, page, pageSize, "", true);
+    }
+
+    @Override
+    public List<CaseInstance> getCaseInstances(Integer page, Integer pageSize, String sort, boolean sortOrder) {
+        return getCaseInstances(null, page, pageSize, sort, sortOrder);
+    }
+
+    @Override
+    public List<CaseInstance> getCaseInstances(List<Integer> status, Integer page, Integer pageSize, String sort, boolean sortOrder) {
         CaseInstanceList list = null;
         if( config.isRest() ) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
 
             String queryString = getPagingQueryString("", page, pageSize);
             queryString = getAdditionalParams(queryString, "status", status);
+            queryString = getSortingQueryString(queryString, sort, sortOrder);
 
             list = makeHttpGetRequestAndCreateCustomResponse(
                     build(loadBalancer.getUrl(), CASE_QUERY_URI + "/" + CASE_ALL_INSTANCES_GET_URI, valuesMap) + queryString, CaseInstanceList.class);
 
         } else {
             CommandScript script = new CommandScript( Collections.singletonList(
-                    (KieServerCommand) new DescriptorCommand("CaseQueryService", "getCaseInstances", new Object[]{safeList(status), page, pageSize})) );
+                    (KieServerCommand) new DescriptorCommand("CaseQueryService", "getCaseInstances", new Object[]{safeList(status), page, pageSize, sort, sortOrder})) );
             ServiceResponse<CaseInstanceList> response = (ServiceResponse<CaseInstanceList>)
                     executeJmsCommand( script, DescriptorCommand.class.getName(), KieServerConstants.CAPABILITY_CASE ).getResponses().get(0);
 
@@ -724,19 +746,25 @@ public class CaseServicesClientImpl extends AbstractKieServicesClientImpl implem
 
     @Override
     public List<CaseInstance> getCaseInstancesOwnedBy(String owner, List<Integer> status, Integer page, Integer pageSize) {
+        return getCaseInstancesOwnedBy(owner, status, page, pageSize, "", true);
+    }
+
+    @Override
+    public List<CaseInstance> getCaseInstancesOwnedBy(String owner, List<Integer> status, Integer page, Integer pageSize, String sort, boolean sortOrder) {
         CaseInstanceList list = null;
         if( config.isRest() ) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
 
             String queryString = getPagingQueryString("?owner="+owner, page, pageSize);
             queryString = getAdditionalParams(queryString, "status", status);
+            queryString = getSortingQueryString(queryString, sort, sortOrder);
 
             list = makeHttpGetRequestAndCreateCustomResponse(
                     build(loadBalancer.getUrl(), CASE_QUERY_URI + "/" + CASE_ALL_INSTANCES_GET_URI, valuesMap) + queryString, CaseInstanceList.class);
 
         } else {
             CommandScript script = new CommandScript( Collections.singletonList(
-                    (KieServerCommand) new DescriptorCommand("CaseQueryService", "getCaseInstancesOwnedBy", new Object[]{owner, safeList(status), page, pageSize})) );
+                    (KieServerCommand) new DescriptorCommand("CaseQueryService", "getCaseInstancesOwnedBy", new Object[]{owner, safeList(status), page, pageSize, sort, sortOrder})) );
             ServiceResponse<CaseInstanceList> response = (ServiceResponse<CaseInstanceList>)
                     executeJmsCommand( script, DescriptorCommand.class.getName(), KieServerConstants.CAPABILITY_CASE ).getResponses().get(0);
 
@@ -756,6 +784,11 @@ public class CaseServicesClientImpl extends AbstractKieServicesClientImpl implem
 
     @Override
     public List<CaseInstance> getCaseInstancesByContainer(String containerId, List<Integer> status, Integer page, Integer pageSize) {
+        return getCaseInstancesByContainer(containerId, status, page, pageSize, "", true);
+    }
+
+    @Override
+    public List<CaseInstance> getCaseInstancesByContainer(String containerId, List<Integer> status, Integer page, Integer pageSize, String sort, boolean sortOrder) {
         CaseInstanceList list = null;
         if( config.isRest() ) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
@@ -763,13 +796,14 @@ public class CaseServicesClientImpl extends AbstractKieServicesClientImpl implem
 
             String queryString = getPagingQueryString("", page, pageSize);
             queryString = getAdditionalParams(queryString, "status", status);
+            queryString = getSortingQueryString(queryString, sort, sortOrder);
 
             list = makeHttpGetRequestAndCreateCustomResponse(
                     build(loadBalancer.getUrl(), CASE_URI + "/" + CASE_INSTANCES_GET_URI, valuesMap) + queryString, CaseInstanceList.class);
 
         } else {
             CommandScript script = new CommandScript( Collections.singletonList(
-                    (KieServerCommand) new DescriptorCommand("CaseQueryService", "getCaseInstancesByContainer", new Object[]{containerId, safeList(status), page, pageSize})) );
+                    (KieServerCommand) new DescriptorCommand("CaseQueryService", "getCaseInstancesByContainer", new Object[]{containerId, safeList(status), page, pageSize, sort, sortOrder})) );
             ServiceResponse<CaseInstanceList> response = (ServiceResponse<CaseInstanceList>)
                     executeJmsCommand( script, DescriptorCommand.class.getName(), KieServerConstants.CAPABILITY_CASE ).getResponses().get(0);
 
@@ -789,6 +823,11 @@ public class CaseServicesClientImpl extends AbstractKieServicesClientImpl implem
 
     @Override
     public List<CaseInstance> getCaseInstancesByDefinition(String containerId, String caseDefinitionId, List<Integer> status, Integer page, Integer pageSize) {
+        return getCaseInstancesByDefinition(containerId, caseDefinitionId, status, page, pageSize, "", true);
+    }
+
+    @Override
+    public List<CaseInstance> getCaseInstancesByDefinition(String containerId, String caseDefinitionId, List<Integer> status, Integer page, Integer pageSize, String sort, boolean sortOrder) {
         CaseInstanceList list = null;
         if( config.isRest() ) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
@@ -797,13 +836,14 @@ public class CaseServicesClientImpl extends AbstractKieServicesClientImpl implem
 
             String queryString = getPagingQueryString("", page, pageSize);
             queryString = getAdditionalParams(queryString, "status", status);
+            queryString = getSortingQueryString(queryString, sort, sortOrder);
 
             list = makeHttpGetRequestAndCreateCustomResponse(
                     build(loadBalancer.getUrl(), CASE_URI + "/" + CASE_INSTANCES_BY_DEF_GET_URI, valuesMap) + queryString, CaseInstanceList.class);
 
         } else {
             CommandScript script = new CommandScript( Collections.singletonList(
-                    (KieServerCommand) new DescriptorCommand("CaseQueryService", "getCaseInstancesByDefinition", new Object[]{containerId, caseDefinitionId, safeList(status), page, pageSize})) );
+                    (KieServerCommand) new DescriptorCommand("CaseQueryService", "getCaseInstancesByDefinition", new Object[]{containerId, caseDefinitionId, safeList(status), page, pageSize, sort, sortOrder})) );
             ServiceResponse<CaseInstanceList> response = (ServiceResponse<CaseInstanceList>)
                     executeJmsCommand( script, DescriptorCommand.class.getName(), KieServerConstants.CAPABILITY_CASE ).getResponses().get(0);
 
@@ -823,17 +863,25 @@ public class CaseServicesClientImpl extends AbstractKieServicesClientImpl implem
 
     @Override
     public List<CaseDefinition> getCaseDefinitionsByContainer(String containerId, Integer page, Integer pageSize) {
+        return getCaseDefinitionsByContainer(containerId, page, pageSize, "", true);
+    }
+
+    @Override
+    public List<CaseDefinition> getCaseDefinitionsByContainer(String containerId, Integer page, Integer pageSize, String sort, boolean sortOrder) {
         CaseDefinitionList list = null;
         if( config.isRest() ) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
             valuesMap.put(CONTAINER_ID, containerId);
 
+            String queryString = getPagingQueryString("", page, pageSize);
+            queryString = getSortingQueryString(queryString, sort, sortOrder);
+
             list = makeHttpGetRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), CASE_URI, valuesMap), CaseDefinitionList.class);
+                    build(loadBalancer.getUrl(), CASE_URI, valuesMap) + queryString, CaseDefinitionList.class);
 
         } else {
             CommandScript script = new CommandScript( Collections.singletonList(
-                    (KieServerCommand) new DescriptorCommand("CaseQueryService", "getCaseDefinitionsByContainer", new Object[]{containerId, page, pageSize})) );
+                    (KieServerCommand) new DescriptorCommand("CaseQueryService", "getCaseDefinitionsByContainer", new Object[]{containerId, page, pageSize, sort, sortOrder})) );
             ServiceResponse<CaseDefinitionList> response = (ServiceResponse<CaseDefinitionList>)
                     executeJmsCommand( script, DescriptorCommand.class.getName(), KieServerConstants.CAPABILITY_CASE ).getResponses().get(0);
 
@@ -852,22 +900,24 @@ public class CaseServicesClientImpl extends AbstractKieServicesClientImpl implem
     }
 
     @Override
-    public List<CaseDefinition> getCaseDefinitions(String filter, Integer page, Integer pageSize) {
+    public List<CaseDefinition> getCaseDefinitions(String filter, Integer page, Integer pageSize, String sort, boolean sortOrder) {
         CaseDefinitionList list = null;
         if( config.isRest() ) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
 
-            String queryString = "";
+            String filterQueryString = "";
             if (filter != null) {
-                queryString = "?filter=" + emptyIfNull(filter);
+                filterQueryString = "?filter=" + emptyIfNull(filter);
             }
+            String queryString = getPagingQueryString(filterQueryString, page, pageSize);
+            queryString = getSortingQueryString(queryString, sort, sortOrder);
 
             list = makeHttpGetRequestAndCreateCustomResponse(
                     build(loadBalancer.getUrl(), CASE_QUERY_URI, valuesMap) + queryString, CaseDefinitionList.class);
 
         } else {
             CommandScript script = new CommandScript( Collections.singletonList(
-                    (KieServerCommand) new DescriptorCommand("CaseQueryService", "getCaseDefinitions", new Object[]{emptyIfNull(filter), page, pageSize})) );
+                    (KieServerCommand) new DescriptorCommand("CaseQueryService", "getCaseDefinitions", new Object[]{emptyIfNull(filter), page, pageSize, sort, sortOrder})) );
             ServiceResponse<CaseDefinitionList> response = (ServiceResponse<CaseDefinitionList>)
                     executeJmsCommand( script, DescriptorCommand.class.getName(), KieServerConstants.CAPABILITY_CASE ).getResponses().get(0);
 
@@ -887,7 +937,17 @@ public class CaseServicesClientImpl extends AbstractKieServicesClientImpl implem
 
     @Override
     public List<CaseDefinition> getCaseDefinitions(Integer page, Integer pageSize) {
-        return getCaseDefinitions(null, page, pageSize);
+        return getCaseDefinitions(null, page, pageSize, "", true);
+    }
+
+    @Override
+    public List<CaseDefinition> getCaseDefinitions(String filter, Integer page, Integer pageSize) {
+        return getCaseDefinitions(filter, page, pageSize, "", true);
+    }
+
+    @Override
+    public List<CaseDefinition> getCaseDefinitions(Integer page, Integer pageSize, String sort, boolean sortOrder) {
+        return getCaseDefinitions(null, page, pageSize, sort, sortOrder);
     }
 
     @Override

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-case-mgmt/src/main/java/org/kie/server/remote/rest/casemgmt/CaseQueryResource.java
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-case-mgmt/src/main/java/org/kie/server/remote/rest/casemgmt/CaseQueryResource.java
@@ -57,7 +57,8 @@ public class CaseQueryResource extends AbstractCaseResource {
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     public Response getCaseInstances(@javax.ws.rs.core.Context HttpHeaders headers,
             @QueryParam("owner") String owner, @QueryParam("status") List<Integer> status,
-            @QueryParam("page") @DefaultValue("0") Integer page, @QueryParam("pageSize") @DefaultValue("10") Integer pageSize) {
+            @QueryParam("page") @DefaultValue("0") Integer page, @QueryParam("pageSize") @DefaultValue("10") Integer pageSize,
+            @QueryParam("sort") String sort, @QueryParam("sortOrder") @DefaultValue("true") boolean sortOrder) {
 
         return invokeCaseOperation(headers,
                 "",
@@ -67,10 +68,10 @@ public class CaseQueryResource extends AbstractCaseResource {
                     CaseInstanceList responseObject = null;
                     if (owner != null && !owner.isEmpty()) {
                         logger.debug("About to look for case instances owned by {} with status {}", owner, status);
-                        responseObject = this.caseManagementRuntimeDataServiceBase.getCaseInstancesOwnedBy(owner, status, page, pageSize);
+                        responseObject = this.caseManagementRuntimeDataServiceBase.getCaseInstancesOwnedBy(owner, status, page, pageSize, sort, sortOrder);
                     } else {
                         logger.debug("About to look for case instances with status {}", status);
-                        responseObject = this.caseManagementRuntimeDataServiceBase.getCaseInstances(status, page, pageSize);
+                        responseObject = this.caseManagementRuntimeDataServiceBase.getCaseInstances(status, page, pageSize, sort, sortOrder);
                     }
 
                     logger.debug("Returning OK response with content '{}'", responseObject);
@@ -85,7 +86,8 @@ public class CaseQueryResource extends AbstractCaseResource {
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     public Response getCaseDefinitions(@javax.ws.rs.core.Context HttpHeaders headers,
             @QueryParam("filter") String filter,
-            @QueryParam("page") @DefaultValue("0") Integer page, @QueryParam("pageSize") @DefaultValue("10") Integer pageSize) {
+            @QueryParam("page") @DefaultValue("0") Integer page, @QueryParam("pageSize") @DefaultValue("10") Integer pageSize,
+            @QueryParam("sort") String sort, @QueryParam("sortOrder") @DefaultValue("true") boolean sortOrder) {
 
         return invokeCaseOperation(headers,
                 "",
@@ -93,7 +95,7 @@ public class CaseQueryResource extends AbstractCaseResource {
                 (Variant v, String type, Header... customHeaders) -> {
 
                     logger.debug("About to look for case definitions with filter {}", filter);
-                    CaseDefinitionList responseObject = this.caseManagementRuntimeDataServiceBase.getCaseDefinitions(filter, page, pageSize);
+                    CaseDefinitionList responseObject = this.caseManagementRuntimeDataServiceBase.getCaseDefinitions(filter, page, pageSize, sort, sortOrder);
 
                     logger.debug("Returning OK response with content '{}'", responseObject);
                     return createCorrectVariant(responseObject, headers, Response.Status.OK, customHeaders);

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-case-mgmt/src/test/java/org/kie/server/remote/rest/casemgmt/CaseQueryResourceTest.java
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-case-mgmt/src/test/java/org/kie/server/remote/rest/casemgmt/CaseQueryResourceTest.java
@@ -60,12 +60,14 @@ public class CaseQueryResourceTest {
         String filter = null;
         Integer page = 0;
         Integer pageSize= 10;
-        when(runtimeDataService.getCaseDefinitions(filter, page, pageSize)).thenReturn(new CaseDefinitionList());
+        String sort = "CaseId";
+        boolean sortOrder = true;
+        when(runtimeDataService.getCaseDefinitions(filter, page, pageSize, sort, sortOrder)).thenReturn(new CaseDefinitionList());
 
-        caseQueryResource.getCaseDefinitions(httpHeaders, filter, page, pageSize);
+        caseQueryResource.getCaseDefinitions(httpHeaders, filter, page, pageSize, sort, sortOrder);
 
         verify(kieServerRegistry).getContainer("");
-        verify(runtimeDataService).getCaseDefinitions(filter, page, pageSize);
+        verify(runtimeDataService).getCaseDefinitions(filter, page, pageSize, sort, sortOrder);
     }
 
     @Test
@@ -73,12 +75,14 @@ public class CaseQueryResourceTest {
         List<Integer> status = null;
         Integer page = 0;
         Integer pageSize= 10;
-        when(runtimeDataService.getCaseInstances(status, page, pageSize)).thenReturn(new CaseInstanceList());
+        String sort = "CorrelationKey";
+        boolean sortOrder = true;
+        when(runtimeDataService.getCaseInstances(status, page, pageSize, sort, sortOrder)).thenReturn(new CaseInstanceList());
 
-        caseQueryResource.getCaseInstances(httpHeaders, null, status, page, pageSize);
+        caseQueryResource.getCaseInstances(httpHeaders, null, status, page, pageSize, sort, sortOrder);
 
         verify(kieServerRegistry).getContainer("");
-        verify(runtimeDataService).getCaseInstances(status, page, pageSize);
+        verify(runtimeDataService).getCaseInstances(status, page, pageSize, sort, sortOrder);
     }
 
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-case-mgmt/src/main/java/org/kie/server/services/casemgmt/CaseManagementRuntimeDataServiceBase.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-case-mgmt/src/main/java/org/kie/server/services/casemgmt/CaseManagementRuntimeDataServiceBase.java
@@ -27,7 +27,6 @@ import org.jbpm.casemgmt.api.model.instance.CaseStageInstance;
 import org.jbpm.services.api.model.NodeInstanceDesc;
 import org.jbpm.services.api.model.ProcessInstanceDesc;
 import org.kie.internal.identity.IdentityProvider;
-import org.kie.internal.query.QueryContext;
 import org.kie.server.api.KieServerConstants;
 import org.kie.server.api.model.cases.CaseAdHocFragment;
 import org.kie.server.api.model.cases.CaseAdHocFragmentList;
@@ -113,9 +112,11 @@ public class CaseManagementRuntimeDataServiceBase {
         return activeNodesList;
     }
 
-    public ProcessInstanceList getProcessInstancesForCase(String containerId, String caseId, List<Integer> status, Integer page, Integer pageSize) {
+    public ProcessInstanceList getProcessInstancesForCase(String containerId, String caseId, List<Integer> status, Integer page, Integer pageSize, String sort, boolean sortOrder) {
         status = safeStatus(status);
-        Collection<ProcessInstanceDesc> processInstanceDescs = caseRuntimeDataService.getProcessInstancesForCase(caseId, status, ConvertUtils.buildQueryContext(page, pageSize));
+        sort = safeProcessInstanceSort(sort);
+
+        Collection<ProcessInstanceDesc> processInstanceDescs = caseRuntimeDataService.getProcessInstancesForCase(caseId, status, ConvertUtils.buildQueryContext(page, pageSize, sort, sortOrder));
 
         List<ProcessInstance> processInstances = ConvertUtils.transformProcessInstance(processInstanceDescs);
 
@@ -124,9 +125,11 @@ public class CaseManagementRuntimeDataServiceBase {
         return processInstancesList;
     }
 
-    public CaseInstanceList getCaseInstancesByContainer(String containerId, List<Integer> status, Integer page, Integer pageSize) {
+    public CaseInstanceList getCaseInstancesByContainer(String containerId, List<Integer> status, Integer page, Integer pageSize, String sort, boolean sortOrder) {
         status = safeStatus(status);
-        Collection<org.jbpm.casemgmt.api.model.instance.CaseInstance> caseInstanceDescs = caseRuntimeDataService.getCaseInstancesByDeployment(containerId, status, ConvertUtils.buildQueryContext(page, pageSize));
+        sort = safeCaseInstanceSort(sort);
+
+        Collection<org.jbpm.casemgmt.api.model.instance.CaseInstance> caseInstanceDescs = caseRuntimeDataService.getCaseInstancesByDeployment(containerId, status, ConvertUtils.buildQueryContext(page, pageSize, sort, sortOrder));
 
         List<CaseInstance> caseInstances = ConvertUtils.transformCaseInstances(caseInstanceDescs);
 
@@ -135,9 +138,11 @@ public class CaseManagementRuntimeDataServiceBase {
         return caseInstancesList;
     }
 
-    public CaseInstanceList getCaseInstancesByDefinition(String containerId, String caseDefinitionId, List<Integer> status, Integer page, Integer pageSize) {
+    public CaseInstanceList getCaseInstancesByDefinition(String containerId, String caseDefinitionId, List<Integer> status, Integer page, Integer pageSize, String sort, boolean sortOrder) {
+        status = safeStatus(status);
+        sort = safeCaseInstanceSort(sort);
 
-        Collection<org.jbpm.casemgmt.api.model.instance.CaseInstance> caseInstanceDescs = caseRuntimeDataService.getCaseInstancesByDefinition(caseDefinitionId,  status, ConvertUtils.buildQueryContext(page, pageSize));
+        Collection<org.jbpm.casemgmt.api.model.instance.CaseInstance> caseInstanceDescs = caseRuntimeDataService.getCaseInstancesByDefinition(caseDefinitionId,  status, ConvertUtils.buildQueryContext(page, pageSize, sort, sortOrder));
 
         List<CaseInstance> caseInstances = ConvertUtils.transformCaseInstances(caseInstanceDescs);
 
@@ -146,10 +151,12 @@ public class CaseManagementRuntimeDataServiceBase {
         return caseInstancesList;
     }
 
-    public CaseInstanceList getCaseInstancesOwnedBy(String owner, List<Integer> status, Integer page, Integer pageSize) {
+    public CaseInstanceList getCaseInstancesOwnedBy(String owner, List<Integer> status, Integer page, Integer pageSize, String sort, boolean sortOrder) {
         status = safeStatus(status);
         owner = getUser(owner);
-        Collection<org.jbpm.casemgmt.api.model.instance.CaseInstance> caseInstanceDescs = caseRuntimeDataService.getCaseInstancesOwnedBy(owner, status, ConvertUtils.buildQueryContext(page, pageSize));
+        sort = safeCaseInstanceSort(sort);
+
+        Collection<org.jbpm.casemgmt.api.model.instance.CaseInstance> caseInstanceDescs = caseRuntimeDataService.getCaseInstancesOwnedBy(owner, status, ConvertUtils.buildQueryContext(page, pageSize, sort, sortOrder));
 
         List<CaseInstance> caseInstances = ConvertUtils.transformCaseInstances(caseInstanceDescs);
 
@@ -158,9 +165,11 @@ public class CaseManagementRuntimeDataServiceBase {
         return caseInstancesList;
     }
 
-    public CaseInstanceList getCaseInstances(List<Integer> status, Integer page, Integer pageSize) {
+    public CaseInstanceList getCaseInstances(List<Integer> status, Integer page, Integer pageSize, String sort, boolean sortOrder) {
         status = safeStatus(status);
-        Collection<org.jbpm.casemgmt.api.model.instance.CaseInstance> caseInstanceDescs = caseRuntimeDataService.getCaseInstances(status, ConvertUtils.buildQueryContext(page, pageSize));
+        sort = safeCaseInstanceSort(sort);
+
+        Collection<org.jbpm.casemgmt.api.model.instance.CaseInstance> caseInstanceDescs = caseRuntimeDataService.getCaseInstances(status, ConvertUtils.buildQueryContext(page, pageSize, sort, sortOrder));
 
         List<CaseInstance> caseInstances = ConvertUtils.transformCaseInstances(caseInstanceDescs);
 
@@ -169,9 +178,10 @@ public class CaseManagementRuntimeDataServiceBase {
         return caseInstancesList;
     }
 
-    public CaseDefinitionList getCaseDefinitionsByContainer(String containerId, Integer page, Integer pageSize) {
+    public CaseDefinitionList getCaseDefinitionsByContainer(String containerId, Integer page, Integer pageSize, String sort, boolean sortOrder) {
+        sort = safeCaseDefinitionSort(sort);
 
-        Collection<CaseDefinition> caseDescs = caseRuntimeDataService.getCasesByDeployment(containerId, ConvertUtils.buildQueryContext(page, pageSize));
+        Collection<CaseDefinition> caseDescs = caseRuntimeDataService.getCasesByDeployment(containerId, ConvertUtils.buildQueryContext(page, pageSize, sort, sortOrder));
 
         List<org.kie.server.api.model.cases.CaseDefinition> cases = ConvertUtils.transformCases(caseDescs);
 
@@ -180,13 +190,15 @@ public class CaseManagementRuntimeDataServiceBase {
         return caseList;
     }
 
-    public CaseDefinitionList getCaseDefinitions(String filter, Integer page, Integer pageSize) {
+    public CaseDefinitionList getCaseDefinitions(String filter, Integer page, Integer pageSize, String sort, boolean sortOrder) {
 
         Collection<CaseDefinition> caseDescs = null;
+        sort = safeCaseDefinitionSort(sort);
+
         if (filter != null && !filter.isEmpty()) {
-            caseDescs = caseRuntimeDataService.getCases(filter, ConvertUtils.buildQueryContext(page, pageSize));
+            caseDescs = caseRuntimeDataService.getCases(filter, ConvertUtils.buildQueryContext(page, pageSize, sort, sortOrder));
         } else {
-            caseDescs = caseRuntimeDataService.getCases(ConvertUtils.buildQueryContext(page, pageSize));
+            caseDescs = caseRuntimeDataService.getCases(ConvertUtils.buildQueryContext(page, pageSize, sort, sortOrder));
         }
 
         List<org.kie.server.api.model.cases.CaseDefinition> cases = ConvertUtils.transformCases(caseDescs);
@@ -199,6 +211,11 @@ public class CaseManagementRuntimeDataServiceBase {
     public org.kie.server.api.model.cases.CaseDefinition getCaseDefinition(String containerId, String caseDefinitionId) {
 
         CaseDefinition caseDef = caseRuntimeDataService.getCase(containerId, caseDefinitionId);
+
+        // TODO: Inspired by DefinitionServiceBase.findProcessDefinition(), delete comment after approving.
+        if (caseDef == null) {
+            throw new IllegalStateException("Case definition " + containerId + " : " + caseDefinitionId + " not found");
+        }
 
         org.kie.server.api.model.cases.CaseDefinition caseDefinition = ConvertUtils.transformCase(caseDef);
 
@@ -213,5 +230,32 @@ public class CaseManagementRuntimeDataServiceBase {
         }
 
         return actualStatus;
+    }
+
+    protected String safeCaseInstanceSort(String sort) {
+        String actualSort = sort;
+        if (sort == null || sort.isEmpty()) {
+            actualSort = "CorrelationKey";
+        }
+
+        return actualSort;
+    }
+
+    protected String safeCaseDefinitionSort(String sort) {
+        String actualSort = sort;
+        if (sort == null || sort.isEmpty()) {
+            actualSort = "CaseId";
+        }
+
+        return actualSort;
+    }
+
+    protected String safeProcessInstanceSort(String sort) {
+        String actualSort = sort;
+        if (sort == null || sort.isEmpty()) {
+            actualSort = "ProcessInstanceId";
+        }
+
+        return actualSort;
     }
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-case-mgmt/src/main/java/org/kie/server/services/casemgmt/ConvertUtils.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-case-mgmt/src/main/java/org/kie/server/services/casemgmt/ConvertUtils.java
@@ -162,6 +162,14 @@ public class ConvertUtils {
         return new QueryContext(page * pageSize, pageSize);
     }
 
+    public static QueryContext buildQueryContext(Integer page, Integer pageSize, String orderBy, boolean asc) {
+        if (orderBy != null && !orderBy.isEmpty()) {
+            return new QueryContext(page * pageSize, pageSize, orderBy, asc);
+        }
+
+        return new QueryContext(page * pageSize, pageSize);
+    }
+
     public static List<ProcessInstance> transformProcessInstance(Collection<ProcessInstanceDesc> processInstanceDescs) {
         if (processInstanceDescs == null) {
             return Collections.emptyList();

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/cases/CaseRuntimeDataServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/cases/CaseRuntimeDataServiceIntegrationTest.java
@@ -21,12 +21,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kie.api.KieServices;
 import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.task.model.Status;
 import org.kie.server.api.model.ReleaseId;
+import org.kie.server.api.model.cases.CaseAdHocFragment;
 import org.kie.server.api.model.cases.CaseComment;
 import org.kie.server.api.model.cases.CaseDefinition;
 import org.kie.server.api.model.cases.CaseFile;
@@ -36,6 +38,9 @@ import org.kie.server.api.model.cases.CaseRoleAssignment;
 import org.kie.server.api.model.cases.CaseStage;
 import org.kie.server.api.model.instance.NodeInstance;
 import org.kie.server.api.model.instance.TaskSummary;
+import org.kie.server.client.CaseServicesClient;
+import org.kie.server.client.KieServicesException;
+import org.kie.server.integrationtests.config.TestConfig;
 import org.kie.server.integrationtests.jbpm.JbpmKieServerBaseIntegrationTest;
 import org.kie.server.integrationtests.shared.KieServerAssert;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
@@ -49,22 +54,30 @@ public class CaseRuntimeDataServiceIntegrationTest extends JbpmKieServerBaseInte
             "1.0.0.Final");
 
     private static final String CONTAINER_ID = "insurance";
+    private static final String CONTAINER_ID2 = "insurance-second";
     private static final String PROPERTY_DAMAGE_REPORT_CLASS_NAME = "org.kie.server.testing.PropertyDamageReport";
     private static final String CLAIM_REPORT_CLASS_NAME = "org.kie.server.testing.ClaimReport";
 
-    private static final String CASE_DEF_ID = "UserTaskCase";
-    private static final String CLAIM_CASE_DEF_ID = "insurance-claims.CarInsuranceClaimCase";
-
     private static final String CASE_OWNER_ROLE = "owner";
     private static final String CASE_CONTACT_ROLE = "contact";
-
-    private static final String CASE_ID_PREFIX = "HR";
 
     private static final String CASE_INSURED_ROLE = "insured";
     private static final String CASE_INS_REP_ROLE = "insuranceRepresentative";
     private static final String CASE_ASSESSOR_ROLE = "assessor";
 
     private static final String CLAIM_CASE_ID_PREFIX = "CAR_INS";
+    private static final String CLAIM_CASE_DEF_ID = "insurance-claims.CarInsuranceClaimCase";
+    private static final String CLAIM_CASE_DESRIPTION = "CarInsuranceClaimCase";
+    private static final String CLAIM_CASE_NAME = "CarInsuranceClaimCase";
+    private static final String CLAIM_CASE_VERSION = "1.0";
+
+    private static final String CASE_HR_ID_PREFIX = "HR";
+    private static final String CASE_HR_DEF_ID = "UserTaskCase";
+    private static final String CASE_HR_DESRIPTION = "Case first case started";
+    private static final String CASE_HR_NAME = "Simple Case with User Tasks";
+    private static final String CASE_HR_VERSION = "1.0";
+
+    private static final String DATA_VERIFICATION_DEF_ID = "DataVerification";
 
     @BeforeClass
     public static void buildAndDeployArtifacts() {
@@ -84,344 +97,1238 @@ public class CaseRuntimeDataServiceIntegrationTest extends JbpmKieServerBaseInte
     }
 
     @Test
-    public void testListCaseDefinitions() {
+    public void testGetCaseDefinitionsByNotExistingContainer() {
+        List<CaseDefinition> definitions = caseClient.getCaseDefinitionsByContainer("not-existing-container", 0, 10);
+        assertNotNull(definitions);
+        assertEquals(0, definitions.size());
+    }
+
+    @Test
+    public void testGetCaseDefinitionsByContainer() {
         List<CaseDefinition> definitions = caseClient.getCaseDefinitionsByContainer(CONTAINER_ID, 0, 10);
         assertNotNull(definitions);
         assertEquals(2, definitions.size());
 
-        Map<String, CaseDefinition> mappedDefinitions = definitions.stream().collect(Collectors.toMap(CaseDefinition::getIdentifier, d -> d));
-        assertTrue(mappedDefinitions.containsKey(CASE_DEF_ID));
-        assertTrue(mappedDefinitions.containsKey(CLAIM_CASE_DEF_ID));
+        List<String> mappedDefinitions = definitions.stream().map(CaseDefinition::getIdentifier).collect(Collectors.toList());
+        assertTrue(mappedDefinitions.contains(CASE_HR_DEF_ID));
+        assertTrue(mappedDefinitions.contains(CLAIM_CASE_DEF_ID));
 
-        CaseDefinition hrCase = caseClient.getCaseDefinition(CONTAINER_ID, CASE_DEF_ID);
-        assertNotNull(hrCase);
-        assertEquals(CASE_DEF_ID, hrCase.getIdentifier());
-        assertEquals("Simple Case with User Tasks", hrCase.getName());
-        assertEquals("HR", hrCase.getCaseIdPrefix());
-        assertEquals("1.0", hrCase.getVersion());
-        assertEquals(3, hrCase.getAdHocFragments().size());
-        KieServerAssert.assertNullOrEmpty("Stages should be empty", hrCase.getCaseStages());
-        assertEquals(2, hrCase.getMilestones().size());
-        assertEquals(3, hrCase.getRoles().size());
-        assertEquals(CONTAINER_ID, hrCase.getContainerId());
-
-        definitions = caseClient.getCaseDefinitions("User*", 0, 10);
+        definitions = caseClient.getCaseDefinitionsByContainer(CONTAINER_ID, 0, 1);
         assertNotNull(definitions);
         assertEquals(1, definitions.size());
+        assertHrCaseDefinition(definitions.get(0));
 
-        definitions = caseClient.getCaseDefinitions(0, 10);
+        definitions = caseClient.getCaseDefinitionsByContainer(CONTAINER_ID, 1, 1);
+        assertNotNull(definitions);
+        assertEquals(1, definitions.size());
+        assertCarInsuranceCaseDefinition(definitions.get(0));
+    }
+
+    @Test
+    public void testGetCaseDefinitionsByContainerSorting() {
+        List<CaseDefinition> definitions = caseClient.getCaseDefinitionsByContainer(CONTAINER_ID, 0, 1, CaseServicesClient.SORT_BY_CASE_DEFINITION_ID, true);
+        assertNotNull(definitions);
+        assertEquals(1, definitions.size());
+        assertHrCaseDefinition(definitions.get(0));
+
+        definitions = caseClient.getCaseDefinitionsByContainer(CONTAINER_ID, 1, 1, CaseServicesClient.SORT_BY_CASE_DEFINITION_ID, true);
+        assertNotNull(definitions);
+        assertEquals(1, definitions.size());
+        assertCarInsuranceCaseDefinition(definitions.get(0));
+
+        definitions = caseClient.getCaseDefinitionsByContainer(CONTAINER_ID, 0, 10, CaseServicesClient.SORT_BY_CASE_DEFINITION_ID, false);
         assertNotNull(definitions);
         assertEquals(2, definitions.size());
+        assertCarInsuranceCaseDefinition(definitions.get(0));
+        assertHrCaseDefinition(definitions.get(1));
+    }
+
+    @Test
+    public void testGetCaseDefinitionNotExistingContainer() {
+        try {
+            caseClient.getCaseDefinition("not-existing-container", CASE_HR_DEF_ID);
+            fail("Should have failed because of not existing container.");
+        } catch (KieServicesException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testGetCaseDefinitionNotExistingCase() {
+        try {
+            caseClient.getCaseDefinition(CONTAINER_ID, "not-existing-case");
+            fail("Should have failed because of not existing case definition Id.");
+        } catch (KieServicesException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testGetCaseDefinition() {
+        CaseDefinition hrCase = caseClient.getCaseDefinition(CONTAINER_ID, CASE_HR_DEF_ID);
+        assertHrCaseDefinition(hrCase);
+    }
+
+    @Test
+    public void testGetCaseDefinitions() {
+        List<CaseDefinition> definitions = caseClient.getCaseDefinitions(0, 10);
+        assertNotNull(definitions);
+        assertEquals(2, definitions.size());
+
+        List<String> mappedDefinitions = definitions.stream().map(CaseDefinition::getIdentifier).collect(Collectors.toList());
+        assertTrue(mappedDefinitions.contains(CASE_HR_DEF_ID));
+        assertTrue(mappedDefinitions.contains(CLAIM_CASE_DEF_ID));
+
+        definitions = caseClient.getCaseDefinitions(0, 1);
+        assertNotNull(definitions);
+        assertEquals(1, definitions.size());
+        assertHrCaseDefinition(definitions.get(0));
+
+        definitions = caseClient.getCaseDefinitions(1, 1);
+        assertNotNull(definitions);
+        assertEquals(1, definitions.size());
+        assertCarInsuranceCaseDefinition(definitions.get(0));
+    }
+
+    @Test
+    public void testGetCaseDefinitionsSorting() {
+        List<CaseDefinition> definitions = caseClient.getCaseDefinitions(0, 1, CaseServicesClient.SORT_BY_CASE_DEFINITION_ID, true);
+        assertNotNull(definitions);
+        assertEquals(1, definitions.size());
+        assertHrCaseDefinition(definitions.get(0));
+
+        definitions = caseClient.getCaseDefinitions(1, 1, CaseServicesClient.SORT_BY_CASE_DEFINITION_ID, true);
+        assertNotNull(definitions);
+        assertEquals(1, definitions.size());
+        assertCarInsuranceCaseDefinition(definitions.get(0));
+
+        definitions = caseClient.getCaseDefinitions(0, 10, CaseServicesClient.SORT_BY_CASE_DEFINITION_ID, false);
+        assertNotNull(definitions);
+        assertEquals(2, definitions.size());
+        assertCarInsuranceCaseDefinition(definitions.get(0));
+        assertHrCaseDefinition(definitions.get(1));
+    }
+
+    @Test
+    public void testGetCaseDefinitionsSortingByCaseName() {
+        List<CaseDefinition> definitions = caseClient.getCaseDefinitions(0, 10, CaseServicesClient.SORT_BY_CASE_DEFINITION_NAME, true);
+        assertNotNull(definitions);
+        assertEquals(2, definitions.size());
+        assertCarInsuranceCaseDefinition(definitions.get(0));
+        assertHrCaseDefinition(definitions.get(1));
+    }
+
+    @Test
+    public void testGetCaseDefinitionsSortingByDeploymentId() {
+        createContainer(CONTAINER_ID2, releaseId);
+
+        List<CaseDefinition> definitions = caseClient.getCaseDefinitions(0, 10, CaseServicesClient.SORT_BY_CASE_DEFINITION_DEPLOYMENT_ID, true);
+        assertNotNull(definitions);
+        assertEquals(4, definitions.size());
+        assertEquals(definitions.get(0).getContainerId(), CONTAINER_ID);
+        assertEquals(definitions.get(1).getContainerId(), CONTAINER_ID);
+        assertEquals(definitions.get(2).getContainerId(), CONTAINER_ID2);
+        assertEquals(definitions.get(3).getContainerId(), CONTAINER_ID2);
+
+        KieServerAssert.assertSuccess(client.disposeContainer(CONTAINER_ID2));
+    }
+
+    @Test
+    public void testGetCaseDefinitionsWithFilter() {
+        List<CaseDefinition> definitions = caseClient.getCaseDefinitions("User", 0, 10);
+        assertNotNull(definitions);
+        assertEquals(1, definitions.size());
+        assertHrCaseDefinition(definitions.get(0));
+
+        definitions = caseClient.getCaseDefinitions("User", 1, 10);
+        assertNotNull(definitions);
+        assertEquals(0, definitions.size());
+    }
+
+    @Test
+    public void testGetCaseDefinitionsWithFilterSorting() {
+        List<CaseDefinition> definitions = caseClient.getCaseDefinitions("Case", 0, 1, CaseServicesClient.SORT_BY_CASE_DEFINITION_ID, true);
+        assertNotNull(definitions);
+        assertEquals(1, definitions.size());
+        assertHrCaseDefinition(definitions.get(0));
+
+        definitions = caseClient.getCaseDefinitions("Case", 1, 1, CaseServicesClient.SORT_BY_CASE_DEFINITION_ID, true);
+        assertNotNull(definitions);
+        assertEquals(1, definitions.size());
+        assertCarInsuranceCaseDefinition(definitions.get(0));
+
+        definitions = caseClient.getCaseDefinitions("Case", 0, 10, CaseServicesClient.SORT_BY_CASE_DEFINITION_ID, false);
+        assertNotNull(definitions);
+        assertEquals(2, definitions.size());
+        assertCarInsuranceCaseDefinition(definitions.get(0));
+        assertHrCaseDefinition(definitions.get(1));
+    }
+
+    @Test
+    public void testGetCaseInstanceNotExistingContainer() {
+        try {
+            caseClient.getCaseInstance("not-existing-container", CASE_HR_DEF_ID);
+            fail("Should have failed because of not existing container.");
+        } catch (KieServicesException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testGetCaseInstanceNotExistingCase() {
+        try {
+            caseClient.getCaseInstance(CONTAINER_ID, "not-existing-case");
+            fail("Should have failed because of not existing case definition Id.");
+        } catch (KieServicesException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testGetCaseInstance() {
+        String caseId = startUserTaskCase(USER_YODA, USER_JOHN);
+
+        CaseInstance caseInstance = caseClient.getCaseInstance(CONTAINER_ID, caseId);
+        assertHrCaseInstance(caseInstance, caseId, USER_YODA);
+        assertNull(caseInstance.getCaseFile());
+        assertNull(caseInstance.getRoleAssignments());
+        assertNull(caseInstance.getMilestones());
+        assertNull(caseInstance.getStages());
+    }
+
+    @Test
+    public void testGetCaseInstanceUserTaskCaseWithData() {
+        String caseId = startUserTaskCase(USER_YODA, USER_JOHN);
+
+        caseClient.triggerAdHocFragment(CONTAINER_ID, caseId, "Milestone1", null);
+
+        CaseInstance caseInstance = caseClient.getCaseInstance(CONTAINER_ID, caseId, true, true, true, true);
+        assertHrCaseInstance(caseInstance, caseId, USER_YODA);
+
+        KieServerAssert.assertNullOrEmpty("Stages should be empty.", caseInstance.getStages());
+
+        // Assert case file
+        assertNotNull(caseInstance.getCaseFile());
+        assertEquals("first case started", caseInstance.getCaseFile().getData().get("s"));
+
+        // Assert role assignments
+        assertNotNull(caseInstance.getRoleAssignments());
+        assertEquals(3, caseInstance.getRoleAssignments().size());
+
+        CaseRoleAssignment ownerRole = caseInstance.getRoleAssignments().get(0);
+        assertEquals("owner", ownerRole.getName());
+        assertEquals(1, ownerRole.getUsers().size());
+        assertEquals(USER_YODA, ownerRole.getUsers().get(0));
+        KieServerAssert.assertNullOrEmpty("Groups should be empty.", ownerRole.getGroups());
+
+        CaseRoleAssignment contactRole = caseInstance.getRoleAssignments().get(1);
+        assertEquals("contact", contactRole.getName());
+        assertEquals(1, contactRole.getUsers().size());
+        assertEquals(USER_JOHN, contactRole.getUsers().get(0));
+        KieServerAssert.assertNullOrEmpty("Groups should be empty.", contactRole.getGroups());
+
+        CaseRoleAssignment participantRole = caseInstance.getRoleAssignments().get(2);
+        assertEquals("participant", participantRole.getName());
+        KieServerAssert.assertNullOrEmpty("Users should be empty.", participantRole.getUsers());
+        KieServerAssert.assertNullOrEmpty("Groups should be empty.", participantRole.getGroups());
+
+        // Assert milestones
+        assertNotNull(caseInstance.getMilestones());
+        assertEquals(1, caseInstance.getMilestones().size());
+
+        CaseMilestone milestone = caseInstance.getMilestones().get(0);
+        assertEquals("2", milestone.getIdentifier());
+        assertEquals("Milestone1", milestone.getName());
+        assertEquals("Completed", milestone.getStatus());
+        assertNotNull(milestone.getAchievedAt());
+        assertTrue(milestone.isAchieved());
+    }
+
+    @Test
+    public void testGetCaseInstanceCarInsuranceClaimCaseWithData() {
+        String caseId = startCarInsuranceClaimCase(USER_YODA, USER_JOHN);
+
+        CaseInstance caseInstance = caseClient.getCaseInstance(CONTAINER_ID, caseId, true, true, true, true);
+        assertCarInsuranceCaseInstance(caseInstance, caseId, USER_YODA);
+
+        KieServerAssert.assertNullOrEmpty("Milestones should be empty.", caseInstance.getMilestones());
+
+        // Assert case file
+        assertNotNull(caseInstance.getCaseFile());
+        assertEquals("first case started", caseInstance.getCaseFile().getData().get("s"));
+
+        // Assert role assignments
+        assertNotNull(caseInstance.getRoleAssignments());
+        assertEquals(3, caseInstance.getRoleAssignments().size());
+
+        CaseRoleAssignment insuredRole = caseInstance.getRoleAssignments().get(0);
+        assertEquals("insured", insuredRole.getName());
+        assertEquals(1, insuredRole.getUsers().size());
+        assertEquals(USER_YODA, insuredRole.getUsers().get(0));
+        KieServerAssert.assertNullOrEmpty("Groups should be empty.", insuredRole.getGroups());
+
+        CaseRoleAssignment assessorRole = caseInstance.getRoleAssignments().get(1);
+        assertEquals("assessor", assessorRole.getName());
+        KieServerAssert.assertNullOrEmpty("Users should be empty.", assessorRole.getUsers());
+        KieServerAssert.assertNullOrEmpty("Groups should be empty.", assessorRole.getGroups());
+
+        CaseRoleAssignment insuranceRepresentativeRole = caseInstance.getRoleAssignments().get(2);
+        assertEquals("insuranceRepresentative", insuranceRepresentativeRole.getName());
+        assertEquals(1, insuranceRepresentativeRole.getUsers().size());
+        assertEquals(USER_JOHN, insuranceRepresentativeRole.getUsers().get(0));
+        KieServerAssert.assertNullOrEmpty("Groups should be empty.", insuranceRepresentativeRole.getGroups());
+
+        // Assert stages
+        assertNotNull(caseInstance.getStages());
+        assertEquals(1, caseInstance.getStages().size());
+
+        CaseStage stage = caseInstance.getStages().get(0);
+        assertNotNull(stage.getIdentifier());
+        assertEquals("Build claim report", stage.getName());
+        assertEquals("Active", stage.getStatus());
+        KieServerAssert.assertNullOrEmpty("Active nodes should be empty.", stage.getActiveNodes());
+        assertEquals(2, stage.getAdHocFragments().size());
+    }
+
+    @Test
+    public void testGetCaseInstances() {
+        List<CaseInstance> caseInstances = caseClient.getCaseInstances(0, 10);
+        assertNotNull(caseInstances);
+        assertEquals(0, caseInstances.size());
+
+        String caseId = startUserTaskCase(USER_YODA, USER_JOHN);
+        String caseId2 = startCarInsuranceClaimCase(USER_YODA, USER_JOHN);
+        assertNotEquals(caseId, caseId2);
+
+        caseInstances = caseClient.getCaseInstances(0, 10);
+        assertEquals(2, caseInstances.size());
+
+        List<String> mappedInstances = caseInstances.stream().map(CaseInstance::getCaseId).collect(Collectors.toList());
+        assertTrue(mappedInstances.contains(caseId));
+        assertTrue(mappedInstances.contains(caseId2));
+
+        caseInstances = caseClient.getCaseInstances(0, 1);
+        assertEquals(1, caseInstances.size());
+        assertCarInsuranceCaseInstance(caseInstances.get(0), caseId2, USER_YODA);
+
+        caseInstances = caseClient.getCaseInstances(1, 1);
+        assertEquals(1, caseInstances.size());
+        assertHrCaseInstance(caseInstances.get(0), caseId, USER_YODA);
+    }
+
+    @Test
+    public void testGetCaseInstancesSorting() {
+        String hrCaseId = startUserTaskCase(USER_YODA, USER_JOHN);
+        String claimCaseId = startCarInsuranceClaimCase(USER_YODA, USER_JOHN);
+        assertNotEquals(hrCaseId, claimCaseId);
+
+        List<CaseInstance> caseInstances = caseClient.getCaseInstances(0, 1, CaseServicesClient.SORT_BY_CASE_INSTANCE_ID, true);
+        assertEquals(1, caseInstances.size());
+        assertEquals(claimCaseId, caseInstances.get(0).getCaseId());
+
+        caseInstances = caseClient.getCaseInstances(1, 1, CaseServicesClient.SORT_BY_CASE_INSTANCE_ID, true);
+        assertEquals(1, caseInstances.size());
+        assertEquals(hrCaseId, caseInstances.get(0).getCaseId());
+
+        caseInstances = caseClient.getCaseInstances(0, 10, CaseServicesClient.SORT_BY_CASE_INSTANCE_ID, false);
+        assertEquals(2, caseInstances.size());
+        assertEquals(hrCaseId, caseInstances.get(0).getCaseId());
+        assertEquals(claimCaseId, caseInstances.get(1).getCaseId());
+    }
+
+    @Test
+    public void testGetCaseInstancesByStatus() {
+        List<CaseInstance> caseInstances = caseClient.getCaseInstances(Arrays.asList(ProcessInstance.STATE_ABORTED), 0, 1000);
+        assertNotNull(caseInstances);
+        int abortedCaseInstanceCount = caseInstances.size();
+
+        String caseId = startUserTaskCase(USER_YODA, USER_JOHN);
+
+        caseInstances = caseClient.getCaseInstances(Arrays.asList(ProcessInstance.STATE_ACTIVE), 0, 10);
+        assertEquals(1, caseInstances.size());
+        assertHrCaseInstance(caseInstances.get(0), caseId, USER_YODA);
+
+        caseClient.cancelCaseInstance(CONTAINER_ID, caseId);
+
+        caseInstances = caseClient.getCaseInstances(Arrays.asList(ProcessInstance.STATE_ABORTED), 0, 1000);
+        assertNotNull(caseInstances);
+        assertEquals(abortedCaseInstanceCount + 1, caseInstances.size());
+    }
+
+    @Test
+    public void testGetCaseInstancesByStatusSorting() {
+        String hrCaseId = startUserTaskCase(USER_YODA, USER_JOHN);
+        String claimCaseId = startCarInsuranceClaimCase(USER_YODA, USER_JOHN);
+        assertNotEquals(hrCaseId, claimCaseId);
+
+        List<CaseInstance> caseInstances = caseClient.getCaseInstances(Arrays.asList(ProcessInstance.STATE_ACTIVE), 0, 1, CaseServicesClient.SORT_BY_CASE_INSTANCE_ID, true);
+        assertEquals(1, caseInstances.size());
+        assertEquals(claimCaseId, caseInstances.get(0).getCaseId());
+
+        caseInstances = caseClient.getCaseInstances(Arrays.asList(ProcessInstance.STATE_ACTIVE), 1, 1, CaseServicesClient.SORT_BY_CASE_INSTANCE_ID, true);
+        assertEquals(1, caseInstances.size());
+        assertEquals(hrCaseId, caseInstances.get(0).getCaseId());
+
+        caseInstances = caseClient.getCaseInstances(Arrays.asList(ProcessInstance.STATE_ACTIVE), 0, 10, CaseServicesClient.SORT_BY_CASE_INSTANCE_ID, false);
+        assertEquals(2, caseInstances.size());
+        assertEquals(hrCaseId, caseInstances.get(0).getCaseId());
+        assertEquals(claimCaseId, caseInstances.get(1).getCaseId());
+    }
+
+    @Test
+    public void testGetCaseInstancesByNotExistingContainer() {
+        List<CaseInstance> caseInstances = caseClient.getCaseInstancesByContainer("not-existing-container", Arrays.asList(ProcessInstance.STATE_ACTIVE), 0, 10);
+        assertNotNull(caseInstances);
+        assertEquals(0, caseInstances.size());
+    }
+
+    @Test
+    public void testGetCaseInstancesByContainer() {
+        List<CaseInstance> caseInstances = caseClient.getCaseInstancesByContainer(CONTAINER_ID, Arrays.asList(ProcessInstance.STATE_ACTIVE), 0, 10);
+        assertNotNull(caseInstances);
+        assertEquals(0, caseInstances.size());
+
+        String caseId = startUserTaskCase(USER_YODA, USER_JOHN);
+        String caseId2 = startCarInsuranceClaimCase(USER_YODA, USER_JOHN);
+
+        caseInstances = caseClient.getCaseInstancesByContainer(CONTAINER_ID, Arrays.asList(ProcessInstance.STATE_ACTIVE), 0, 1);
+        assertNotNull(caseInstances);
+        assertEquals(1, caseInstances.size());
+        assertCarInsuranceCaseInstance(caseInstances.get(0), caseId2, USER_YODA);
+
+        caseInstances = caseClient.getCaseInstancesByContainer(CONTAINER_ID, Arrays.asList(ProcessInstance.STATE_ACTIVE), 1, 1);
+        assertNotNull(caseInstances);
+        assertEquals(1, caseInstances.size());
+        assertHrCaseInstance(caseInstances.get(0), caseId, USER_YODA);
+    }
+
+    @Test
+    public void testGetCaseInstancesByContainerSorting() {
+        String caseId = startUserTaskCase(USER_YODA, USER_JOHN);
+        String caseId2 = startCarInsuranceClaimCase(USER_YODA, USER_JOHN);
+
+        List<CaseInstance> caseInstances = caseClient.getCaseInstancesByContainer(CONTAINER_ID, Arrays.asList(ProcessInstance.STATE_ACTIVE), 0, 1, CaseServicesClient.SORT_BY_CASE_INSTANCE_ID, true);
+        assertNotNull(caseInstances);
+        assertEquals(1, caseInstances.size());
+        assertCarInsuranceCaseInstance(caseInstances.get(0), caseId2, USER_YODA);
+
+        caseInstances = caseClient.getCaseInstancesByContainer(CONTAINER_ID, Arrays.asList(ProcessInstance.STATE_ACTIVE), 1, 1, CaseServicesClient.SORT_BY_CASE_INSTANCE_ID, true);
+        assertNotNull(caseInstances);
+        assertEquals(1, caseInstances.size());
+        assertHrCaseInstance(caseInstances.get(0), caseId, USER_YODA);
+
+        caseInstances = caseClient.getCaseInstancesByContainer(CONTAINER_ID, Arrays.asList(ProcessInstance.STATE_ACTIVE), 0, 10, CaseServicesClient.SORT_BY_CASE_INSTANCE_ID, false);
+        assertNotNull(caseInstances);
+        assertEquals(2, caseInstances.size());
+        assertHrCaseInstance(caseInstances.get(0), caseId, USER_YODA);
+        assertCarInsuranceCaseInstance(caseInstances.get(1), caseId2, USER_YODA);
+    }
+
+    @Test
+    public void testGetCaseInstancesByDefinitionNotExistingContainer() {
+        List<CaseInstance> caseInstances = caseClient.getCaseInstancesByDefinition("not-existing-container", CASE_HR_DEF_ID, Arrays.asList(ProcessInstance.STATE_ACTIVE), 0, 10);
+        assertNotNull(caseInstances);
+        assertEquals(0, caseInstances.size());
+    }
+
+    @Test
+    public void testGetCaseInstancesByNotExistingDefinition() {
+        List<CaseInstance> caseInstances = caseClient.getCaseInstancesByDefinition(CONTAINER_ID, "not-existing-case", Arrays.asList(ProcessInstance.STATE_ACTIVE), 0, 10);
+        assertNotNull(caseInstances);
+        assertEquals(0, caseInstances.size());
+    }
+
+    @Test
+    public void testGetCaseInstancesByDefinition() {
+        List<CaseInstance> caseInstances = caseClient.getCaseInstancesByDefinition(CONTAINER_ID, CASE_HR_DEF_ID, Arrays.asList(ProcessInstance.STATE_ACTIVE), 0, 10);
+        assertNotNull(caseInstances);
+        assertEquals(0, caseInstances.size());
+
+        String caseId = startUserTaskCase(USER_YODA, USER_JOHN);
+        String caseId2 = startCarInsuranceClaimCase(USER_JOHN, USER_YODA);
+
+        caseInstances = caseClient.getCaseInstancesByDefinition(CONTAINER_ID, CASE_HR_DEF_ID, Arrays.asList(ProcessInstance.STATE_ACTIVE), 0, 1);
+        assertNotNull(caseInstances);
+        assertEquals(1, caseInstances.size());
+        assertHrCaseInstance(caseInstances.get(0), caseId, USER_YODA);
+
+        caseInstances = caseClient.getCaseInstancesByDefinition(CONTAINER_ID, CLAIM_CASE_DEF_ID, Arrays.asList(ProcessInstance.STATE_ACTIVE), 0, 1);
+        assertNotNull(caseInstances);
+        assertEquals(1, caseInstances.size());
+        assertCarInsuranceCaseInstance(caseInstances.get(0), caseId2, USER_YODA);
+
+        caseInstances = caseClient.getCaseInstancesByDefinition(CONTAINER_ID, CLAIM_CASE_DEF_ID, Arrays.asList(ProcessInstance.STATE_ACTIVE), 1, 1);
+        assertNotNull(caseInstances);
+        assertEquals(0, caseInstances.size());
+    }
+
+    @Test
+    public void testGetCaseInstancesByDefinitionSorting() {
+        String caseId = startUserTaskCase(USER_YODA, USER_JOHN);
+        String caseId2 = startUserTaskCase(USER_YODA, USER_JOHN);
+
+        List<CaseInstance> caseInstances = caseClient.getCaseInstancesByDefinition(CONTAINER_ID, CASE_HR_DEF_ID, Arrays.asList(ProcessInstance.STATE_ACTIVE), 0, 1, CaseServicesClient.SORT_BY_CASE_INSTANCE_ID, true);
+        assertNotNull(caseInstances);
+        assertEquals(1, caseInstances.size());
+        assertHrCaseInstance(caseInstances.get(0), caseId, USER_YODA);
+
+        caseInstances = caseClient.getCaseInstancesByDefinition(CONTAINER_ID, CASE_HR_DEF_ID, Arrays.asList(ProcessInstance.STATE_ACTIVE), 1, 1, CaseServicesClient.SORT_BY_CASE_INSTANCE_ID, true);
+        assertNotNull(caseInstances);
+        assertEquals(1, caseInstances.size());
+        assertHrCaseInstance(caseInstances.get(0), caseId2, USER_YODA);
+
+        caseInstances = caseClient.getCaseInstancesByDefinition(CONTAINER_ID, CASE_HR_DEF_ID, Arrays.asList(ProcessInstance.STATE_ACTIVE), 0, 10, CaseServicesClient.SORT_BY_CASE_INSTANCE_ID, false);
+        assertNotNull(caseInstances);
+        assertEquals(2, caseInstances.size());
+        assertHrCaseInstance(caseInstances.get(0), caseId2, USER_YODA);
+        assertHrCaseInstance(caseInstances.get(1), caseId, USER_YODA);
+    }
+
+    @Test
+    public void testGetCaseInstancesOwnedByNotExistingUser() throws Exception {
+        List<CaseInstance> caseInstances = caseClient.getCaseInstancesOwnedBy("not-existing-user", Arrays.asList(ProcessInstance.STATE_ACTIVE), 0, 10);
+        assertNotNull(caseInstances);
+        assertEquals(0, caseInstances.size());
+    }
+
+    @Test
+    public void testGetCaseInstancesOwnedBy() throws Exception {
+        // Test is using user authentication, isn't available for local execution(which has mocked authentication info).
+        Assume.assumeFalse(TestConfig.isLocalServer());
+
+        List<CaseInstance> caseInstances = caseClient.getCaseInstancesOwnedBy(USER_YODA, Arrays.asList(ProcessInstance.STATE_ACTIVE), 0, 10);
+        assertNotNull(caseInstances);
+        assertEquals(0, caseInstances.size());
+
+        try {
+            changeUser(USER_YODA);
+            String caseId = startUserTaskCase(USER_YODA, USER_JOHN);
+            changeUser(USER_JOHN);
+            String caseId2 = startCarInsuranceClaimCase(USER_JOHN, USER_YODA);
+
+            changeUser(USER_YODA);
+            caseInstances = caseClient.getCaseInstancesOwnedBy(USER_YODA, Arrays.asList(ProcessInstance.STATE_ACTIVE), 0, 1);
+            assertNotNull(caseInstances);
+            assertEquals(1, caseInstances.size());
+            assertHrCaseInstance(caseInstances.get(0), caseId, USER_YODA);
+
+            caseInstances = caseClient.getCaseInstancesOwnedBy(USER_YODA, Arrays.asList(ProcessInstance.STATE_ACTIVE), 1, 1);
+            assertNotNull(caseInstances);
+            assertEquals(0, caseInstances.size());
+
+            changeUser(USER_JOHN);
+            caseInstances = caseClient.getCaseInstancesOwnedBy(USER_JOHN, Arrays.asList(ProcessInstance.STATE_ACTIVE), 0, 10);
+            assertNotNull(caseInstances);
+            assertEquals(1, caseInstances.size());
+            assertCarInsuranceCaseInstance(caseInstances.get(0), caseId2, USER_JOHN);
+        } finally {
+            changeUser(TestConfig.getUsername());
+        }
+    }
+
+    @Test
+    public void testGetCaseInstancesOwnedBySorting() throws Exception {
+        String hrCaseId = startUserTaskCase(USER_YODA, USER_JOHN);
+        String claimCaseId = startCarInsuranceClaimCase(USER_JOHN, USER_YODA);
+
+        List<CaseInstance> caseInstances = caseClient.getCaseInstancesOwnedBy(USER_YODA, Arrays.asList(ProcessInstance.STATE_ACTIVE), 0, 1, CaseServicesClient.SORT_BY_CASE_INSTANCE_ID, true);
+        assertNotNull(caseInstances);
+        assertEquals(1, caseInstances.size());
+        assertCarInsuranceCaseInstance(caseInstances.get(0), claimCaseId, USER_YODA);
+
+        caseInstances = caseClient.getCaseInstancesOwnedBy(USER_YODA, Arrays.asList(ProcessInstance.STATE_ACTIVE), 1, 1, CaseServicesClient.SORT_BY_CASE_INSTANCE_ID, true);
+        assertNotNull(caseInstances);
+        assertEquals(1, caseInstances.size());
+        assertHrCaseInstance(caseInstances.get(0), hrCaseId, USER_YODA);
+
+        caseInstances = caseClient.getCaseInstancesOwnedBy(USER_YODA, Arrays.asList(ProcessInstance.STATE_ACTIVE), 0, 10, CaseServicesClient.SORT_BY_CASE_INSTANCE_ID, false);
+        assertNotNull(caseInstances);
+        assertEquals(2, caseInstances.size());
+        assertHrCaseInstance(caseInstances.get(0), hrCaseId, USER_YODA);
+        assertCarInsuranceCaseInstance(caseInstances.get(1), claimCaseId, USER_YODA);
+    }
+
+    @Test
+    public void testAdHocFragments() {
+        String caseId = startUserTaskCase(USER_YODA, USER_JOHN);
+
+        List<CaseAdHocFragment> caseAdHocFragments = caseClient.getAdHocFragments(CONTAINER_ID, caseId);
+        assertEquals(3, caseAdHocFragments.size());
+
+        // TODO: should it return also case id, maybe also container id? So we will know where fragments belong.
+        Map<String, CaseAdHocFragment> mappedAdHocFragments = caseAdHocFragments.stream().collect(Collectors.toMap(CaseAdHocFragment::getName, d -> d));
+        assertTrue(mappedAdHocFragments.containsKey("Milestone1"));
+        assertTrue(mappedAdHocFragments.containsKey("Milestone2"));
+        assertTrue(mappedAdHocFragments.containsKey("Hello2"));
+        assertEquals("MilestoneNode", mappedAdHocFragments.get("Milestone1").getType());
+        assertEquals("MilestoneNode", mappedAdHocFragments.get("Milestone2").getType());
+        assertEquals("HumanTaskNode", mappedAdHocFragments.get("Hello2").getType());
+    }
+
+    @Test
+    public void testAdHocFragmentsNotExistingCase() {
+        try {
+            caseClient.getAdHocFragments(CONTAINER_ID, "not-existing-case");
+            fail("Should have failed because of non existing case Id.");
+        } catch (KieServicesException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testAdHocFragmentsNotExistingContainer() {
+        try {
+            caseClient.getAdHocFragments("not-existing-container", CASE_HR_DEF_ID);
+            fail("Should have failed because of not existing container.");
+        } catch (KieServicesException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testGetProcessInstances() {
+        String userTaskCase = startUserTaskCase(USER_YODA, USER_JOHN);
+        String carInsuranceClaimCase = startCarInsuranceClaimCase(USER_JOHN, USER_YODA);
+
+        List<org.kie.server.api.model.instance.ProcessInstance> processInstances = caseClient.getProcessInstances(CONTAINER_ID, userTaskCase, Arrays.asList(ProcessInstance.STATE_ACTIVE), 0, 1);
+        assertNotNull(processInstances);
+        assertEquals(1, processInstances.size());
+        assertHrProcessInstance(processInstances.get(0), userTaskCase);
+
+        processInstances = caseClient.getProcessInstances(CONTAINER_ID, userTaskCase, Arrays.asList(ProcessInstance.STATE_ACTIVE), 1, 1);
+        assertNotNull(processInstances);
+        assertEquals(0, processInstances.size());
+
+        processInstances = caseClient.getProcessInstances(CONTAINER_ID, carInsuranceClaimCase, Arrays.asList(ProcessInstance.STATE_ACTIVE), 0, 10);
+        assertNotNull(processInstances);
+        assertEquals(1, processInstances.size());
+        assertCarInsuranceProcessInstance(processInstances.get(0), carInsuranceClaimCase);
+
+        caseClient.cancelCaseInstance(CONTAINER_ID, userTaskCase);
+
+        processInstances = caseClient.getProcessInstances(CONTAINER_ID, userTaskCase, Arrays.asList(ProcessInstance.STATE_ACTIVE), 0, 10);
+        assertNotNull(processInstances);
+        assertEquals(0, processInstances.size());
+
+        processInstances = caseClient.getProcessInstances(CONTAINER_ID, userTaskCase, Arrays.asList(ProcessInstance.STATE_ABORTED), 0, 10);
+        assertNotNull(processInstances);
+        assertEquals(1, processInstances.size());
+        assertHrProcessInstance(processInstances.get(0), userTaskCase, ProcessInstance.STATE_ABORTED);
+    }
+
+    @Test
+    public void testGetProcessInstancesNotExistingCase() {
+        // TODO: should return exception or empty result?
+        List<org.kie.server.api.model.instance.ProcessInstance> processInstances = caseClient.getProcessInstances(CONTAINER_ID, "not-existing-case", Arrays.asList(ProcessInstance.STATE_ACTIVE), 0, 10);
+        assertNotNull(processInstances);
+        assertEquals(0, processInstances.size());
+    }
+
+    @Test
+    public void testGetProcessInstancesNotExistingContainer() {
+        try {
+            caseClient.getProcessInstances("not-existing-container", CASE_HR_DEF_ID, Arrays.asList(ProcessInstance.STATE_ACTIVE), 0, 10);
+            fail("Should have failed because of not existing container.");
+        } catch (KieServicesException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testGetProcessInstancesSorting() {
+        String carInsuranceClaimCase = startCarInsuranceClaimCase(USER_JOHN, USER_YODA);
+        caseClient.addDynamicSubProcess(CONTAINER_ID, carInsuranceClaimCase, DATA_VERIFICATION_DEF_ID, new HashMap<>());
+
+        List<org.kie.server.api.model.instance.ProcessInstance> processInstances = caseClient.getProcessInstances(CONTAINER_ID, carInsuranceClaimCase, Arrays.asList(ProcessInstance.STATE_ACTIVE, ProcessInstance.STATE_COMPLETED), 0, 1, CaseServicesClient.SORT_BY_PROCESS_INSTANCE_ID, true);
+        assertNotNull(processInstances);
+        assertEquals(1, processInstances.size());
+        assertEquals(processInstances.get(0).getProcessId(), CLAIM_CASE_DEF_ID);
+
+        processInstances = caseClient.getProcessInstances(CONTAINER_ID, carInsuranceClaimCase, Arrays.asList(ProcessInstance.STATE_ACTIVE, ProcessInstance.STATE_COMPLETED), 1, 1, CaseServicesClient.SORT_BY_PROCESS_INSTANCE_ID, true);
+        assertNotNull(processInstances);
+        assertEquals(1, processInstances.size());
+        assertEquals(processInstances.get(0).getProcessId(), DATA_VERIFICATION_DEF_ID);
+
+        processInstances = caseClient.getProcessInstances(CONTAINER_ID, carInsuranceClaimCase, Arrays.asList(ProcessInstance.STATE_ACTIVE, ProcessInstance.STATE_COMPLETED), 0, 10, CaseServicesClient.SORT_BY_PROCESS_INSTANCE_ID, false);
+        assertNotNull(processInstances);
+        assertEquals(2, processInstances.size());
+        assertEquals(processInstances.get(0).getProcessId(), DATA_VERIFICATION_DEF_ID);
+        assertEquals(processInstances.get(1).getProcessId(), CLAIM_CASE_DEF_ID);
+    }
+
+    @Test
+    public void testGetActiveProcessInstances() {
+        String userTaskCase = startUserTaskCase(USER_YODA, USER_JOHN);
+        String carInsuranceClaimCase = startCarInsuranceClaimCase(USER_JOHN, USER_YODA);
+
+        List<org.kie.server.api.model.instance.ProcessInstance> processInstances = caseClient.getActiveProcessInstances(CONTAINER_ID, userTaskCase, 0, 1);
+        assertNotNull(processInstances);
+        assertEquals(1, processInstances.size());
+        assertHrProcessInstance(processInstances.get(0), userTaskCase);
+
+        processInstances = caseClient.getActiveProcessInstances(CONTAINER_ID, userTaskCase, 1, 1);
+        assertNotNull(processInstances);
+        assertEquals(0, processInstances.size());
+
+        processInstances = caseClient.getActiveProcessInstances(CONTAINER_ID, carInsuranceClaimCase, 0, 10);
+        assertNotNull(processInstances);
+        assertEquals(1, processInstances.size());
+        assertCarInsuranceProcessInstance(processInstances.get(0), carInsuranceClaimCase);
+
+        caseClient.cancelCaseInstance(CONTAINER_ID, userTaskCase);
+
+        processInstances = caseClient.getActiveProcessInstances(CONTAINER_ID, userTaskCase, 0, 1);
+        assertNotNull(processInstances);
+        assertEquals(0, processInstances.size());
+    }
+
+    @Test
+    public void testGetActiveProcessInstancesNotExistingCase() {
+        // TODO: should return exception or empty result?
+        List<org.kie.server.api.model.instance.ProcessInstance> processInstances = caseClient.getActiveProcessInstances(CONTAINER_ID, "not-existing-case", 0, 10);
+        assertNotNull(processInstances);
+        assertEquals(0, processInstances.size());
+    }
+
+    @Test
+    public void testGetActiveProcessInstancesNotExistingContainer() {
+        try {
+            caseClient.getActiveProcessInstances("not-existing-container", CASE_HR_DEF_ID, 0, 10);
+            fail("Should have failed because of not existing container.");
+        } catch (KieServicesException e) {
+            // expected
+        }
     }
 
     @Test
     public void testCreateCaseWithCaseFileAndTriggerMilestones() {
-        Map<String, Object> data = new HashMap<>();
-        data.put("s", "first case started");
-        CaseFile caseFile = CaseFile.builder()
-                .addUserAssignments(CASE_OWNER_ROLE, USER_YODA)
-                .addUserAssignments(CASE_CONTACT_ROLE, USER_JOHN)
-                .data(data)
-                .build();
+        String caseId = startUserTaskCase(USER_YODA, USER_JOHN);
 
-        String caseId = caseClient.startCase(CONTAINER_ID, CASE_DEF_ID, caseFile);
+        assertNotNull(caseId);
+        assertTrue(caseId.startsWith(CASE_HR_ID_PREFIX));
+
+        CaseInstance caseInstance = caseClient.getCaseInstance(CONTAINER_ID, caseId);
+        assertHrCaseInstance(caseInstance, caseId, USER_YODA);
+
+        List<CaseInstance> caseInstances = caseClient.getCaseInstancesOwnedBy(USER_YODA, null, 0, 10);
+        assertEquals(1, caseInstances.size());
+
+        List<CaseMilestone> milestones = caseClient.getMilestones(CONTAINER_ID, caseId, true, 0, 10);
+        assertNotNull(milestones);
+        assertEquals(0, milestones.size());
+
+        caseClient.triggerAdHocFragment(CONTAINER_ID, caseId, "Milestone1", null);
+
+        milestones = caseClient.getMilestones(CONTAINER_ID, caseId, true, 0, 10);
+        assertNotNull(milestones);
+        assertEquals(1, milestones.size());
+
+        CaseMilestone milestone = milestones.get(0);
+        assertNotNull(milestone);
+        assertEquals("Milestone1", milestone.getName());
+        assertEquals(true, milestone.isAchieved());
+        assertEquals("2", milestone.getIdentifier());
+        assertNotNull(milestone.getAchievedAt());
+
+        caseClient.triggerAdHocFragment(CONTAINER_ID, caseId, "Milestone2", null);
+        milestones = caseClient.getMilestones(CONTAINER_ID, caseId, true, 0, 10);
+        assertNotNull(milestones);
+        assertEquals(1, milestones.size());
+
+        milestones = caseClient.getMilestones(CONTAINER_ID, caseId, false, 0, 10);
+        assertNotNull(milestones);
+        assertEquals(2, milestones.size());
+
+        Map<String, CaseMilestone> mappedMilestones = milestones.stream().collect(Collectors.toMap(CaseMilestone::getName, d -> d));
+        assertTrue(mappedMilestones.containsKey("Milestone1"));
+        assertTrue(mappedMilestones.containsKey("Milestone2"));
+
+        assertTrue(mappedMilestones.get("Milestone1").isAchieved());
+        assertFalse(mappedMilestones.get("Milestone2").isAchieved());
+
+        caseInstances = caseClient.getCaseInstances(0, 10);
+        assertEquals(1, caseInstances.size());
+
+        assertHrCaseInstance(caseInstances.get(0), caseId, USER_YODA);
+
+        // now auto complete milestone by inserting data
+        caseClient.putCaseInstanceData(CONTAINER_ID, caseId, "dataComplete", true);
+        milestones = caseClient.getMilestones(CONTAINER_ID, caseId, true, 0, 10);
+        assertNotNull(milestones);
+        assertEquals(2, milestones.size());
+    }
+
+    @Test
+    public void testGetCaseMilestonesNotExistingContainer() {
         try {
-            assertNotNull(caseId);
-            assertTrue(caseId.startsWith(CASE_ID_PREFIX));
+            caseClient.getMilestones("not-existing-container", CASE_HR_DEF_ID, false, 0, 10);
+            fail("Should have failed because of not existing container.");
+        } catch (KieServicesException e) {
+            // expected
+        }
+    }
 
-            CaseInstance caseInstance = caseClient.getCaseInstance(CONTAINER_ID, caseId);
-            assertHrCaseInstance(caseInstance, caseId);
-
-            List<CaseInstance> caseInstances = caseClient.getCaseInstancesOwnedBy(USER_YODA, null, 0, 10);
-            assertEquals(1, caseInstances.size());
-
-            List<CaseMilestone> milestones = caseClient.getMilestones(CONTAINER_ID, caseId, true, 0, 10);
-            assertNotNull(milestones);
-            assertEquals(0, milestones.size());
-
-            caseClient.triggerAdHocFragment(CONTAINER_ID, caseId, "Milestone1", null);
-
-            milestones = caseClient.getMilestones(CONTAINER_ID, caseId, true, 0, 10);
-            assertNotNull(milestones);
-            assertEquals(1, milestones.size());
-
-            CaseMilestone milestone = milestones.get(0);
-            assertNotNull(milestone);
-            assertEquals("Milestone1", milestone.getName());
-            assertEquals(true, milestone.isAchieved());
-            assertEquals("2", milestone.getIdentifier());
-            assertNotNull(milestone.getAchievedAt());
-
-            caseClient.triggerAdHocFragment(CONTAINER_ID, caseId, "Milestone2", null);
-            milestones = caseClient.getMilestones(CONTAINER_ID, caseId, true, 0, 10);
-            assertNotNull(milestones);
-            assertEquals(1, milestones.size());
-
-            milestones = caseClient.getMilestones(CONTAINER_ID, caseId, false, 0, 10);
-            assertNotNull(milestones);
-            assertEquals(2, milestones.size());
-
-            Map<String, CaseMilestone> mappedMilestones = milestones.stream().collect(Collectors.toMap(CaseMilestone::getName, d -> d));
-            assertTrue(mappedMilestones.containsKey("Milestone1"));
-            assertTrue(mappedMilestones.containsKey("Milestone2"));
-
-            assertTrue(mappedMilestones.get("Milestone1").isAchieved());
-            assertFalse(mappedMilestones.get("Milestone2").isAchieved());
-
-            caseInstances = caseClient.getCaseInstances(0, 10);
-            assertEquals(1, caseInstances.size());
-
-            assertHrCaseInstance(caseInstances.get(0), caseId);
-
-            // now auto complete milestone by inserting data
-            caseClient.putCaseInstanceData(CONTAINER_ID, caseId, "dataComplete", true);
-            milestones = caseClient.getMilestones(CONTAINER_ID, caseId, true, 0, 10);
-            assertNotNull(milestones);
-            assertEquals(2, milestones.size());
-        } catch (Exception e) {
-            fail("Failed due to " + e.getMessage());
-        } finally {
-            if (caseId != null) {
-                caseClient.cancelCaseInstance(CONTAINER_ID, caseId);
-            }
+    @Test
+    public void testGetCaseMilestonesNotExistingCase() {
+        try {
+            caseClient.getMilestones(CONTAINER_ID, "not-existing-case", false, 0, 10);
+            fail("Should have failed because of not existing case definition Id.");
+        } catch (KieServicesException e) {
+            // expected
         }
     }
 
     @Test
     public void testCreateCaseWithCaseFileAndDynamicActivities() {
-        Map<String, Object> data = new HashMap<>();
-        data.put("s", "first case started");
-        CaseFile caseFile = CaseFile.builder()
-                .addUserAssignments(CASE_OWNER_ROLE, USER_JOHN)
-                .addUserAssignments(CASE_CONTACT_ROLE, USER_YODA)
-                .data(data)
-                .build();
+        String caseId = startUserTaskCase(USER_JOHN, USER_YODA);
 
-        String caseId = caseClient.startCase(CONTAINER_ID, CASE_DEF_ID, caseFile);
-        try {
-            assertNotNull(caseId);
-            assertTrue(caseId.startsWith(CASE_ID_PREFIX));
+        assertNotNull(caseId);
+        assertTrue(caseId.startsWith(CASE_HR_ID_PREFIX));
 
-            List<NodeInstance> activeNodes = caseClient.getActiveNodes(CONTAINER_ID, caseId, 0, 10);
-            assertNotNull(activeNodes);
-            assertEquals(1, activeNodes.size());
+        List<NodeInstance> activeNodes = caseClient.getActiveNodes(CONTAINER_ID, caseId, 0, 10);
+        assertNotNull(activeNodes);
+        assertEquals(1, activeNodes.size());
 
-            NodeInstance activeNode = activeNodes.get(0);
-            assertNotNull(activeNode);
-            assertEquals("Hello1", activeNode.getName());
+        NodeInstance activeNode = activeNodes.get(0);
+        assertNotNull(activeNode);
+        assertEquals("Hello1", activeNode.getName());
 
-            List<org.kie.server.api.model.instance.ProcessInstance> instances = caseClient.getActiveProcessInstances(CONTAINER_ID, caseId, 0, 10);
-            assertNotNull(instances);
-            assertEquals(1, instances.size());
+        List<org.kie.server.api.model.instance.ProcessInstance> instances = caseClient.getActiveProcessInstances(CONTAINER_ID, caseId, 0, 10);
+        assertNotNull(instances);
+        assertEquals(1, instances.size());
 
-            org.kie.server.api.model.instance.ProcessInstance pi = instances.get(0);
-            assertEquals(CASE_DEF_ID, pi.getProcessId());
-            assertEquals(caseId, pi.getCorrelationKey());
+        org.kie.server.api.model.instance.ProcessInstance pi = instances.get(0);
+        assertEquals(CASE_HR_DEF_ID, pi.getProcessId());
+        assertEquals(caseId, pi.getCorrelationKey());
 
-            Map<String, Object> parameters = new HashMap<>();
-            parameters.put("input", "text data");
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("input", "text data");
 
-            caseClient.addDynamicUserTask(CONTAINER_ID, caseId, "dynamic task", "simple description", USER_YODA, null, parameters);
+        caseClient.addDynamicUserTask(CONTAINER_ID, caseId, "dynamic task", "simple description", USER_YODA, null, parameters);
 
-            List<TaskSummary> tasks = taskClient.findTasksAssignedAsPotentialOwner(USER_YODA, 0, 10);
-            assertEquals(1, tasks.size());
-            TaskSummary task = tasks.get(0);
-            assertEquals("dynamic task", task.getName());
-            assertEquals("simple description", task.getDescription());
-            assertEquals(Status.Reserved.toString(), task.getStatus());
-            assertEquals(USER_YODA, task.getActualOwner());
+        List<TaskSummary> tasks = taskClient.findTasksAssignedAsPotentialOwner(USER_YODA, 0, 10);
+        assertEquals(1, tasks.size());
+        TaskSummary task = tasks.get(0);
+        assertEquals("dynamic task", task.getName());
+        assertEquals("simple description", task.getDescription());
+        assertEquals(Status.Reserved.toString(), task.getStatus());
+        assertEquals(USER_YODA, task.getActualOwner());
 
-            activeNodes = caseClient.getActiveNodes(CONTAINER_ID, caseId, 0, 10);
-            assertNotNull(activeNodes);
-            assertEquals(2, activeNodes.size());
+        activeNodes = caseClient.getActiveNodes(CONTAINER_ID, caseId, 0, 10);
+        assertNotNull(activeNodes);
+        assertEquals(2, activeNodes.size());
 
-            List<String> nodeNames = activeNodes.stream().map(n -> n.getName()).collect(toList());
-            assertTrue(nodeNames.contains("[Dynamic] dynamic task"));
-            assertTrue(nodeNames.contains("Hello1"));
+        List<String> nodeNames = activeNodes.stream().map(n -> n.getName()).collect(toList());
+        assertTrue(nodeNames.contains("[Dynamic] dynamic task"));
+        assertTrue(nodeNames.contains("Hello1"));
 
 
-            caseClient.addDynamicSubProcess(CONTAINER_ID, caseId, "DataVerification", parameters);
+        caseClient.addDynamicSubProcess(CONTAINER_ID, caseId, "DataVerification", parameters);
 
-            instances = caseClient.getProcessInstances(CONTAINER_ID, caseId, Arrays.asList(1, 2, 3), 0, 10);
-            assertNotNull(instances);
-            assertEquals(2, instances.size());
-        } catch (Exception e) {
-            fail("Failed due to " + e.getMessage());
-        } finally {
-            if (caseId != null) {
-                caseClient.cancelCaseInstance(CONTAINER_ID, caseId);
-            }
-        }
+        instances = caseClient.getProcessInstances(CONTAINER_ID, caseId, Arrays.asList(1, 2, 3), 0, 10);
+        assertNotNull(instances);
+        assertEquals(2, instances.size());
     }
 
     @Test
     public void testCreateCaseWithCaseFileWithComments() {
-        Map<String, Object> data = new HashMap<>();
-        data.put("s", "first case started");
-        CaseFile caseFile = CaseFile.builder()
-                .addUserAssignments(CASE_OWNER_ROLE, USER_JOHN)
-                .addUserAssignments(CASE_CONTACT_ROLE, USER_YODA)
-                .data(data)
-                .build();
+        String caseId = startUserTaskCase(USER_YODA, USER_JOHN);
 
-        String caseId = caseClient.startCase(CONTAINER_ID, CASE_DEF_ID, caseFile);
+        assertNotNull(caseId);
+        assertTrue(caseId.startsWith(CASE_HR_ID_PREFIX));
+
+        List<CaseComment> comments = caseClient.getComments(CONTAINER_ID, caseId, 0, 10);
+        assertNotNull(comments);
+        assertEquals(0, comments.size());
+
+        caseClient.addComment(CONTAINER_ID, caseId, USER_YODA, "first comment");
+
+        comments = caseClient.getComments(CONTAINER_ID, caseId, 0, 10);
+        assertNotNull(comments);
+        assertEquals(1, comments.size());
+
+        CaseComment comment = comments.get(0);
+        assertNotNull(comment);
+        assertEquals(USER_YODA, comment.getAuthor());
+        assertEquals("first comment", comment.getText());
+        assertNotNull(comment.getAddedAt());
+        assertNotNull(comment.getId());
+
+        caseClient.updateComment(CONTAINER_ID, caseId, comment.getId(), USER_YODA, "updated comment");
+        comments = caseClient.getComments(CONTAINER_ID, caseId, 0, 10);
+        assertNotNull(comments);
+        assertEquals(1, comments.size());
+
+        comment = comments.get(0);
+        assertNotNull(comment);
+        assertEquals(USER_YODA, comment.getAuthor());
+        assertEquals("updated comment", comment.getText());
+        assertNotNull(comment.getAddedAt());
+        assertNotNull(comment.getId());
+
+        caseClient.removeComment(CONTAINER_ID, caseId, comment.getId());
+
+        comments = caseClient.getComments(CONTAINER_ID, caseId, 0, 10);
+        assertNotNull(comments);
+        assertEquals(0, comments.size());
+    }
+
+    @Test
+    public void testGetCaseCommentsNotExistingContainer() {
         try {
-            assertNotNull(caseId);
-            assertTrue(caseId.startsWith(CASE_ID_PREFIX));
+            caseClient.getComments("not-existing-container", CASE_HR_DEF_ID, 0, 10);
+            fail("Should have failed because of not existing container.");
+        } catch (KieServicesException e) {
+            // expected
+        }
+    }
 
-            List<CaseComment> comments = caseClient.getComments(CONTAINER_ID, caseId, 0, 10);
-            assertNotNull(comments);
-            assertEquals(0, comments.size());
+    @Test
+    public void testGetCaseCommentsNotExistingCase() {
+        try {
+            caseClient.getComments(CONTAINER_ID, "not-existing-case", 0, 10);
+            fail("Should have failed because of not existing case definition Id.");
+        } catch (KieServicesException e) {
+            // expected
+        }
+    }
 
-            caseClient.addComment(CONTAINER_ID, caseId, USER_YODA, "first comment");
+    @Test
+    public void testAddCaseCommentNotExistingContainer() {
+        try {
+            caseClient.addComment("not-existing-container", CASE_HR_DEF_ID, USER_YODA, "Random comment.");
+            fail("Should have failed because of not existing container.");
+        } catch (KieServicesException e) {
+            // expected
+        }
+    }
 
-            comments = caseClient.getComments(CONTAINER_ID, caseId, 0, 10);
-            assertNotNull(comments);
-            assertEquals(1, comments.size());
+    @Test
+    public void testAddCaseCommentNotExistingCase() {
+        try {
+            caseClient.addComment(CONTAINER_ID, "not-existing-case", USER_YODA, "Random comment.");
+            fail("Should have failed because of not existing case definition Id.");
+        } catch (KieServicesException e) {
+            // expected
+        }
+    }
 
-            CaseComment comment = comments.get(0);
-            assertNotNull(comment);
-            assertEquals(USER_YODA, comment.getAuthor());
-            assertEquals("first comment", comment.getText());
-            assertNotNull(comment.getAddedAt());
-            assertNotNull(comment.getId());
+    @Test
+    public void testUpdateCaseCommentNotExistingContainer() {
+        try {
+            caseClient.updateComment("not-existing-container", CASE_HR_DEF_ID, "random-id", USER_YODA, "Random comment.");
+            fail("Should have failed because of not existing container.");
+        } catch (KieServicesException e) {
+            // expected
+        }
+    }
 
-            caseClient.updateComment(CONTAINER_ID, caseId, comment.getId(), USER_YODA, "updated comment");
-            comments = caseClient.getComments(CONTAINER_ID, caseId, 0, 10);
-            assertNotNull(comments);
-            assertEquals(1, comments.size());
+    @Test
+    public void testUpdateCaseCommentNotExistingCase() {
+        try {
+            caseClient.updateComment(CONTAINER_ID, "not-existing-case", "random-id", USER_YODA, "Random comment.");
+            fail("Should have failed because of not existing case definition Id.");
+        } catch (KieServicesException e) {
+            // expected
+        }
+    }
 
-            comment = comments.get(0);
-            assertNotNull(comment);
-            assertEquals(USER_YODA, comment.getAuthor());
-            assertEquals("updated comment", comment.getText());
-            assertNotNull(comment.getAddedAt());
-            assertNotNull(comment.getId());
+    @Test
+    public void testUpdateNotExistingCaseComment() {
+        String caseId = startUserTaskCase(USER_YODA, USER_JOHN);
 
-            caseClient.removeComment(CONTAINER_ID, caseId, comment.getId());
+        try {
+            caseClient.updateComment(CONTAINER_ID, caseId, "not-existing-id", USER_YODA, "Random comment.");
+            fail("Should have failed because of not existing comment Id.");
+        } catch (KieServicesException e) {
+            // expected
+        }
+    }
 
-            comments = caseClient.getComments(CONTAINER_ID, caseId, 0, 10);
-            assertNotNull(comments);
-            assertEquals(0, comments.size());
+    @Test
+    public void testRemoveCaseCommentNotExistingContainer() {
+        try {
+            caseClient.removeComment("not-existing-container", CASE_HR_DEF_ID, "random-id");
+            fail("Should have failed because of not existing container.");
+        } catch (KieServicesException e) {
+            // expected
+        }
+    }
 
-        } catch (Exception e) {
-            fail("Failed due to " + e.getMessage());
-        } finally {
-            if (caseId != null) {
-                caseClient.cancelCaseInstance(CONTAINER_ID, caseId);
-            }
+    @Test
+    public void testRemoveCaseCommentNotExistingCase() {
+        try {
+            caseClient.removeComment(CONTAINER_ID, "not-existing-case", "random-id");
+            fail("Should have failed because of not existing case definition Id.");
+        } catch (KieServicesException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testRemoveNotExistingCaseComment() {
+        String caseId = startUserTaskCase(USER_YODA, USER_JOHN);
+
+        try {
+            caseClient.removeComment(CONTAINER_ID, caseId, "not-existing-id");
+            fail("Should have failed because of not existing comment Id.");
+        } catch (KieServicesException e) {
+            // expected
         }
     }
 
     @Test
     public void testCreateDifferentTypesCases() {
-        Map<String, Object> data = new HashMap<>();
-        data.put("s", "first case started");
-        CaseFile caseFile = CaseFile.builder()
-                .addUserAssignments(CASE_OWNER_ROLE, USER_JOHN)
-                .addUserAssignments(CASE_CONTACT_ROLE, USER_YODA)
-                .data(data)
-                .build();
+        String caseId = startUserTaskCase(USER_YODA, USER_JOHN);
 
-        CaseFile caseClaimFile = CaseFile.builder()
-                .addUserAssignments(CASE_INSURED_ROLE, USER_JOHN)
-                .addUserAssignments(CASE_INS_REP_ROLE, USER_YODA)
-                .data(data)
-                .build();
+        String caseClaimId = startCarInsuranceClaimCase(USER_JOHN, USER_YODA);
 
-        String caseId = caseClient.startCase(CONTAINER_ID, CASE_DEF_ID, caseFile);
+        assertNotNull(caseId);
+        assertTrue(caseId.startsWith(CASE_HR_ID_PREFIX));
 
-        String caseClaimId = caseClient.startCase(CONTAINER_ID, CLAIM_CASE_DEF_ID, caseClaimFile);
+        assertNotNull(caseClaimId);
+        assertTrue(caseClaimId.startsWith(CLAIM_CASE_ID_PREFIX));
+
+        List<CaseInstance> caseInstances = caseClient.getCaseInstancesByContainer(CONTAINER_ID, Arrays.asList(1), 0, 10);
+        assertEquals(2, caseInstances.size());
+
+        List<String> caseDefs = caseInstances.stream().map(c -> c.getCaseDefinitionId()).collect(toList());
+        assertTrue(caseDefs.contains(CASE_HR_DEF_ID));
+        assertTrue(caseDefs.contains(CLAIM_CASE_DEF_ID));
+
+        caseInstances = caseClient.getCaseInstancesByDefinition(CONTAINER_ID, CLAIM_CASE_DEF_ID, Arrays.asList(1), 0, 10);
+        assertEquals(1, caseInstances.size());
+
+        List<CaseStage> stages = caseClient.getStages(CONTAINER_ID, caseClaimId, true, 0, 10);
+        assertEquals(1, stages.size());
+        CaseStage caseStage = stages.get(0);
+        assertEquals("Build claim report", caseStage.getName());
+        assertEquals(2, caseStage.getAdHocFragments().size());
+
+        List<CaseRoleAssignment> roles = caseClient.getRoleAssignments(CONTAINER_ID, caseClaimId);
+        assertEquals(3, roles.size());
+
+        Map<String, CaseRoleAssignment> mappedRoles = roles.stream().collect(toMap(CaseRoleAssignment::getName, r -> r));
+        assertTrue(mappedRoles.containsKey(CASE_INSURED_ROLE));
+        assertTrue(mappedRoles.containsKey(CASE_INS_REP_ROLE));
+        assertTrue(mappedRoles.containsKey(CASE_ASSESSOR_ROLE));
+
+        CaseRoleAssignment insuredRole = mappedRoles.get(CASE_INSURED_ROLE);
+        assertTrue(insuredRole.getUsers().contains(USER_JOHN));
+        KieServerAssert.assertNullOrEmpty("Groups should be empty", insuredRole.getGroups());
+
+        CaseRoleAssignment insRepRole = mappedRoles.get(CASE_INS_REP_ROLE);
+        assertTrue(insRepRole.getUsers().contains(USER_YODA));
+        KieServerAssert.assertNullOrEmpty("Groups should be empty", insRepRole.getGroups());
+
+        CaseRoleAssignment assessorRole = mappedRoles.get(CASE_ASSESSOR_ROLE);
+        KieServerAssert.assertNullOrEmpty("Users should be empty", assessorRole.getUsers());
+        KieServerAssert.assertNullOrEmpty("Groups should be empty", assessorRole.getGroups());
+
+        caseClient.assignUserToRole(CONTAINER_ID, caseClaimId, CASE_ASSESSOR_ROLE, USER_MARY);
+        caseClient.assignGroupToRole(CONTAINER_ID, caseClaimId, CASE_ASSESSOR_ROLE, "managers");
+
+        roles = caseClient.getRoleAssignments(CONTAINER_ID, caseClaimId);
+        assertEquals(3, roles.size());
+        mappedRoles = roles.stream().collect(toMap(CaseRoleAssignment::getName, r -> r));
+
+        assessorRole = mappedRoles.get(CASE_ASSESSOR_ROLE);
+        assertTrue(assessorRole.getUsers().contains(USER_MARY));
+        assertTrue(assessorRole.getGroups().contains("managers"));
+
+        caseClient.removeUserFromRole(CONTAINER_ID, caseClaimId, CASE_ASSESSOR_ROLE, USER_MARY);
+        caseClient.removeGroupFromRole(CONTAINER_ID, caseClaimId, CASE_ASSESSOR_ROLE, "managers");
+
+        roles = caseClient.getRoleAssignments(CONTAINER_ID, caseClaimId);
+        assertEquals(3, roles.size());
+        mappedRoles = roles.stream().collect(toMap(CaseRoleAssignment::getName, r -> r));
+
+        assessorRole = mappedRoles.get(CASE_ASSESSOR_ROLE);
+        KieServerAssert.assertNullOrEmpty("Users should be empty", assessorRole.getUsers());
+        KieServerAssert.assertNullOrEmpty("Groups should be empty", assessorRole.getGroups());
+    }
+
+    @Test
+    public void testGetCaseStagesNotExistingContainer() {
         try {
-            assertNotNull(caseId);
-            assertTrue(caseId.startsWith(CASE_ID_PREFIX));
-
-            assertNotNull(caseClaimId);
-            assertTrue(caseClaimId.startsWith(CLAIM_CASE_ID_PREFIX));
-
-            List<CaseInstance> caseInstances = caseClient.getCaseInstancesByContainer(CONTAINER_ID, Arrays.asList(1), 0, 10);
-            assertEquals(2, caseInstances.size());
-
-            List<String> caseDefs = caseInstances.stream().map(c -> c.getCaseDefinitionId()).collect(toList());
-            assertTrue(caseDefs.contains(CASE_DEF_ID));
-            assertTrue(caseDefs.contains(CLAIM_CASE_DEF_ID));
-
-            caseInstances = caseClient.getCaseInstancesByDefinition(CONTAINER_ID, CLAIM_CASE_DEF_ID, Arrays.asList(1), 0, 10);
-            assertEquals(1, caseInstances.size());
-
-            List<CaseStage> stages = caseClient.getStages(CONTAINER_ID, caseClaimId, true, 0, 10);
-            assertEquals(1, stages.size());
-            CaseStage caseStage = stages.get(0);
-            assertEquals("Build claim report", caseStage.getName());
-            assertEquals(2, caseStage.getAdHocFragments().size());
-
-            List<CaseRoleAssignment> roles = caseClient.getRoleAssignments(CONTAINER_ID, caseClaimId);
-            assertEquals(3, roles.size());
-
-            Map<String, CaseRoleAssignment> mappedRoles = roles.stream().collect(toMap(CaseRoleAssignment::getName, r -> r));
-            assertTrue(mappedRoles.containsKey(CASE_INSURED_ROLE));
-            assertTrue(mappedRoles.containsKey(CASE_INS_REP_ROLE));
-            assertTrue(mappedRoles.containsKey(CASE_ASSESSOR_ROLE));
-
-            CaseRoleAssignment insuredRole = mappedRoles.get(CASE_INSURED_ROLE);
-            assertTrue(insuredRole.getUsers().contains(USER_JOHN));
-            KieServerAssert.assertNullOrEmpty("Groups should be empty", insuredRole.getGroups());
-
-            CaseRoleAssignment insRepRole = mappedRoles.get(CASE_INS_REP_ROLE);
-            assertTrue(insRepRole.getUsers().contains(USER_YODA));
-            KieServerAssert.assertNullOrEmpty("Groups should be empty", insRepRole.getGroups());
-
-            CaseRoleAssignment assessorRole = mappedRoles.get(CASE_ASSESSOR_ROLE);
-            KieServerAssert.assertNullOrEmpty("Users should be empty", assessorRole.getUsers());
-            KieServerAssert.assertNullOrEmpty("Groups should be empty", assessorRole.getGroups());
-
-            caseClient.assignUserToRole(CONTAINER_ID, caseClaimId, CASE_ASSESSOR_ROLE, USER_MARY);
-            caseClient.assignGroupToRole(CONTAINER_ID, caseClaimId, CASE_ASSESSOR_ROLE, "managers");
-
-            roles = caseClient.getRoleAssignments(CONTAINER_ID, caseClaimId);
-            assertEquals(3, roles.size());
-            mappedRoles = roles.stream().collect(toMap(CaseRoleAssignment::getName, r -> r));
-
-            assessorRole = mappedRoles.get(CASE_ASSESSOR_ROLE);
-            assertTrue(assessorRole.getUsers().contains(USER_MARY));
-            assertTrue(assessorRole.getGroups().contains("managers"));
-
-            caseClient.removeUserFromRole(CONTAINER_ID, caseClaimId, CASE_ASSESSOR_ROLE, USER_MARY);
-            caseClient.removeGroupFromRole(CONTAINER_ID, caseClaimId, CASE_ASSESSOR_ROLE, "managers");
-
-            roles = caseClient.getRoleAssignments(CONTAINER_ID, caseClaimId);
-            assertEquals(3, roles.size());
-            mappedRoles = roles.stream().collect(toMap(CaseRoleAssignment::getName, r -> r));
-
-            assessorRole = mappedRoles.get(CASE_ASSESSOR_ROLE);
-            KieServerAssert.assertNullOrEmpty("Users should be empty", assessorRole.getUsers());
-            KieServerAssert.assertNullOrEmpty("Groups should be empty", assessorRole.getGroups());
-
-        } catch (Exception e) {
-            fail("Failed due to " + e.getMessage());
-        } finally {
-            if (caseId != null) {
-                caseClient.cancelCaseInstance(CONTAINER_ID, caseId);
-            }
-
-            if (caseClaimId != null) {
-                caseClient.cancelCaseInstance(CONTAINER_ID, caseClaimId);
-            }
+            caseClient.getStages("not-existing-container", CASE_HR_DEF_ID, false, 0, 10);
+            fail("Should have failed because of not existing container.");
+        } catch (KieServicesException e) {
+            // expected
         }
     }
 
-    protected void assertHrCaseInstance(CaseInstance caseInstance, String caseId) {
-        caseInstance = caseClient.getCaseInstance(CONTAINER_ID, caseId);
+    @Test
+    public void testGetCaseStagesNotExistingCase() {
+        try {
+            caseClient.getStages(CONTAINER_ID, "not-existing-case", false, 0, 10);
+            fail("Should have failed because of not existing case definition Id.");
+        } catch (KieServicesException e) {
+            // expected
+        }
+    }
+
+    private String startUserTaskCase(String owner, String contact) {
+        Map<String, Object> data = new HashMap<>();
+        data.put("s", "first case started");
+        CaseFile caseFile = CaseFile.builder()
+                .addUserAssignments(CASE_OWNER_ROLE, owner)
+                .addUserAssignments(CASE_CONTACT_ROLE, contact)
+                .data(data)
+                .build();
+
+        String caseId = caseClient.startCase(CONTAINER_ID, CASE_HR_DEF_ID, caseFile);
+        assertNotNull(caseId);
+        return caseId;
+    }
+
+    private String startCarInsuranceClaimCase(String insured, String insuranceRep) {
+        Map<String, Object> data = new HashMap<>();
+        data.put("s", "first case started");
+        CaseFile caseFile = CaseFile.builder()
+                .addUserAssignments(CASE_INSURED_ROLE, insured)
+                .addUserAssignments(CASE_INS_REP_ROLE, insuranceRep)
+                .data(data)
+                .build();
+
+        String caseId = caseClient.startCase(CONTAINER_ID, CLAIM_CASE_DEF_ID, caseFile);
+        assertNotNull(caseId);
+        return caseId;
+    }
+
+    private void assertHrCaseInstance(CaseInstance caseInstance, String caseId, String owner) {
         assertNotNull(caseInstance);
         assertEquals(caseId, caseInstance.getCaseId());
-        assertEquals(CASE_DEF_ID, caseInstance.getCaseDefinitionId());
-        assertEquals("Case first case started", caseInstance.getCaseDescription());
-        assertEquals(USER_YODA, caseInstance.getCaseOwner());
+        assertEquals(CASE_HR_DEF_ID, caseInstance.getCaseDefinitionId());
+        assertEquals(CASE_HR_DESRIPTION, caseInstance.getCaseDescription());
+        assertEquals(owner, caseInstance.getCaseOwner());
         assertEquals(ProcessInstance.STATE_ACTIVE, caseInstance.getCaseStatus().intValue());
         assertNotNull(caseInstance.getStartedAt());
         assertNull(caseInstance.getCompletedAt());
-        assertEquals("", caseInstance.getCompletionMessage());
+        // TODO which should be correct?
+        KieServerAssert.assertNullOrEmpty(caseInstance.getCompletionMessage());
         assertEquals(CONTAINER_ID, caseInstance.getContainerId());
     }
 
+    private void assertCarInsuranceCaseInstance(CaseInstance caseInstance, String caseId, String owner) {
+        assertNotNull(caseInstance);
+        assertEquals(caseId, caseInstance.getCaseId());
+        assertEquals(CLAIM_CASE_DEF_ID, caseInstance.getCaseDefinitionId());
+        assertEquals(CLAIM_CASE_DESRIPTION, caseInstance.getCaseDescription());
+        assertEquals(owner, caseInstance.getCaseOwner());
+        assertEquals(ProcessInstance.STATE_ACTIVE, caseInstance.getCaseStatus().intValue());
+        assertNotNull(caseInstance.getStartedAt());
+        assertNull(caseInstance.getCompletedAt());
+        // TODO which should be correct?
+        KieServerAssert.assertNullOrEmpty(caseInstance.getCompletionMessage());
+        assertEquals(CONTAINER_ID, caseInstance.getContainerId());
+    }
+
+    private void assertHrCaseDefinition(CaseDefinition caseDefinition) {
+        assertNotNull(caseDefinition);
+        assertEquals(CASE_HR_DEF_ID, caseDefinition.getIdentifier());
+        assertEquals(CASE_HR_NAME, caseDefinition.getName());
+        assertEquals(CASE_HR_ID_PREFIX, caseDefinition.getCaseIdPrefix());
+        assertEquals(CASE_HR_VERSION, caseDefinition.getVersion());
+        assertEquals(3, caseDefinition.getAdHocFragments().size());
+        KieServerAssert.assertNullOrEmpty("Stages should be empty", caseDefinition.getCaseStages());
+        assertEquals(CONTAINER_ID, caseDefinition.getContainerId());
+
+        // Milestones checks
+        assertEquals(2, caseDefinition.getMilestones().size());
+        assertEquals("Milestone1", caseDefinition.getMilestones().get(0).getName());
+        assertEquals("_SomeID4", caseDefinition.getMilestones().get(0).getIdentifier());
+        assertFalse("Case shouldn't be mandatory.", caseDefinition.getMilestones().get(0).isMandatory());
+        assertEquals("Milestone2", caseDefinition.getMilestones().get(1).getName());
+        assertEquals("_5", caseDefinition.getMilestones().get(1).getIdentifier());
+        assertFalse("Case shouldn't be mandatory.", caseDefinition.getMilestones().get(1).isMandatory());
+        // TODO what does mandatory mean?
+
+        // Roles check
+        assertEquals(3, caseDefinition.getRoles().size());
+        assertTrue("Role 'owner' is missing.", caseDefinition.getRoles().containsKey("owner"));
+        assertTrue("Role 'contact' is missing.", caseDefinition.getRoles().containsKey("contact"));
+        assertTrue("Role 'participant' is missing.", caseDefinition.getRoles().containsKey("participant"));
+    }
+
+    private void assertCarInsuranceCaseDefinition(CaseDefinition caseDefinition) {
+        assertNotNull(caseDefinition);
+        assertEquals(CLAIM_CASE_DEF_ID, caseDefinition.getIdentifier());
+        assertEquals(CLAIM_CASE_NAME, caseDefinition.getName());
+        assertEquals(CLAIM_CASE_ID_PREFIX, caseDefinition.getCaseIdPrefix());
+        assertEquals(CLAIM_CASE_VERSION, caseDefinition.getVersion());
+        assertEquals(1, caseDefinition.getAdHocFragments().size());
+        KieServerAssert.assertNullOrEmpty("Milestones should be empty.", caseDefinition.getMilestones());
+        assertEquals(CONTAINER_ID, caseDefinition.getContainerId());
+
+        // Stages check
+        assertEquals(3, caseDefinition.getCaseStages().size());
+        assertEquals("Build claim report", caseDefinition.getCaseStages().get(0).getName());
+        assertNotNull(caseDefinition.getCaseStages().get(0).getIdentifier());
+        assertEquals("Claim assesment", caseDefinition.getCaseStages().get(1).getName());
+        assertNotNull(caseDefinition.getCaseStages().get(1).getIdentifier());
+        assertEquals("Escalate rejected claim", caseDefinition.getCaseStages().get(2).getName());
+        assertNotNull(caseDefinition.getCaseStages().get(2).getIdentifier());
+
+        List<CaseAdHocFragment> buildClaimFragments = caseDefinition.getCaseStages().get(0).getAdHocFragments();
+        assertEquals(2, buildClaimFragments.size());
+        assertEquals("Provide accident information", buildClaimFragments.get(0).getName());
+        assertEquals("HumanTaskNode", buildClaimFragments.get(0).getType());
+        assertEquals("Submit police report", buildClaimFragments.get(1).getName());
+        assertEquals("HumanTaskNode", buildClaimFragments.get(1).getType());
+
+        List<CaseAdHocFragment> claimAssesmentFragments = caseDefinition.getCaseStages().get(1).getAdHocFragments();
+        assertEquals(2, claimAssesmentFragments.size());
+        assertEquals("Classify claim", claimAssesmentFragments.get(0).getName());
+        assertEquals("RuleSetNode", claimAssesmentFragments.get(0).getType());
+        assertEquals("Calculate claim", claimAssesmentFragments.get(1).getName());
+        assertEquals("WorkItemNode", claimAssesmentFragments.get(1).getType());
+
+        List<CaseAdHocFragment> escalateRejectedClaimFragments = caseDefinition.getCaseStages().get(2).getAdHocFragments();
+        assertEquals(1, escalateRejectedClaimFragments.size());
+        assertEquals("Negotiation meeting", escalateRejectedClaimFragments.get(0).getName());
+        assertEquals("HumanTaskNode", escalateRejectedClaimFragments.get(0).getType());
+
+        // Roles check
+        assertEquals(3, caseDefinition.getRoles().size());
+        assertTrue("Role 'insured' is missing.", caseDefinition.getRoles().containsKey("insured"));
+        assertTrue("Role 'insuranceRepresentative' is missing.", caseDefinition.getRoles().containsKey("insuranceRepresentative"));
+        assertTrue("Role 'assessor' is missing.", caseDefinition.getRoles().containsKey("assessor"));
+    }
+
+    private void assertHrProcessInstance(org.kie.server.api.model.instance.ProcessInstance processInstance, String caseId) {
+        assertHrProcessInstance(processInstance, caseId, ProcessInstance.STATE_ACTIVE);
+    }
+
+    private void assertHrProcessInstance(org.kie.server.api.model.instance.ProcessInstance processInstance, String caseId, long processInstanceState) {
+        assertNotNull(processInstance);
+        assertNotNull(processInstance.getId());
+        assertEquals(caseId, processInstance.getCorrelationKey());
+        assertEquals(processInstanceState, processInstance.getState().intValue());
+        assertEquals(CASE_HR_DEF_ID, processInstance.getProcessId());
+        assertEquals(CASE_HR_NAME, processInstance.getProcessName());
+        assertEquals(CASE_HR_VERSION, processInstance.getProcessVersion());
+        assertEquals(CONTAINER_ID, processInstance.getContainerId());
+        assertEquals(CASE_HR_DESRIPTION, processInstance.getProcessInstanceDescription());
+        assertEquals(USER_YODA, processInstance.getInitiator());
+        assertEquals(-1L, processInstance.getParentId().longValue());
+        assertNotNull(processInstance.getCorrelationKey());
+        assertNotNull(processInstance.getDate());
+    }
+
+    private void assertCarInsuranceProcessInstance(org.kie.server.api.model.instance.ProcessInstance processInstance, String caseId) {
+        assertNotNull(processInstance);
+        assertNotNull(processInstance.getId());
+        assertEquals(caseId, processInstance.getCorrelationKey());
+        assertEquals(ProcessInstance.STATE_ACTIVE, processInstance.getState().intValue());
+        assertEquals(CLAIM_CASE_DEF_ID, processInstance.getProcessId());
+        assertEquals(CLAIM_CASE_NAME, processInstance.getProcessName());
+        assertEquals(CLAIM_CASE_VERSION, processInstance.getProcessVersion());
+        assertEquals(CONTAINER_ID, processInstance.getContainerId());
+        assertEquals(CLAIM_CASE_DESRIPTION, processInstance.getProcessInstanceDescription());
+        assertEquals(USER_YODA, processInstance.getInitiator());
+        assertEquals(-1L, processInstance.getParentId().longValue());
+        assertNotNull(processInstance.getCorrelationKey());
+        assertNotNull(processInstance.getDate());
+    }
 }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/cases/CaseServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/cases/CaseServiceIntegrationTest.java
@@ -42,13 +42,12 @@ public class CaseServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
     private static final String PROPERTY_DAMAGE_REPORT_CLASS_NAME = "org.kie.server.testing.PropertyDamageReport";
     private static final String CLAIM_REPORT_CLASS_NAME = "org.kie.server.testing.ClaimReport";
 
-    private static final String CASE_DEF_ID = "insurance-claims.CarInsuranceClaimCase";
-    private static final String CASE_DESCRIPTION = "CarInsuranceClaimCase";
+    private static final String CLAIM_CASE_ID_PREFIX = "CAR_INS";
+    private static final String CLAIM_CASE_DEF_ID = "insurance-claims.CarInsuranceClaimCase";
+    private static final String CLAIM_CASE_DESRIPTION = "CarInsuranceClaimCase";
 
     private static final String CASE_INSURED_ROLE = "insured";
     private static final String CASE_INS_REP_ROLE = "insuranceRepresentative";
-
-    private static final String CASE_ID_PREFIX = "CAR_INS";
 
     private static final String CONTAINER_ALIAS = "ins";
 
@@ -71,33 +70,17 @@ public class CaseServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
 
     @Test
     public void testCreateCaseWithEmptyCaseFile() {
-        String caseId = caseClient.startCase(CONTAINER_ID, CASE_DEF_ID);
-        try {
-            assertNotNull(caseId);
-            assertTrue(caseId.startsWith(CASE_ID_PREFIX));
+        String caseId = caseClient.startCase(CONTAINER_ID, CLAIM_CASE_DEF_ID);
 
-            CaseInstance caseInstance = caseClient.getCaseInstance(CONTAINER_ID, caseId);
-            assertNotNull(caseInstance);
-            assertEquals(caseId, caseInstance.getCaseId());
-            assertEquals(CASE_DEF_ID, caseInstance.getCaseDefinitionId());
-            assertEquals(CASE_DESCRIPTION, caseInstance.getCaseDescription());
-            assertEquals(USER_YODA, caseInstance.getCaseOwner());
-            assertEquals(ProcessInstance.STATE_ACTIVE, caseInstance.getCaseStatus().intValue());
-            assertNotNull(caseInstance.getStartedAt());
-            assertNull(caseInstance.getCompletedAt());
-            assertEquals("", caseInstance.getCompletionMessage());
-            assertEquals(CONTAINER_ID, caseInstance.getContainerId());
+        assertNotNull(caseId);
+        assertTrue(caseId.startsWith(CLAIM_CASE_ID_PREFIX));
 
-            // since roles were not assigned to any users/groups no tasks are available
-            List<TaskSummary> tasks = taskClient.findTasksAssignedAsPotentialOwner(USER_YODA, 0, 10);
-            assertEquals(0, tasks.size());
-        } catch (Exception e) {
-            fail("Failed due to " + e.getMessage());
-        } finally {
-            if (caseId != null) {
-                caseClient.cancelCaseInstance(CONTAINER_ID, caseId);
-            }
-        }
+        CaseInstance caseInstance = caseClient.getCaseInstance(CONTAINER_ID, caseId);
+        assertCarInsuranceCaseInstance(caseInstance, caseId, USER_YODA);
+
+        // since roles were not assigned to any users/groups no tasks are available
+        List<TaskSummary> tasks = taskClient.findTasksAssignedAsPotentialOwner(USER_YODA, 0, 10);
+        assertEquals(0, tasks.size());
     }
 
     @Test
@@ -106,38 +89,22 @@ public class CaseServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
                                               .addUserAssignments(CASE_INS_REP_ROLE, USER_JOHN)
                                               .build();
 
-        String caseId = caseClient.startCase(CONTAINER_ID, CASE_DEF_ID, caseFile);
-        try {
-            assertNotNull(caseId);
-            assertTrue(caseId.startsWith(CASE_ID_PREFIX));
+        String caseId = caseClient.startCase(CONTAINER_ID, CLAIM_CASE_DEF_ID, caseFile);
 
-            CaseInstance caseInstance = caseClient.getCaseInstance(CONTAINER_ID, caseId);
-            assertNotNull(caseInstance);
-            assertEquals(caseId, caseInstance.getCaseId());
-            assertEquals(CASE_DEF_ID, caseInstance.getCaseDefinitionId());
-            assertEquals(CASE_DESCRIPTION, caseInstance.getCaseDescription());
-            assertEquals(USER_YODA, caseInstance.getCaseOwner());
-            assertEquals(ProcessInstance.STATE_ACTIVE, caseInstance.getCaseStatus().intValue());
-            assertNotNull(caseInstance.getStartedAt());
-            assertNull(caseInstance.getCompletedAt());
-            assertEquals("", caseInstance.getCompletionMessage());
-            assertEquals(CONTAINER_ID, caseInstance.getContainerId());
+        assertNotNull(caseId);
+        assertTrue(caseId.startsWith(CLAIM_CASE_ID_PREFIX));
 
-            List<TaskSummary> tasks = taskClient.findTasksAssignedAsPotentialOwner(USER_YODA, 0, 10);
-            assertEquals(1, tasks.size());
+        CaseInstance caseInstance = caseClient.getCaseInstance(CONTAINER_ID, caseId);
+        assertCarInsuranceCaseInstance(caseInstance, caseId, USER_YODA);
 
-            TaskSummary task = tasks.get(0);
-            assertNotNull(task);
-            assertEquals("Provide accident information", task.getName());
-            assertEquals(null, task.getActualOwner());
-            assertEquals("Ready", task.getStatus());
-        } catch (Exception e) {
-            fail("Failed due to " + e.getMessage());
-        } finally {
-            if (caseId != null) {
-                caseClient.cancelCaseInstance(CONTAINER_ID, caseId);
-            }
-        }
+        List<TaskSummary> tasks = taskClient.findTasksAssignedAsPotentialOwner(USER_YODA, 0, 10);
+        assertEquals(1, tasks.size());
+
+        TaskSummary task = tasks.get(0);
+        assertNotNull(task);
+        assertEquals("Provide accident information", task.getName());
+        assertEquals(null, task.getActualOwner());
+        assertEquals("Ready", task.getStatus());
     }
 
     @Test
@@ -150,195 +117,227 @@ public class CaseServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
                 .data(caseData)
                 .build();
 
-        String caseId = caseClient.startCase(CONTAINER_ID, CASE_DEF_ID, caseFile);
-        try {
-            assertNotNull(caseId);
-            assertTrue(caseId.startsWith(CASE_ID_PREFIX));
+        String caseId = caseClient.startCase(CONTAINER_ID, CLAIM_CASE_DEF_ID, caseFile);
 
-            caseData = caseClient.getCaseInstanceData(CONTAINER_ID, caseId);
-            assertNotNull(caseData);
-            assertEquals(1, caseData.size());
-            assertEquals("ford", caseData.get("car"));
+        assertNotNull(caseId);
+        assertTrue(caseId.startsWith(CLAIM_CASE_ID_PREFIX));
 
-            caseClient.putCaseInstanceData(CONTAINER_ID, caseId, "car", "fiat");
+        caseData = caseClient.getCaseInstanceData(CONTAINER_ID, caseId);
+        assertNotNull(caseData);
+        assertEquals(1, caseData.size());
+        assertEquals("ford", caseData.get("car"));
 
-            Object carCaseData = caseClient.getCaseInstanceData(CONTAINER_ID, caseId, "car");
-            assertNotNull(carCaseData);
-            assertTrue(carCaseData instanceof String);
-            assertEquals("fiat", carCaseData);
+        caseClient.putCaseInstanceData(CONTAINER_ID, caseId, "car", "fiat");
 
-            List<TaskSummary> tasks = taskClient.findTasksAssignedAsPotentialOwner(USER_YODA, 0, 10);
-            assertEquals(1, tasks.size());
+        Object carCaseData = caseClient.getCaseInstanceData(CONTAINER_ID, caseId, "car");
+        assertNotNull(carCaseData);
+        assertTrue(carCaseData instanceof String);
+        assertEquals("fiat", carCaseData);
 
-            TaskSummary task = tasks.get(0);
-            assertNotNull(task);
-            assertEquals("Provide accident information", task.getName());
-            assertEquals(null, task.getActualOwner());
-            assertEquals("Ready", task.getStatus());
+        List<TaskSummary> tasks = taskClient.findTasksAssignedAsPotentialOwner(USER_YODA, 0, 10);
+        assertEquals(1, tasks.size());
 
-            Map<String, Object> output = new HashMap<>();
-            Object claimReport = createInstance(CLAIM_REPORT_CLASS_NAME);
-            setValue(claimReport, "name", "John Doe");
+        TaskSummary task = tasks.get(0);
+        assertNotNull(task);
+        assertEquals("Provide accident information", task.getName());
+        assertEquals(null, task.getActualOwner());
+        assertEquals("Ready", task.getStatus());
 
-            output.put("claimReport_", claimReport);
-            taskClient.completeAutoProgress(CONTAINER_ID, task.getId(), USER_YODA, output);
+        Map<String, Object> output = new HashMap<>();
+        Object claimReport = createInstance(CLAIM_REPORT_CLASS_NAME);
+        setValue(claimReport, "name", "John Doe");
 
-            caseData = caseClient.getCaseInstanceData(CONTAINER_ID, caseId);
-            assertNotNull(caseData);
-            assertEquals(2, caseData.size());
-            assertEquals("fiat", caseData.get("car"));
+        output.put("claimReport_", claimReport);
+        taskClient.completeAutoProgress(CONTAINER_ID, task.getId(), USER_YODA, output);
 
-            Object caseClaimReport = caseData.get("claimReport");
-            assertNotNull(caseClaimReport);
-            assertEquals(caseClaimReport.getClass().getName(), CLAIM_REPORT_CLASS_NAME);
+        caseData = caseClient.getCaseInstanceData(CONTAINER_ID, caseId);
+        assertNotNull(caseData);
+        assertEquals(2, caseData.size());
+        assertEquals("fiat", caseData.get("car"));
 
-            caseClient.removeCaseInstanceData(CONTAINER_ID, caseId, "claimReport");
-            caseData = caseClient.getCaseInstanceData(CONTAINER_ID, caseId);
-            assertNotNull(caseData);
-            assertEquals(1, caseData.size());
-            assertEquals("fiat", caseData.get("car"));
+        Object caseClaimReport = caseData.get("claimReport");
+        assertNotNull(caseClaimReport);
+        assertEquals(caseClaimReport.getClass().getName(), CLAIM_REPORT_CLASS_NAME);
 
-            Map<String, Object> data = new HashMap<>();
-            data.put("owner", "john");
-            data.put("report", caseClaimReport);
-            caseClient.putCaseInstanceData(CONTAINER_ID, caseId, data);
+        caseClient.removeCaseInstanceData(CONTAINER_ID, caseId, "claimReport");
+        caseData = caseClient.getCaseInstanceData(CONTAINER_ID, caseId);
+        assertNotNull(caseData);
+        assertEquals(1, caseData.size());
+        assertEquals("fiat", caseData.get("car"));
 
-            caseData = caseClient.getCaseInstanceData(CONTAINER_ID, caseId);
-            assertNotNull(caseData);
-            assertEquals(3, caseData.size());
-            assertEquals("fiat", caseData.get("car"));
-            assertEquals("john", caseData.get("owner"));
+        Map<String, Object> data = new HashMap<>();
+        data.put("owner", "john");
+        data.put("report", caseClaimReport);
+        caseClient.putCaseInstanceData(CONTAINER_ID, caseId, data);
 
-            caseClaimReport = caseData.get("report");
-            assertNotNull(caseClaimReport);
-            assertEquals(caseClaimReport.getClass().getName(), CLAIM_REPORT_CLASS_NAME);
-        } catch (Exception e) {
-            fail("Failed due to " + e.getMessage());
-        } finally {
-            if (caseId != null) {
-                caseClient.cancelCaseInstance(CONTAINER_ID, caseId);
-            }
-        }
+        caseData = caseClient.getCaseInstanceData(CONTAINER_ID, caseId);
+        assertNotNull(caseData);
+        assertEquals(3, caseData.size());
+        assertEquals("fiat", caseData.get("car"));
+        assertEquals("john", caseData.get("owner"));
+
+        caseClaimReport = caseData.get("report");
+        assertNotNull(caseClaimReport);
+        assertEquals(caseClaimReport.getClass().getName(), CLAIM_REPORT_CLASS_NAME);
     }
 
     @Test
     public void testCreateCaseWithEmptyCaseFileThenDestroyIt() {
-        String caseId = caseClient.startCase(CONTAINER_ID, CASE_DEF_ID);
+        String caseId = caseClient.startCase(CONTAINER_ID, CLAIM_CASE_DEF_ID);
+
+        assertNotNull(caseId);
+        assertTrue(caseId.startsWith(CLAIM_CASE_ID_PREFIX));
+
+        CaseInstance caseInstance = caseClient.getCaseInstance(CONTAINER_ID, caseId);
+        assertCarInsuranceCaseInstance(caseInstance, caseId, USER_YODA);
+
+        // since roles were not assigned to any users/groups no tasks are available
+        List<TaskSummary> tasks = taskClient.findTasksAssignedAsPotentialOwner(USER_YODA, 0, 10);
+        assertEquals(0, tasks.size());
+
+        caseClient.destroyCaseInstance(CONTAINER_ID, caseId);
+
         try {
-            assertNotNull(caseId);
-            assertTrue(caseId.startsWith(CASE_ID_PREFIX));
-
-            CaseInstance caseInstance = caseClient.getCaseInstance(CONTAINER_ID, caseId);
-            assertNotNull(caseInstance);
-            assertEquals(caseId, caseInstance.getCaseId());
-            assertEquals(CASE_DEF_ID, caseInstance.getCaseDefinitionId());
-            assertEquals(CASE_DESCRIPTION, caseInstance.getCaseDescription());
-            assertEquals(USER_YODA, caseInstance.getCaseOwner());
-            assertEquals(ProcessInstance.STATE_ACTIVE, caseInstance.getCaseStatus().intValue());
-            assertNotNull(caseInstance.getStartedAt());
-            assertNull(caseInstance.getCompletedAt());
-            assertEquals("", caseInstance.getCompletionMessage());
-            assertEquals(CONTAINER_ID, caseInstance.getContainerId());
-
-            // since roles were not assigned to any users/groups no tasks are available
-            List<TaskSummary> tasks = taskClient.findTasksAssignedAsPotentialOwner(USER_YODA, 0, 10);
-            assertEquals(0, tasks.size());
-
-            caseClient.destroyCaseInstance(CONTAINER_ID, caseId);
-
-            try {
-                // this should throw exception as there is no case any more
-                caseClient.getCaseInstance(CONTAINER_ID, caseId);
-                fail("Case should not exists any more");
-            } catch (KieServicesException e) {
-                // expected
-            }
-        } catch (Exception e) {
-            fail("Failed due to " + e.getMessage());
-
-            if (caseId != null) {
-                caseClient.cancelCaseInstance(CONTAINER_ID, caseId);
-            }
+            // this should throw exception as there is no case any more
+            caseClient.getCaseInstance(CONTAINER_ID, caseId);
+            fail("Case should not exists any more");
+        } catch (KieServicesException e) {
+            // expected
         }
     }
 
     @Test
-    public void testCreateCaseWithEmptyCaseFileThenReopenIt() {
-        String caseId = caseClient.startCase(CONTAINER_ID, CASE_DEF_ID);
+    public void testCreateCancelAndReopenCaseWithEmptyCaseFile() {
+        String caseId = caseClient.startCase(CONTAINER_ID, CLAIM_CASE_DEF_ID);
+
+        assertNotNull(caseId);
+        assertTrue(caseId.startsWith(CLAIM_CASE_ID_PREFIX));
+
+        CaseInstance caseInstance = caseClient.getCaseInstance(CONTAINER_ID, caseId);
+        assertCarInsuranceCaseInstance(caseInstance, caseId, USER_YODA);
+
+        caseClient.cancelCaseInstance(CONTAINER_ID, caseId);
+
         try {
-            assertNotNull(caseId);
-            assertTrue(caseId.startsWith(CASE_ID_PREFIX));
-
-            CaseInstance caseInstance = caseClient.getCaseInstance(CONTAINER_ID, caseId);
-            assertNotNull(caseInstance);
-            assertEquals(caseId, caseInstance.getCaseId());
-            assertEquals(CASE_DEF_ID, caseInstance.getCaseDefinitionId());
-            assertEquals(CASE_DESCRIPTION, caseInstance.getCaseDescription());
-            assertEquals(USER_YODA, caseInstance.getCaseOwner());
-            assertEquals(ProcessInstance.STATE_ACTIVE, caseInstance.getCaseStatus().intValue());
-            assertNotNull(caseInstance.getStartedAt());
-            assertNull(caseInstance.getCompletedAt());
-            assertEquals("", caseInstance.getCompletionMessage());
-            assertEquals(CONTAINER_ID, caseInstance.getContainerId());
-
-            caseClient.cancelCaseInstance(CONTAINER_ID, caseId);
-
-            try {
-                // this should throw exception as there is no case any more
-                caseClient.getCaseInstance(CONTAINER_ID, caseId);
-                fail("Case should not exists any more");
-            } catch (KieServicesException e) {
-                // expected
-            }
-            Map<String, Object> data = new HashMap<>();
-            data.put("additionalComment", "reopening the case");
-            caseClient.reopenCase(caseId, CONTAINER_ID, CASE_DEF_ID, data);
-
-            caseInstance = caseClient.getCaseInstance(CONTAINER_ID, caseId);
-            assertNotNull(caseInstance);
-            assertEquals(caseId, caseInstance.getCaseId());
-
-            Object additionalComment = caseClient.getCaseInstanceData(CONTAINER_ID, caseId, "additionalComment");
-            assertNotNull(additionalComment);
-            assertEquals("reopening the case", additionalComment);
-        } catch (Exception e) {
-            fail("Failed due to " + e.getMessage());
-
-            if (caseId != null) {
-                caseClient.cancelCaseInstance(CONTAINER_ID, caseId);
-            }
+            // this should throw exception as there is no case any more
+            caseClient.getCaseInstance(CONTAINER_ID, caseId);
+            fail("Case should not exists any more");
+        } catch (KieServicesException e) {
+            // expected
         }
+        Map<String, Object> data = new HashMap<>();
+        data.put("additionalComment", "reopening the case");
+        caseClient.reopenCase(caseId, CONTAINER_ID, CLAIM_CASE_DEF_ID, data);
+
+        caseInstance = caseClient.getCaseInstance(CONTAINER_ID, caseId);
+        assertNotNull(caseInstance);
+        assertEquals(caseId, caseInstance.getCaseId());
+
+        Object additionalComment = caseClient.getCaseInstanceData(CONTAINER_ID, caseId, "additionalComment");
+        assertNotNull(additionalComment);
+        assertEquals("reopening the case", additionalComment);
     }
 
     @Test
     public void testCreateCaseWithEmptyCaseFileWithContainerAlias() {
-        String caseId = caseClient.startCase(CONTAINER_ALIAS, CASE_DEF_ID);
+        String caseId = caseClient.startCase(CONTAINER_ALIAS, CLAIM_CASE_DEF_ID);
+
+        assertNotNull(caseId);
+        assertTrue(caseId.startsWith(CLAIM_CASE_ID_PREFIX));
+
+        CaseInstance caseInstance = caseClient.getCaseInstance(CONTAINER_ALIAS, caseId);
+        assertCarInsuranceCaseInstance(caseInstance, caseId, USER_YODA);
+
+        // since roles were not assigned to any users/groups no tasks are available
+        List<TaskSummary> tasks = taskClient.findTasksAssignedAsPotentialOwner(USER_YODA, 0, 10);
+        assertEquals(0, tasks.size());
+    }
+
+    @Test
+    public void testCancelCaseInstanceNotExistingContainer() {
         try {
-            assertNotNull(caseId);
-            assertTrue(caseId.startsWith(CASE_ID_PREFIX));
-
-            CaseInstance caseInstance = caseClient.getCaseInstance(CONTAINER_ALIAS, caseId);
-            assertNotNull(caseInstance);
-            assertEquals(caseId, caseInstance.getCaseId());
-            assertEquals(CASE_DEF_ID, caseInstance.getCaseDefinitionId());
-            assertEquals(CASE_DESCRIPTION, caseInstance.getCaseDescription());
-            assertEquals(USER_YODA, caseInstance.getCaseOwner());
-            assertEquals(ProcessInstance.STATE_ACTIVE, caseInstance.getCaseStatus().intValue());
-            assertNotNull(caseInstance.getStartedAt());
-            assertNull(caseInstance.getCompletedAt());
-            assertEquals("", caseInstance.getCompletionMessage());
-            assertEquals(CONTAINER_ID, caseInstance.getContainerId());
-
-            // since roles were not assigned to any users/groups no tasks are available
-            List<TaskSummary> tasks = taskClient.findTasksAssignedAsPotentialOwner(USER_YODA, 0, 10);
-            assertEquals(0, tasks.size());
-        } catch (Exception e) {
-            fail("Failed due to " + e.getMessage());
-        } finally {
-            if (caseId != null) {
-                caseClient.cancelCaseInstance(CONTAINER_ALIAS, caseId);
-            }
+            caseClient.cancelCaseInstance("not-existing-container", CLAIM_CASE_DEF_ID);
+            fail("Should have failed because of not existing container.");
+        } catch (KieServicesException e) {
+            // expected
         }
     }
 
+    @Test
+    public void testCancelCaseInstanceNotExistingCase() {
+        try {
+            caseClient.cancelCaseInstance(CONTAINER_ID, "not-existing-case");
+            fail("Should have failed because of not existing case definition Id.");
+        } catch (KieServicesException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testDestroyCaseInstance() {
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("car", "ford");
+        CaseFile caseFile = CaseFile.builder()
+                .data(caseData)
+                .build();
+
+        String caseId = caseClient.startCase(CONTAINER_ID, CLAIM_CASE_DEF_ID, caseFile);
+        assertNotNull(caseId);
+
+        CaseInstance caseInstance = caseClient.getCaseInstance(CONTAINER_ID, caseId);
+        assertCarInsuranceCaseInstance(caseInstance, caseId, USER_YODA);
+
+        caseClient.destroyCaseInstance(CONTAINER_ID, caseId);
+
+        try {
+            // this should throw exception as there is no case any more
+            caseClient.getCaseInstance(CONTAINER_ID, caseId);
+            fail("Case should not exists any more");
+        } catch (KieServicesException e) {
+            // expected
+        }
+
+        // TODO: how this should work? Looks like destroy case/reopen doesn't work as expected.
+        caseClient.reopenCase(caseId, CONTAINER_ID, CLAIM_CASE_DEF_ID);
+
+        caseInstance = caseClient.getCaseInstance(CONTAINER_ID, caseId);
+        assertCarInsuranceCaseInstance(caseInstance, caseId, USER_YODA);
+
+        caseData = caseClient.getCaseInstanceData(CONTAINER_ID, caseId);
+        assertNotNull(caseData);
+        assertEquals("ford", caseData.get("car"));
+    }
+
+    @Test
+    public void testDestroyCaseInstanceNotExistingContainer() {
+        try {
+            caseClient.destroyCaseInstance("not-existing-container", CLAIM_CASE_DEF_ID);
+            fail("Should have failed because of not existing container.");
+        } catch (KieServicesException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testDestroyCaseInstanceNotExistingCase() {
+        try {
+            caseClient.destroyCaseInstance(CONTAINER_ID, "not-existing-case");
+            fail("Should have failed because of not existing case definition Id.");
+        } catch (KieServicesException e) {
+            // expected
+        }
+    }
+
+    private void assertCarInsuranceCaseInstance(CaseInstance caseInstance, String caseId, String owner) {
+        assertNotNull(caseInstance);
+        assertEquals(caseId, caseInstance.getCaseId());
+        assertEquals(CLAIM_CASE_DEF_ID, caseInstance.getCaseDefinitionId());
+        assertEquals(CLAIM_CASE_DESRIPTION, caseInstance.getCaseDescription());
+        assertEquals(owner, caseInstance.getCaseOwner());
+        assertEquals(ProcessInstance.STATE_ACTIVE, caseInstance.getCaseStatus().intValue());
+        assertNotNull(caseInstance.getStartedAt());
+        assertNull(caseInstance.getCompletedAt());
+        assertEquals("", caseInstance.getCompletionMessage());
+        assertEquals(CONTAINER_ID, caseInstance.getContainerId());
+    }
 }


### PR DESCRIPTION
Some more info:
- changes contains group of //TODO marks, these needs to be clarified first. One widespread question: if Kie server gets request containing wrong container id or case id what it should return? Should it return error or empty result? For example see testGetActiveProcessInstancesNotExistingCase()
- See also sorting extensions for Case client - is sorting implemented for all methods which should have it? Is it missing somewhere else? Is sorting pointless for some methods where it is implemented?