### PR TITLE
kie-server-tests: improve Case dynamic task coverage

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/filtered-resources/kjars-sources/case-insurance/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/filtered-resources/kjars-sources/case-insurance/pom.xml
@@ -13,6 +13,15 @@
   <version>1.0.0.Final</version>
   <name>case-insurance</name>
 
+  <dependencies>
+    <dependency>
+     <groupId>org.kie</groupId>
+     <artifactId>kie-api</artifactId>
+     <version>${version.org.kie}</version>
+     <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
   <build>
     <plugins>
       <plugin>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/filtered-resources/kjars-sources/case-insurance/src/main/java/org/kie/server/workitem/ContactCarProducerWorkItemHandler.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/filtered-resources/kjars-sources/case-insurance/src/main/java/org/kie/server/workitem/ContactCarProducerWorkItemHandler.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.workitem;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.kie.api.runtime.process.WorkItem;
+import org.kie.api.runtime.process.WorkItemHandler;
+import org.kie.api.runtime.process.WorkItemManager;
+
+public class ContactCarProducerWorkItemHandler implements WorkItemHandler {
+
+    public void executeWorkItem(WorkItem workItem, WorkItemManager manager) {
+        String carId = (String) workItem.getParameter("carId");
+
+        Map<String, Object> results = new HashMap<String, Object>();
+        results.put("caseFile_carProducerReport", carId + " was regularly maintained and checked.");
+
+        manager.completeWorkItem(workItem.getId(), results);
+    }
+
+    public void abortWorkItem(WorkItem workItem, WorkItemManager manager) {
+      // Do nothing
+    }
+}

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/filtered-resources/kjars-sources/case-insurance/src/main/resources/META-INF/kie-deployment-descriptor.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/filtered-resources/kjars-sources/case-insurance/src/main/resources/META-INF/kie-deployment-descriptor.xml
@@ -22,6 +22,12 @@
             <parameters/>
             <name>Service Task</name>
         </work-item-handler>
+        <work-item-handler>
+            <resolver>mvel</resolver>
+            <identifier>new org.kie.server.workitem.ContactCarProducerWorkItemHandler()</identifier>
+            <parameters/>
+            <name>ContactCarProducer</name>
+        </work-item-handler>
     </work-item-handlers>
     <environment-entries/>
     <configurations/>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/cases/CaseServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/cases/CaseServiceIntegrationTest.java
@@ -51,6 +51,9 @@ public class CaseServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
 
     private static final String CONTAINER_ALIAS = "ins";
 
+    private static final String CAR_PRODUCER_REPORT_PARAMETER = "carId";
+    private static final String CAR_PRODUCER_REPORT_OUTPUT = "carProducerReport";
+
     @BeforeClass
     public static void buildAndDeployArtifacts() {
 
@@ -320,6 +323,43 @@ public class CaseServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
         try {
             caseClient.destroyCaseInstance(CONTAINER_ID, "not-existing-case");
             fail("Should have failed because of not existing case definition Id.");
+        } catch (KieServicesException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testAddDynamicWorkItemTask() {
+        String carId = "Ford Mustang";
+        String producerReportResponse = carId + " was regularly maintained and checked.";
+
+        String caseId = caseClient.startCase(CONTAINER_ID, CLAIM_CASE_DEF_ID);
+
+        Map<String, Object> data = new HashMap<>();
+        data.put(CAR_PRODUCER_REPORT_PARAMETER, carId);
+
+        caseClient.addDynamicTask(CONTAINER_ID, caseId, "ContactCarProducer", "Contact car producer", data);
+
+        Map<String, Object> caseInstanceData = caseClient.getCaseInstanceData(CONTAINER_ID, caseId);
+        assertTrue(caseInstanceData.containsKey(CAR_PRODUCER_REPORT_OUTPUT));
+        assertEquals(producerReportResponse, caseInstanceData.get(CAR_PRODUCER_REPORT_OUTPUT));
+    }
+
+    @Test
+    public void testAddDynamicWorkItemTaskNotExistingContainer() {
+        try {
+            caseClient.addDynamicTask("not-existing-container", "not-existing-case", "ContactCarProducer", "Contact car producer", null);
+            fail("Should have failed because of not existing container.");
+        } catch (KieServicesException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testAddDynamicWorkItemTaskNotExistingCase() {
+        try {
+            caseClient.addDynamicTask(CONTAINER_ID, "not-existing-case", "ContactCarProducer", "Contact car producer", null);
+            fail("Should have failed because of not existing case case Id.");
         } catch (KieServicesException e) {
             // expected
         }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/rest/cases/CaseServiceRestOnlyIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/rest/cases/CaseServiceRestOnlyIntegrationTest.java
@@ -29,6 +29,9 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.kie.server.api.KieServerConstants;
+import org.kie.server.api.marshalling.Marshaller;
+import org.kie.server.api.marshalling.MarshallerFactory;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.cases.CaseFile;
 import org.kie.server.api.model.type.JaxbString;
@@ -113,6 +116,40 @@ public class CaseServiceRestOnlyIntegrationTest extends RestJbpmBaseIntegrationT
         logger.debug("Remove case: [DELETE] " + clientRequest.getUri());
 
         response = clientRequest.request(getMediaType()).delete();
+        Assert.assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    public void testAddDynamicWorkItemTaskNoTaskSpec() {
+        String caseId = startUserTaskCase(USER_YODA, USER_JOHN);
+
+        Map<String, Object> valuesMap = new HashMap<String, Object>();
+        valuesMap.put(RestURI.CONTAINER_ID, CONTAINER_ID);
+        valuesMap.put(RestURI.CASE_ID, caseId);
+
+        WebTarget clientRequest = newRequest(build(TestConfig.getKieServerHttpUrl(), RestURI.CASE_URI + "/" + RestURI.CASE_DYNAMIC_TASK_POST_URI, valuesMap));
+        logger.debug("Add dynamic work item: [POST] " + clientRequest.getUri());
+
+        response = clientRequest.request(getMediaType()).post(Entity.entity("", getMediaType()));
+        Assert.assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    public void testAddDynamicWorkItemTaskNotExistingContainer() {
+        Marshaller marshaller = MarshallerFactory.getMarshaller(marshallingFormat, ClassLoader.getSystemClassLoader());
+
+        Map<String, Object> valuesMap = new HashMap<String, Object>();
+        valuesMap.put(RestURI.CONTAINER_ID, "not-existing-id");
+        valuesMap.put(RestURI.CASE_ID, "not-existing-id");
+
+        Map<String, Object> taskSpecMap = new HashMap<String, Object>();
+        taskSpecMap.put(KieServerConstants.CASE_DYNAMIC_NAME_PROP, "Contact car producer");
+        taskSpecMap.put(KieServerConstants.CASE_DYNAMIC_NODE_TYPE_PROP, "ContactCarProducer");
+
+        WebTarget clientRequest = newRequest(build(TestConfig.getKieServerHttpUrl(), RestURI.CASE_URI + "/" + RestURI.CASE_DYNAMIC_TASK_POST_URI, valuesMap));
+        logger.debug("Add dynamic work item: [POST] " + clientRequest.getUri());
+
+        response = clientRequest.request(getMediaType()).post(createEntity(marshaller.marshall(taskSpecMap)));
         Assert.assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
     }
 


### PR DESCRIPTION
Rest tests are failing:
- testAddDynamicWorkItemTaskNoTaskSpec fails because CaseManagementServiceBase suppose that unmarshalled taskSpecificationMap is not null. May be good to return Response.Status.BAD_REQUEST in that case with description what is missing there.
- testAddDynamicWorkItemTaskNotExistingContainer fails because Kie server service returns IllegalArgumentException for missing container which isn't handled in case resource.

@mswiderski What do you think about it?