### PR TITLE
[DROOLS-1357] kie-server: always return container resource with refre…

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/api/KieContainerInstance.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/api/KieContainerInstance.java
@@ -34,8 +34,6 @@ public interface KieContainerInstance {
 
     KieContainerResource getResource();
 
-    KieContainerResource getRefreshedResource();
-
     KieScanner getScanner();
 
     Marshaller getMarshaller(MarshallingFormat format);

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieContainerInstanceImpl.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieContainerInstanceImpl.java
@@ -114,16 +114,9 @@ public class KieContainerInstanceImpl implements KieContainerInstance {
         this.resource.setStatus( status );
     }
 
-    public KieContainerResource getResource() {
-        return resource;
-    }
-
     @Override
-    public KieContainerResource getRefreshedResource() {
-        if ( kieContainer != null ) {
-            this.resource.setReleaseId( new ReleaseId( kieContainer.getContainerReleaseId() ) );
-            this.resource.setResolvedReleaseId( new ReleaseId( kieContainer.getReleaseId() ) );
-        }
+    public KieContainerResource getResource() {
+        updateReleaseId();
         return resource;
     }
 
@@ -237,11 +230,37 @@ public class KieContainerInstanceImpl implements KieContainerInstance {
     }
 
     protected void updateReleaseId() {
+        ReleaseId oldReleaseId = this.resource.getReleaseId();
+        ReleaseId oldResolvedReleaseId = this.resource.getResolvedReleaseId();
         if ( kieContainer != null ) {
             this.resource.setReleaseId( new ReleaseId( kieContainer.getContainerReleaseId() ) );
             this.resource.setResolvedReleaseId( new ReleaseId( kieContainer.getReleaseId() ) );
         }
-        disposeMarshallers();
+        // marshallers need to disposed in case the container was updated with different releaseId
+        // proper solution is to attach listener directly to the KieScanner and dispose the marshallers,
+        // but those listeners are not (yet) available, so this is a temporary hackish "solution"
+        if (releaseIdUpdated(oldReleaseId, this.resource.getReleaseId())
+                || releaseIdUpdated(oldResolvedReleaseId, this.resource.getResolvedReleaseId())) {
+            disposeMarshallers();
+        }
+    }
+
+    /**
+     * Checks whether the releaseId was updated (i.e. the old one is different from the new one).
+     *
+     * @param oldReleaseId old ReleaseId
+     * @param newReleaseId new releaseId
+     * @return true if the second (new) releaseId is different and thus was updated; otherwise false
+     */
+    private boolean releaseIdUpdated(ReleaseId oldReleaseId, ReleaseId newReleaseId) {
+        if (oldReleaseId == null && newReleaseId == null) {
+            return false;
+        }
+        if (oldReleaseId == null && newReleaseId != null) {
+            return true;
+        }
+        // now both releaseIds are non-null, so it is safe to call equals()
+        return oldReleaseId.equals(newReleaseId);
     }
 
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
@@ -666,7 +666,7 @@ public class KieServerImpl implements KieServer {
         try {
             KieContainerInstanceImpl ci = context.getContainer(id);
             if (ci != null) {
-                return new ServiceResponse<ReleaseId>(ServiceResponse.ResponseType.SUCCESS, "ReleaseId for container " + id, ci.getRefreshedResource().getReleaseId());
+                return new ServiceResponse<ReleaseId>(ServiceResponse.ResponseType.SUCCESS, "ReleaseId for container " + id, ci.getResource().getReleaseId());
             }
             return new ServiceResponse<ReleaseId>(ServiceResponse.ResponseType.FAILURE, "Container " + id + " is not instantiated.");
         } catch (Exception e) {

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/pom.xml
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/pom.xml
@@ -17,11 +17,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/KieServerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/KieServerIntegrationTest.java
@@ -65,7 +65,7 @@ public class KieServerIntegrationTest extends RestJmsSharedBaseIntegrationTest {
         KieScannerResource info = si.getResult();
         Assert.assertEquals( KieScannerStatus.DISPOSED, info.getStatus() );
         
-        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.STARTED, 10000l));
+        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.STARTED, 10000L));
         Assert.assertEquals( si.getMsg(), ResponseType.SUCCESS, si.getType() );
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.STARTED, info.getStatus() );
@@ -75,7 +75,7 @@ public class KieServerIntegrationTest extends RestJmsSharedBaseIntegrationTest {
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.STARTED, info.getStatus() );
         
-        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.STOPPED, 10000l));
+        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.STOPPED, 10000L));
         Assert.assertEquals( si.getMsg(), ResponseType.SUCCESS, si.getType() );
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.STOPPED, info.getStatus() );
@@ -85,7 +85,7 @@ public class KieServerIntegrationTest extends RestJmsSharedBaseIntegrationTest {
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.STOPPED, info.getStatus() );
         
-        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.DISPOSED, 10000l));
+        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.DISPOSED, 10000L));
         Assert.assertEquals( si.getMsg(), ResponseType.SUCCESS, si.getType() );
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.DISPOSED, info.getStatus() );
@@ -103,7 +103,7 @@ public class KieServerIntegrationTest extends RestJmsSharedBaseIntegrationTest {
         KieScannerResource info = si.getResult();
         Assert.assertEquals( KieScannerStatus.DISPOSED, info.getStatus() );
 
-        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.SCANNING, 0l));
+        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.SCANNING, 0L));
         Assert.assertEquals( si.getMsg(), ResponseType.SUCCESS, si.getType() );
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.STOPPED, info.getStatus() );
@@ -113,7 +113,7 @@ public class KieServerIntegrationTest extends RestJmsSharedBaseIntegrationTest {
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.STOPPED, info.getStatus() );
 
-        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.DISPOSED, 10000l));
+        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.DISPOSED, 10000L));
         Assert.assertEquals( si.getMsg(), ResponseType.SUCCESS, si.getType() );
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.DISPOSED, info.getStatus() );
@@ -132,7 +132,7 @@ public class KieServerIntegrationTest extends RestJmsSharedBaseIntegrationTest {
         KieContainerResource kci = reply.getResult();
         Assert.assertEquals( KieScannerStatus.DISPOSED, kci.getScanner().getStatus() );
 
-        ServiceResponse<KieScannerResource> si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.STARTED, 10000l));
+        ServiceResponse<KieScannerResource> si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.STARTED, 10000L));
         Assert.assertEquals( si.getMsg(), ResponseType.SUCCESS, si.getType() );
         KieScannerResource info = si.getResult();
         Assert.assertEquals( KieScannerStatus.STARTED, info.getStatus() );
@@ -141,7 +141,7 @@ public class KieServerIntegrationTest extends RestJmsSharedBaseIntegrationTest {
         Assert.assertEquals( KieScannerStatus.STARTED, kci.getScanner().getStatus() );
         Assert.assertEquals( 10000, kci.getScanner().getPollInterval().longValue() );
 
-        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.STOPPED, 10000l));
+        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.STOPPED, 10000L));
         Assert.assertEquals( si.getMsg(), ResponseType.SUCCESS, si.getType() );
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.STOPPED, info.getStatus() );
@@ -149,7 +149,7 @@ public class KieServerIntegrationTest extends RestJmsSharedBaseIntegrationTest {
         kci = client.getContainerInfo( CONTAINER_ID ).getResult();
         Assert.assertEquals( KieScannerStatus.STOPPED, kci.getScanner().getStatus() );
 
-        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.DISPOSED, 10000l));
+        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.DISPOSED, 10000L));
         Assert.assertEquals( si.getMsg(), ResponseType.SUCCESS, si.getType() );
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.DISPOSED, info.getStatus() );


### PR DESCRIPTION
…shed releaseIds

 * the scanner works asynchronously, using own thread, so the releaseIds
   can be basically updated any time. We need to make sure to always
   update the releaseIds before actually returning the container resource

@mswiderski, @etirelli one thing I am wondering about is the existence of the method `KieContainerInstanceImpl#getResource` since it may return stale data. I think we should just rename the `getRefreshedResource()` to `getResource()` and make sure to always return refreshed resource. WDYT?