### PR TITLE
kie-server-tests: minor cleanup and update

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/pom.xml
@@ -12,6 +12,11 @@
   <name>KIE :: Execution Server :: Tests :: Drools and jBPM Integration Tests</name>
   <description>KIE Execution Server Integration Tests (REST, JMS) with configuration to run on different supported containers.</description>
 
+  <properties>
+    <org.drools.server.ext.disabled>false</org.drools.server.ext.disabled>
+    <org.jbpm.server.ext.disabled>false</org.jbpm.server.ext.disabled>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.kie.server</groupId>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/pom.xml
@@ -188,7 +188,6 @@
                 <org.kie.server.controller.pwd>usetheforce123@</org.kie.server.controller.pwd>
                 <org.kie.server.user>yoda</org.kie.server.user>
                 <org.kie.server.pwd>usetheforce123@</org.kie.server.pwd>
-                <kie.server.testing.kjars.build.settings.xml>${kie.server.testing.kjars.build.settings.xml}</kie.server.testing.kjars.build.settings.xml>
               </systemProperties>
             </container>
             <deployables combine.children="append">

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/pom.xml
@@ -12,6 +12,10 @@
   <name>KIE :: Execution Server :: Tests :: Drools Integration Tests</name>
   <description>KIE Execution Server Integration Tests (REST, JMS) with configuration options to run on different containers.</description>
 
+  <properties>
+    <org.drools.server.ext.disabled>false</org.drools.server.ext.disabled>
+  </properties>
+
   <dependencies>
    <dependency>
       <groupId>org.kie.server</groupId>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/KieServerDroolsIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/KieServerDroolsIntegrationTest.java
@@ -49,6 +49,7 @@ import org.kie.server.integrationtests.shared.KieServerDeployer;
 
 public class KieServerDroolsIntegrationTest extends DroolsKieServerBaseIntegrationTest {
     private static ReleaseId releaseId = new ReleaseId("foo.bar", "baz", "2.1.0.GA");
+    private static ReleaseId releaseIdScript = new ReleaseId("foo.bar", "baz-script", "2.1.0.GA");
 
     private static final String CONTAINER_ID = "kie1";
     private static final String KIE_SESSION = "defaultKieSession";
@@ -65,6 +66,7 @@ public class KieServerDroolsIntegrationTest extends DroolsKieServerBaseIntegrati
     @BeforeClass
     public static void initialize() throws Exception {
         KieServerDeployer.createAndDeployKJar(releaseId);
+        KieServerDeployer.createAndDeployKJar(releaseIdScript);
 
         File jar = KieServerDeployer.getRepository().resolveArtifact(releaseId).getFile();
         kjarClassLoader = new URLClassLoader(new URL[]{jar.toURI().toURL()});
@@ -132,7 +134,7 @@ public class KieServerDroolsIntegrationTest extends DroolsKieServerBaseIntegrati
         String payload = marshaller.marshall(batch);
 
         String containerId = "command-script-container";
-        KieServerCommand create = new CreateContainerCommand(new KieContainerResource( containerId, releaseId, null));
+        KieServerCommand create = new CreateContainerCommand(new KieContainerResource( containerId, releaseIdScript, null));
         KieServerCommand call = new CallContainerCommand(containerId, payload);
         KieServerCommand dispose = new DisposeContainerCommand(containerId);
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
@@ -12,6 +12,10 @@
   <name>KIE :: Execution Server :: Tests :: jBPM Integration Tests</name>
   <description>KIE Execution Server Integration Tests (REST, JMS) with configuration to run on different supported containers.</description>
 
+  <properties>
+    <org.jbpm.server.ext.disabled>false</org.jbpm.server.ext.disabled>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.kie.server</groupId>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/pom.xml
@@ -12,6 +12,11 @@
   <name>KIE :: Execution Server :: Tests :: OptaPlanner Integration Tests</name>
   <description>KIE Execution Server Integration Tests (REST, JMS) with configuration options to run on different containers.</description>
 
+  <properties>
+    <org.drools.server.ext.disabled>false</org.drools.server.ext.disabled>
+    <org.optaplanner.server.ext.disabled>false</org.optaplanner.server.ext.disabled>
+  </properties>
+
   <dependencies>
    <dependency>
       <groupId>org.kie.server</groupId>


### PR DESCRIPTION
- cleanup of test properties as part of Cargo update preparation - new Cargo doesn't like system properties with null value
- fixed instability of KieServerDroolsIntegrationTest - there were 2 different containers with same GAV created, our KeepLatestOnly policy was randomly disposing one of them