### PR TITLE
Fix JMS signal queue and connection factory for WebLogic

### DIFF
--- a/kie-server-parent/kie-server-wars/kie-server/src/main/shared-ee6-ee7-resources/WEB-INF/weblogic-ejb-jar.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/src/main/shared-ee6-ee7-resources/WEB-INF/weblogic-ejb-jar.xml
@@ -27,8 +27,8 @@
   <weblogic-enterprise-bean>
     <ejb-name>JMSSignalReceiver</ejb-name>
     <message-driven-descriptor>
-      <destination-jndi-name>jms/KIE.SIGNAL</destination-jndi-name>
-      <connection-factory-jndi-name>jms/cf/KIE.SIGNAL</connection-factory-jndi-name>
+      <destination-jndi-name>jms/KIE.SERVER.SIGNAL</destination-jndi-name>
+      <connection-factory-jndi-name>jms/cf/KIE.SERVER.SIGNAL</connection-factory-jndi-name>
     </message-driven-descriptor>
   </weblogic-enterprise-bean>
   -->


### PR DESCRIPTION
`JMSSignalReceiver` configuration for WebLogic incorrectly used `KIE.SIGNAL` queue and connection factory instead of `KIE.SERVER.SIGNAL`.