### PR TITLE
[DROOLS-1357, RHBPMS-4438] kie-server: always return container resour…

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-common/pom.xml
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/pom.xml
@@ -126,6 +126,17 @@
     </dependency>
 
     <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
     </dependency>

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/api/KieContainerInstance.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/api/KieContainerInstance.java
@@ -34,8 +34,6 @@ public interface KieContainerInstance {
 
     KieContainerResource getResource();
 
-    KieContainerResource getRefreshedResource();
-
     KieScanner getScanner();
 
     Marshaller getMarshaller(MarshallingFormat format);

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieContainerInstanceImpl.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieContainerInstanceImpl.java
@@ -256,7 +256,7 @@ public class KieContainerInstanceImpl implements KieContainerInstance {
             return true;
         }
         // now both releaseIds are non-null, so it is safe to call equals()
-        return oldReleaseId.equals(newReleaseId);
+        return !oldReleaseId.equals(newReleaseId);
     }
 
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
@@ -438,7 +438,7 @@ public class KieServerImpl {
     }
 
     private KieScannerResource getScannerResource(KieContainerInstanceImpl kci) {
-        return kci.getRefreshedResource().getScanner();
+        return kci.getResource().getScanner();
     }
 
     public ServiceResponse<KieScannerResource> updateScanner(String id, KieScannerResource resource) {
@@ -691,7 +691,7 @@ public class KieServerImpl {
                     repository.store(KieServerEnvironment.getServerId(), currentState);
 
                     messages.add(new Message(Severity.INFO, "Release id successfully updated for container " + id));
-                    return new ServiceResponse<ReleaseId>(ServiceResponse.ResponseType.SUCCESS, "Release id successfully updated.", kci.getRefreshedResource().getReleaseId());
+                    return new ServiceResponse<ReleaseId>(ServiceResponse.ResponseType.SUCCESS, "Release id successfully updated.", kci.getResource().getReleaseId());
                 }
             } else {
                 // no container yet, attempt to create it
@@ -700,7 +700,7 @@ public class KieServerImpl {
                 ServiceResponse<KieContainerResource> response = createContainer(id, containerResource);
                 if (response.getType().equals(ResponseType.SUCCESS)) {
                     kci = context.getContainer(id);
-                    return new ServiceResponse<ReleaseId>(ServiceResponse.ResponseType.SUCCESS, "Release id successfully updated.", kci.getRefreshedResource().getReleaseId());
+                    return new ServiceResponse<ReleaseId>(ServiceResponse.ResponseType.SUCCESS, "Release id successfully updated.", kci.getResource().getReleaseId());
                 } else {
                     return new ServiceResponse<ReleaseId>(ServiceResponse.ResponseType.FAILURE, "Container " + id + " is not instantiated.");
                 }

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/KieContainerInstanceImplTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/KieContainerInstanceImplTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.services.impl;
+
+import org.assertj.core.api.Assertions;
+import org.drools.compiler.kie.builder.impl.InternalKieContainer;
+import org.drools.compiler.kie.builder.impl.InternalKieModule;
+import org.junit.Test;
+import org.kie.api.KieServices;
+import org.kie.api.builder.KieFileSystem;
+import org.kie.api.builder.KieModule;
+import org.kie.scanner.MavenRepository;
+import org.kie.server.api.marshalling.Marshaller;
+import org.kie.server.api.marshalling.MarshallingFormat;
+import org.kie.server.api.model.KieContainerResource;
+import org.kie.server.api.model.KieContainerStatus;
+import org.kie.server.api.model.ReleaseId;
+
+public class KieContainerInstanceImplTest {
+
+    private static final String CONTAINER_ID = "my-container";
+    private static final String GROUP_ID = "org.kie.server.test";
+    private static final String ARTIFACT_ID = "my-test-artifact";
+    private static final String VERSION_100 = "1.0.0.Final";
+    private static final String VERSION_101 = "1.0.1.Final";
+
+    private static final ReleaseId RELEASE_ID_100 = new ReleaseId(GROUP_ID, ARTIFACT_ID, VERSION_100);
+    private static final ReleaseId RELEASE_ID_101 = new ReleaseId(GROUP_ID, ARTIFACT_ID, VERSION_101);
+
+    @Test
+    public void testUpdatingOfReleaseId() {
+        createEmptyKjar(GROUP_ID, ARTIFACT_ID, VERSION_100);
+        createEmptyKjar(GROUP_ID, ARTIFACT_ID, VERSION_101);
+
+        KieServices ks = KieServices.Factory.get();
+        InternalKieContainer kieContainer = (InternalKieContainer) ks.newKieContainer(RELEASE_ID_100);
+        KieContainerInstanceImpl containerInstance = new KieContainerInstanceImpl(CONTAINER_ID, KieContainerStatus.STARTED, kieContainer);
+
+        Marshaller marshaller = containerInstance.getMarshaller(MarshallingFormat.JAXB);
+
+        // Call getResource() and verify release id
+        KieContainerResource containerResource = containerInstance.getResource();
+        Assertions.assertThat(containerResource).isNotNull();
+        verifyReleaseId(containerResource.getReleaseId(), RELEASE_ID_100);
+        verifyReleaseId(containerResource.getResolvedReleaseId(), RELEASE_ID_100);
+
+        // Marshaller is same - no change in release id
+        Marshaller updatedMarshaller = containerInstance.getMarshaller(MarshallingFormat.JAXB);
+        Assertions.assertThat(updatedMarshaller).isEqualTo(marshaller);
+
+        // Setting kie container with version change
+        containerInstance.getKieContainer().updateToVersion(RELEASE_ID_101);
+
+        // Call getResource() and verify release id
+        containerResource = containerInstance.getResource();
+        Assertions.assertThat(containerResource).isNotNull();
+        verifyReleaseId(containerResource.getReleaseId(), RELEASE_ID_101);
+        verifyReleaseId(containerResource.getResolvedReleaseId(), RELEASE_ID_101);
+
+        // Marshaller is different - release id was updated
+        updatedMarshaller = containerInstance.getMarshaller(MarshallingFormat.JAXB);
+        Assertions.assertThat(updatedMarshaller).isNotEqualTo(marshaller);
+    }
+
+    private void verifyReleaseId(ReleaseId actualReleaseId, ReleaseId expectedReleaseId) {
+        Assertions.assertThat(actualReleaseId).isNotNull();
+        Assertions.assertThat(actualReleaseId.getGroupId()).isEqualTo(expectedReleaseId.getGroupId());
+        Assertions.assertThat(actualReleaseId.getArtifactId()).isEqualTo(expectedReleaseId.getArtifactId());
+        Assertions.assertThat(actualReleaseId.getVersion()).isEqualTo(expectedReleaseId.getVersion());
+    }
+
+    private void createEmptyKjar(String groupId, String artifactId, String version) {
+        // create empty kjar; content does not matter
+        KieServices kieServices = KieServices.Factory.get();
+        KieFileSystem kfs = kieServices.newKieFileSystem();
+        org.kie.api.builder.ReleaseId releaseId = kieServices.newReleaseId(groupId, artifactId, version);
+
+        kfs.generateAndWritePomXML(releaseId);
+        KieModule kieModule = kieServices.newKieBuilder( kfs ).buildAll().getKieModule();
+        byte[] pom = kfs.read("pom.xml");
+        byte[] jar = ((InternalKieModule)kieModule).getBytes();
+        MavenRepository.getMavenRepository().installArtifact(releaseId, jar, pom);
+    }
+}

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/KieServerImplTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/KieServerImplTest.java
@@ -16,12 +16,10 @@
 package org.kie.server.services.impl;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.assertj.core.api.Assertions;
 import org.drools.compiler.kie.builder.impl.InternalKieModule;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieFileSystem;
@@ -29,6 +27,7 @@ import org.kie.api.builder.KieModule;
 import org.kie.scanner.MavenRepository;
 import org.kie.server.api.KieServerEnvironment;
 import org.kie.server.api.model.KieContainerResource;
+import org.kie.server.api.model.KieContainerResourceList;
 import org.kie.server.api.model.KieScannerResource;
 import org.kie.server.api.model.KieScannerStatus;
 import org.kie.server.api.model.ReleaseId;
@@ -39,7 +38,7 @@ import org.kie.server.services.impl.storage.file.KieServerStateFileRepository;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Date;
+import java.util.List;
 import java.util.Set;
 
 public class KieServerImplTest {
@@ -47,7 +46,7 @@ public class KieServerImplTest {
     private static final File REPOSITORY_DIR = new File("target/repository-dir");
     private static final String KIE_SERVER_ID = "kie-server-impl-test";
     private static final String GROUP_ID = "org.kie.server.test";
-    private static final String VERSION = "1.0.0.Final";
+    private static final String DEFAULT_VERSION = "1.0.0.Final";
 
     private KieServerImpl kieServer;
     private org.kie.api.builder.ReleaseId releaseId;
@@ -118,17 +117,63 @@ public class KieServerImplTest {
         Assertions.assertThat(getResponse.getResult().getScanner()).isEqualTo(kieScannerResource);
     }
 
+    @Test
+    public void testReturnRefreshedResolvedReleaseIdAfterUpdateFromScanner() throws Exception {
+        // first create a simple container with fixed kjar version
+        String artifactId = "refreshed-resource-test";
+        String version1 = "1.0.0.Final";
+        createEmptyKjar(artifactId, version1);
+        ReleaseId releaseId1 = new ReleaseId(GROUP_ID, artifactId, version1);
+        String containerId = "refreshed-resource-container";
+        ServiceResponse<KieContainerResource> createResponse = kieServer.createContainer(containerId, new KieContainerResource(containerId, releaseId1));
+        Assertions.assertThat(createResponse.getType()).isEqualTo(ServiceResponse.ResponseType.SUCCESS);
+        Assertions.assertThat(createResponse.getResult().getReleaseId()).isEqualTo(releaseId1);
+        Assertions.assertThat(createResponse.getResult().getResolvedReleaseId()).isEqualTo(releaseId1);
+        // now update the version to LATEST and start the scanner
+        ReleaseId latestReleaseId = new ReleaseId(GROUP_ID, artifactId, "LATEST");
+        kieServer.updateContainerReleaseId(containerId, latestReleaseId);
+        kieServer.updateScanner(containerId, new KieScannerResource(KieScannerStatus.STARTED, 200L));
+        // deploy newer version of the kjar; it should get picked up by the scanner
+        String version2 = "1.0.1.Final";
+        createEmptyKjar(artifactId, version2);
+        // the scanner operation is async, so it will take some time until the releaseId gets updated
+        assertReleaseIds(containerId, latestReleaseId, new ReleaseId(GROUP_ID, artifactId, version2), 10000L);
+    }
+
+    private void assertReleaseIds(String containerId, ReleaseId configuredReleaseId, ReleaseId resolvedReleaseId, long timeoutMillis) throws InterruptedException {
+        long timeSpentWaiting = 0;
+        while (timeSpentWaiting < timeoutMillis) {
+            ServiceResponse<KieContainerResourceList> listResponse = kieServer.listContainers();
+            Assertions.assertThat(listResponse.getType()).isEqualTo(ServiceResponse.ResponseType.SUCCESS);
+            List<KieContainerResource> containers = listResponse.getResult().getContainers();
+            for (KieContainerResource container : containers) {
+                if (configuredReleaseId.equals(container.getReleaseId())
+                        && resolvedReleaseId.equals(container.getResolvedReleaseId())) {
+                    return;
+                }
+            }
+            Thread.sleep(200);
+            timeSpentWaiting += 200L;
+        }
+        Assertions.fail("Waiting too long for container " + containerId + " to have expected releaseIds updated! " +
+                "expected: releaseId=" + configuredReleaseId + ", resolvedReleaseId=" + resolvedReleaseId);
+    }
+
+
     private void createEmptyKjar(String artifactId) {
+        createEmptyKjar(artifactId, DEFAULT_VERSION);
+    }
+    private void createEmptyKjar(String artifactId, String version) {
         // create empty kjar; content does not matter
         KieServices kieServices = KieServices.Factory.get();
         KieFileSystem kfs = kieServices.newKieFileSystem();
-        releaseId = kieServices.newReleaseId(GROUP_ID, artifactId, VERSION);
+        releaseId = kieServices.newReleaseId(GROUP_ID, artifactId, version);
         KieModule kieModule = kieServices.newKieBuilder( kfs ).buildAll().getKieModule();
-        MavenRepository.getMavenRepository().installArtifact(releaseId, (InternalKieModule)kieModule, createPomFile(artifactId));
+        MavenRepository.getMavenRepository().installArtifact(releaseId, (InternalKieModule)kieModule, createPomFile(artifactId, version));
         kieServices.getRepository().addKieModule(kieModule);
     }
 
-    private File createPomFile(String artifactId) {
+    private File createPomFile(String artifactId, String version) {
         String pomContent = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                 "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
                 "         xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd\">\n" +
@@ -136,7 +181,7 @@ public class KieServerImplTest {
                 "\n" +
                 "  <groupId>org.kie.server.test</groupId>\n" +
                 "  <artifactId>" + artifactId + "</artifactId>\n" +
-                "  <version>1.0.0.Final</version>\n" +
+                "  <version>" + version + "</version>\n" +
                 "  <packaging>pom</packaging>\n" +
                 "</project>";
         try {

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/KieServerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/KieServerIntegrationTest.java
@@ -74,7 +74,7 @@ public class KieServerIntegrationTest extends RestJmsSharedBaseIntegrationTest {
         KieScannerResource info = si.getResult();
         Assert.assertEquals( KieScannerStatus.DISPOSED, info.getStatus() );
         
-        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.STARTED, 10000l));
+        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.STARTED, 10000L));
         Assert.assertEquals( si.getMsg(), ResponseType.SUCCESS, si.getType() );
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.STARTED, info.getStatus() );
@@ -84,7 +84,7 @@ public class KieServerIntegrationTest extends RestJmsSharedBaseIntegrationTest {
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.STARTED, info.getStatus() );
         
-        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.STOPPED, 10000l));
+        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.STOPPED, 10000L));
         Assert.assertEquals( si.getMsg(), ResponseType.SUCCESS, si.getType() );
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.STOPPED, info.getStatus() );
@@ -94,7 +94,7 @@ public class KieServerIntegrationTest extends RestJmsSharedBaseIntegrationTest {
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.STOPPED, info.getStatus() );
         
-        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.DISPOSED, 10000l));
+        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.DISPOSED, 10000L));
         Assert.assertEquals( si.getMsg(), ResponseType.SUCCESS, si.getType() );
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.DISPOSED, info.getStatus() );
@@ -116,7 +116,7 @@ public class KieServerIntegrationTest extends RestJmsSharedBaseIntegrationTest {
         KieScannerResource info = si.getResult();
         Assert.assertEquals( KieScannerStatus.DISPOSED, info.getStatus() );
 
-        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.SCANNING, 0l));
+        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.SCANNING, 0L));
         Assert.assertEquals( si.getMsg(), ResponseType.SUCCESS, si.getType() );
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.STOPPED, info.getStatus() );
@@ -126,7 +126,7 @@ public class KieServerIntegrationTest extends RestJmsSharedBaseIntegrationTest {
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.STOPPED, info.getStatus() );
 
-        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.DISPOSED, 10000l));
+        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.DISPOSED, 10000L));
         Assert.assertEquals( si.getMsg(), ResponseType.SUCCESS, si.getType() );
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.DISPOSED, info.getStatus() );
@@ -146,7 +146,7 @@ public class KieServerIntegrationTest extends RestJmsSharedBaseIntegrationTest {
         KieContainerResource kci = reply.getResult();
         Assert.assertEquals( KieScannerStatus.DISPOSED, kci.getScanner().getStatus() );
 
-        ServiceResponse<KieScannerResource> si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.STARTED, 10000l));
+        ServiceResponse<KieScannerResource> si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.STARTED, 10000L));
         Assert.assertEquals( si.getMsg(), ResponseType.SUCCESS, si.getType() );
         KieScannerResource info = si.getResult();
         Assert.assertEquals( KieScannerStatus.STARTED, info.getStatus() );
@@ -155,7 +155,7 @@ public class KieServerIntegrationTest extends RestJmsSharedBaseIntegrationTest {
         Assert.assertEquals( KieScannerStatus.STARTED, kci.getScanner().getStatus() );
         Assert.assertEquals( 10000, kci.getScanner().getPollInterval().longValue() );
 
-        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.STOPPED, 10000l));
+        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.STOPPED, 10000L));
         Assert.assertEquals( si.getMsg(), ResponseType.SUCCESS, si.getType() );
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.STOPPED, info.getStatus() );
@@ -163,7 +163,7 @@ public class KieServerIntegrationTest extends RestJmsSharedBaseIntegrationTest {
         kci = client.getContainerInfo( CONTAINER_ID ).getResult();
         Assert.assertEquals( KieScannerStatus.STOPPED, kci.getScanner().getStatus() );
 
-        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.DISPOSED, 10000l));
+        si = client.updateScanner(CONTAINER_ID, new KieScannerResource(KieScannerStatus.DISPOSED, 10000L));
         Assert.assertEquals( si.getMsg(), ResponseType.SUCCESS, si.getType() );
         info = si.getResult();
         Assert.assertEquals( KieScannerStatus.DISPOSED, info.getStatus() );


### PR DESCRIPTION
…ce with refreshed releaseIds

* the scanner works asynchronously, using own thread, so the releaseIds
   can be basically updated any time. We need to make sure to always
   update the releaseIds before actually returning the container resource

Backport of #723.

@mswiderski I am not sure if it is safe to remove the `getRefreshedResource()` in patch release. It seems it should be just internal interface, but is there a chance users could be using it as well?