### PR TITLE
New exception type for kie server http related errors

### DIFF
--- a/kie-server-parent/kie-server-remote/kie-server-client/pom.xml
+++ b/kie-server-parent/kie-server-remote/kie-server-client/pom.xml
@@ -123,6 +123,11 @@
       <classifier>standalone</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/KieServicesHttpException.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/KieServicesHttpException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.client;
+
+public class KieServicesHttpException extends KieServicesException {
+
+    private Integer httpCode;
+
+    private String url;
+
+    private String responseBody;
+
+    public KieServicesHttpException(final String message, final Integer httpCode, final String url, final String responseBody) {
+        super(message);
+        this.httpCode = httpCode;
+        this.url = url;
+        this.responseBody = responseBody;
+    }
+
+    public Integer getHttpCode() {
+        return httpCode;
+    }
+
+    public String getResponseBody() {
+        return responseBody;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+}

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/AbstractKieServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/AbstractKieServicesClientImpl.java
@@ -35,6 +35,7 @@ import javax.jms.TextMessage;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import org.kie.server.client.KieServicesHttpException;
 import org.kie.server.common.rest.KieServerHttpRequest;
 import org.kie.server.common.rest.KieServerHttpRequestException;
 import org.kie.server.common.rest.KieServerHttpResponse;
@@ -613,7 +614,7 @@ public abstract class AbstractKieServicesClientImpl {
         String summaryMessage = "Unexpected HTTP response code when requesting URI '" + request.getUri() + "'! Error code: " +
                 response.code() + ", message: " + response.body();
         logger.debug( summaryMessage + ", response body: " + getMessage(response) );
-        return new KieServicesException( summaryMessage );
+        return new KieServicesHttpException( summaryMessage, response.code(), request.getUri().toString(), response.body() );
     }
 
     protected String getMessage(KieServerHttpResponse response) {


### PR DESCRIPTION
To allow clients to better handle the different type of errors that could be thrown while executing http requests to the Kie Server.