### PR TITLE
kie-server-tests: allow external configuration of excluded groups

### DIFF
--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -34,6 +34,8 @@
     <!-- Custom settings.xml used when building the testing kjars. By default there is no additional configuration needed,
          but for testing e.g. stated builds it is necessary to pass additional repository with the staged artifacts. -->
     <kie.server.testing.kjars.build.settings.xml/>
+    <!-- This property can be overriden to exclude specific test category according to specific needs. -->
+    <failsafe.excluded.groups/>
 
     <version.tomcat7>7.0.55</version.tomcat7>
     <version.tomcat8>8.0.12</version.tomcat8>
@@ -119,6 +121,9 @@
                 <goal>integration-test</goal>
                 <goal>verify</goal>
               </goals>
+              <configuration>
+                <excludedGroups>${failsafe.excluded.groups}</excludedGroups>
+              </configuration>
             </execution>
           </executions>
         </plugin>
@@ -170,6 +175,7 @@
       <id>wildfly81x</id>
       <properties>
         <org.kie.server.persistence.ds>java:jboss/datasources/ExampleDS</org.kie.server.persistence.ds>
+        <failsafe.excluded.groups>org.kie.server.integrationtests.category.Email</failsafe.excluded.groups>
       </properties>
       <build>
         <pluginManagement>
@@ -204,12 +210,6 @@
                 </deployables>
               </configuration>
             </plugin>
-            <plugin>
-              <artifactId>maven-failsafe-plugin</artifactId>
-              <configuration>
-                <excludedGroups>org.kie.server.integrationtests.category.Email</excludedGroups>
-              </configuration>
-            </plugin>
           </plugins>
         </pluginManagement>
       </build>
@@ -219,6 +219,7 @@
       <properties>
         <kie.server.remoting.url>http-remoting://${container.hostname}:${container.port}</kie.server.remoting.url>
         <org.kie.server.persistence.ds>java:jboss/datasources/ExampleDS</org.kie.server.persistence.ds>
+        <failsafe.excluded.groups>org.kie.server.integrationtests.category.Email</failsafe.excluded.groups>
       </properties>
       <build>
         <pluginManagement>
@@ -251,12 +252,6 @@
                     <classifier>ee7</classifier>
                   </deployable>
                 </deployables>
-              </configuration>
-            </plugin>
-            <plugin>
-              <artifactId>maven-failsafe-plugin</artifactId>
-              <configuration>
-                <excludedGroups>org.kie.server.integrationtests.category.Email</excludedGroups>
               </configuration>
             </plugin>
           </plugins>
@@ -369,6 +364,7 @@
       <id>tomcat7x</id>
       <properties>
         <org.kie.server.persistence.ds>java:comp/env/jdbc/jbpm</org.kie.server.persistence.ds>
+        <failsafe.excluded.groups>org.kie.server.integrationtests.category.JMSOnly,org.kie.server.integrationtests.category.Email</failsafe.excluded.groups>
       </properties>
       <build>
         <pluginManagement>
@@ -437,12 +433,6 @@
                 </deployables>
               </configuration>
             </plugin>
-            <plugin>
-              <artifactId>maven-failsafe-plugin</artifactId>
-              <configuration>
-                <excludedGroups>org.kie.server.integrationtests.category.JMSOnly,org.kie.server.integrationtests.category.Email</excludedGroups>
-              </configuration>
-            </plugin>
           </plugins>
         </pluginManagement>
       </build>
@@ -483,6 +473,7 @@
       <id>tomcat8x</id>
       <properties>
         <org.kie.server.persistence.ds>java:comp/env/jdbc/jbpm</org.kie.server.persistence.ds>
+        <failsafe.excluded.groups>org.kie.server.integrationtests.category.JMSOnly,org.kie.server.integrationtests.category.Email</failsafe.excluded.groups>
       </properties>
       <build>
         <pluginManagement>
@@ -549,12 +540,6 @@
                     <classifier>webc</classifier>
                   </deployable>
                 </deployables>
-              </configuration>
-            </plugin>
-            <plugin>
-              <artifactId>maven-failsafe-plugin</artifactId>
-              <configuration>
-                <excludedGroups>org.kie.server.integrationtests.category.JMSOnly,org.kie.server.integrationtests.category.Email</excludedGroups>
               </configuration>
             </plugin>
           </plugins>
@@ -674,6 +659,7 @@
         <kie.server.context>kie-server-${project.version}-ee7</kie.server.context>
         <kie.server.controller.context>kie-server-controller-${project.version}-ee7</kie.server.controller.context>
         <org.kie.server.persistence.ds>jdbc/jbpm</org.kie.server.persistence.ds>
+        <failsafe.excluded.groups>org.kie.server.integrationtests.category.Email</failsafe.excluded.groups>
       </properties>
       <build>
         <pluginManagement>
@@ -771,7 +757,6 @@
                 <additionalClasspathElements>
                   <additionalClasspathElement>${weblogic.home}/wlserver/server/lib/wljmsclient.jar</additionalClasspathElement>
                 </additionalClasspathElements>
-                <excludedGroups>org.kie.server.integrationtests.category.Email</excludedGroups>
               </configuration>
             </plugin>
           </plugins>
@@ -800,6 +785,7 @@
         <kie.server.jndi.response.queue>jms/KIE.SERVER.RESPONSE</kie.server.jndi.response.queue>
         <kie.server.connection.factory>jms/cf/KIE.SERVER.REQUEST</kie.server.connection.factory>
         <org.kie.server.persistence.ds>jdbc/jbpm</org.kie.server.persistence.ds>
+        <failsafe.excluded.groups>org.kie.server.integrationtests.category.Email</failsafe.excluded.groups>
       </properties>
       <build>
         <pluginManagement>
@@ -907,7 +893,6 @@
                   <additionalClasspathElement>${websphere.home}/runtimes/com.ibm.ws.sib.client.thin.jms_8.5.0.jar</additionalClasspathElement>
                   <additionalClasspathElement>${websphere.home}/runtimes/com.ibm.ws.orb_8.5.0.jar</additionalClasspathElement>
                 </additionalClasspathElements>
-                <excludedGroups>org.kie.server.integrationtests.category.Email</excludedGroups>
               </configuration>
             </plugin>
           </plugins>


### PR DESCRIPTION
Cherrypick of https://github.com/droolsjbpm/droolsjbpm-integration/pull/636 .
Affects tests only.