### PR TITLE
Fixes after JPA 2.0 to 2.1 upgrade

### DIFF
--- a/kie-aries-blueprint/pom.xml
+++ b/kie-aries-blueprint/pom.xml
@@ -96,7 +96,7 @@
 
     <dependency>
       <groupId>org.hibernate.javax.persistence</groupId>
-      <artifactId>hibernate-jpa-2.0-api</artifactId>
+      <artifactId>hibernate-jpa-2.1-api</artifactId>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/kie-aries-blueprint/src/test/java/org/kie/aries/blueprint/mocks/MockEntityManager.java
+++ b/kie-aries-blueprint/src/test/java/org/kie/aries/blueprint/mocks/MockEntityManager.java
@@ -16,9 +16,12 @@
 package org.kie.aries.blueprint.mocks;
 
 import javax.persistence.Cache;
+import javax.persistence.EntityGraph;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.PersistenceUnitUtil;
+import javax.persistence.Query;
+import javax.persistence.SynchronizationType;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.metamodel.Metamodel;
 import javax.sql.DataSource;
@@ -56,6 +59,16 @@ public class MockEntityManager implements EntityManagerFactory {
     }
 
     @Override
+    public EntityManager createEntityManager(SynchronizationType synchronizationType) {
+        return null;
+    }
+
+    @Override
+    public EntityManager createEntityManager(SynchronizationType synchronizationType, Map map) {
+        return null;
+    }
+
+    @Override
     public CriteriaBuilder getCriteriaBuilder() {
         return null;
     }
@@ -88,5 +101,20 @@ public class MockEntityManager implements EntityManagerFactory {
     @Override
     public PersistenceUnitUtil getPersistenceUnitUtil() {
         return null;
+    }
+
+    @Override
+    public void addNamedQuery(String s, Query query) {
+
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> aClass) {
+        return null;
+    }
+
+    @Override
+    public <T> void addNamedEntityGraph(String s, EntityGraph<T> entityGraph) {
+
     }
 }

--- a/kie-infinispan/pom.xml
+++ b/kie-infinispan/pom.xml
@@ -40,18 +40,6 @@
         <type>test-jar</type>
         <version>${project.version}</version>
       </dependency>
-
-      <!-- Cersions of hibernate that infinispan 8.1 use. Should be removed once ip-bom upgrades to these versions. -->
-      <dependency>
-        <groupId>org.hibernate</groupId>
-        <artifactId>hibernate-search-engine</artifactId>
-        <version>5.5.1.Final</version>
-      </dependency>
-      <dependency>
-        <groupId>org.hibernate.common</groupId>
-        <artifactId>hibernate-commons-annotations</artifactId>
-        <version>5.0.1.Final</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
   

--- a/kie-osgi/kie-karaf-features/pom.xml
+++ b/kie-osgi/kie-karaf-features/pom.xml
@@ -37,7 +37,7 @@
     <karaf.version.org.apache.geronimo.specs.servlet>1.0</karaf.version.org.apache.geronimo.specs.servlet>
     <karaf.version.javax.servlet>3.1.0</karaf.version.javax.servlet>
     <karaf.version.org.apache.geronimo.specs.jms>1.1.1</karaf.version.org.apache.geronimo.specs.jms>
-    <karaf.version.org.apache.geronimo.specs.jpa>1.1</karaf.version.org.apache.geronimo.specs.jpa>
+    <karaf.version.org.apache.geronimo.specs.jpa>1.0-alpha-1</karaf.version.org.apache.geronimo.specs.jpa>
     <karaf.version.org.apache.geronimo.specs.jta>1.1.1</karaf.version.org.apache.geronimo.specs.jta>
     <karaf.version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec>${version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec}</karaf.version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec>
     <!-- used by optaplanner -->
@@ -48,7 +48,7 @@
     <karaf.version.org.apache.servicemix.bundles.ant>1.8.2_2</karaf.version.org.apache.servicemix.bundles.ant>
     <karaf.version.org.apache.servicemix.bundles.dom4j>1.6.1_5</karaf.version.org.apache.servicemix.bundles.dom4j>
     <karaf.version.org.apache.servicemix.bundles.serp>1.14.1_1</karaf.version.org.apache.servicemix.bundles.serp>
-    <karaf.version.com.fasterxml.classmate>0.9.0</karaf.version.com.fasterxml.classmate>
+    <karaf.version.com.fasterxml.classmate>1.1.0</karaf.version.com.fasterxml.classmate>
     <karaf.version.org.jboss.jandex>1.1.0.Final</karaf.version.org.jboss.jandex>
     <karaf.version.javax.validation>1.1.0.Final</karaf.version.javax.validation>
 
@@ -114,7 +114,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.geronimo.specs</groupId>
-        <artifactId>geronimo-jpa_2.0_spec</artifactId>
+        <artifactId>geronimo-jpa_2.1_spec</artifactId>
         <version>${karaf.version.org.apache.geronimo.specs.jpa}</version>
       </dependency>
       <dependency>
@@ -132,7 +132,7 @@
         <artifactId>org.apache.servicemix.bundles.antlr</artifactId>
         <!--
         there are 2 different versions of this dependency used by osgi features
-        for now one of the 2 has been arbitrarily choosen
+        for now one of the 2 has been arbitrarily chosen
         -->
         <version>${karaf.servicemix.version.org.antlr}</version>
       </dependency>
@@ -466,7 +466,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.geronimo.specs</groupId>
-      <artifactId>geronimo-jpa_2.0_spec</artifactId>
+      <artifactId>geronimo-jpa_2.1_spec</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features-core.xml
+++ b/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features-core.xml
@@ -96,7 +96,7 @@
     <bundle>mvn:joda-time/joda-time/${karaf.version.joda-time}</bundle>
     <bundle>mvn:org.jboss.spec.javax.interceptor/jboss-interceptors-api_1.2_spec/${karaf.version.org.jboss.spec.javax.interceptor}</bundle>
     <bundle>mvn:org.apache.geronimo.specs/geronimo-jms_1.1_spec/${karaf.version.org.apache.geronimo.specs.jms}</bundle>
-    <bundle>mvn:org.apache.geronimo.specs/geronimo-jpa_2.0_spec/${karaf.version.org.apache.geronimo.specs.jpa}</bundle>
+    <bundle>mvn:org.apache.geronimo.specs/geronimo-jpa_2.1_spec/${karaf.version.org.apache.geronimo.specs.jpa}</bundle>
     <bundle>mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/${karaf.version.org.apache.geronimo.specs.jta}</bundle>
   </feature>
 
@@ -146,8 +146,8 @@
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.reflections/${karaf.version.org.apache.servicemix.bundles.reflections}</bundle>
   </feature>
 
-  <feature name="droolsjbpm-hibernate" version="${version.org.hibernate}" description="Hibernate 4.2.x JPA persistence engine support">
-    <details>Enable Hibernate 4.2.x as persistence engine.</details>
+  <feature name="droolsjbpm-hibernate" version="${version.org.hibernate}" description="Hibernate 5.x JPA persistence engine support">
+    <details>Enable Hibernate 5.x as persistence engine.</details>
     <feature>transaction</feature>
     <feature>jpa</feature>
     <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.antlr/${karaf.version.org.apache.servicemix.bundles.antlr}</bundle>
@@ -172,6 +172,7 @@
     <bundle>mvn:org.jboss.logging/jboss-logging/${version.org.jboss.logging.jboss-logging}</bundle>
     <bundle>mvn:org.hibernate/hibernate-validator/${version.org.hibernate.validator}</bundle>
     <bundle>mvn:org.apache.logging.log4j/log4j-api/${karaf.version.org.apache.logging.log4j}</bundle>
+    <bundle>mvn:com.fasterxml/classmate/${karaf.version.com.fasterxml.classmate}</bundle>
   </feature>
 
   <feature name="jbpm-spring-persistent" version="${project.version}" description="jBPM Spring Persistence support">

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/blueprint/KieBlueprintjBPMPersistenceKarafIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/blueprint/KieBlueprintjBPMPersistenceKarafIntegrationTest.java
@@ -16,6 +16,7 @@
 
 package org.kie.karaf.itest.blueprint;
 
+import org.junit.Ignore;
 import org.kie.karaf.itest.AbstractKarafIntegrationTest;
 import org.kie.karaf.itest.beans.AbstractProcessWithPersistenceBean;
 import org.kie.karaf.itest.beans.ProcessWithPersistenceDirectBean;
@@ -44,6 +45,7 @@ import static org.ops4j.pax.tinybundles.core.TinyBundles.bundle;
 /**
  * Tests starting a jBPM process using RuntimeManager with persistence enabled in Blueprint environment.
  */
+@Ignore("JPA 2.1 not supported with Aries Blueprint - see https://issues.jboss.org/browse/DROOLS-1380")
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
 public class KieBlueprintjBPMPersistenceKarafIntegrationTest extends AbstractKarafIntegrationTest {

--- a/kie-osgi/kie-karaf-itests/src/test/resources/META-INF/persistence.xml
+++ b/kie-osgi/kie-karaf-itests/src/test/resources/META-INF/persistence.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<persistence
-        version="2.0"
-        xmlns="http://java.sun.com/xml/ns/persistence"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
+<persistence version="2.1"
+             xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
 
     <persistence-unit name="org.jbpm.persistence.jpa.local" transaction-type="RESOURCE_LOCAL">
-        <provider>org.hibernate.ejb.HibernatePersistence</provider>
+        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
         <mapping-file>META-INF/JBPMorm.xml</mapping-file>
         <mapping-file>META-INF/Taskorm.xml</mapping-file>
         <mapping-file>META-INF/TaskAuditorm.xml</mapping-file>

--- a/kie-osgi/kie-karaf-itests/src/test/resources/org/kie/karaf/itest/blueprint/processpersistence/persistence.xml
+++ b/kie-osgi/kie-karaf-itests/src/test/resources/org/kie/karaf/itest/blueprint/processpersistence/persistence.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<persistence
-        version="2.0"
-        xmlns="http://java.sun.com/xml/ns/persistence"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
+<persistence version="2.0"
+             xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_0.xsd">
 
     <persistence-unit name="process-persistence" transaction-type="JTA">
         <jta-data-source>osgi:service/javax.sql.DataSource/(osgi.jndi.service.name=jdbc/process-persistence-ds)</jta-data-source>

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/resources/jpa/META-INF/persistence.xml
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/resources/jpa/META-INF/persistence.xml
@@ -8,14 +8,13 @@
   License for the specific language governing permissions and ~ limitations 
   under the License. -->
 
-<persistence version="2.0"
-             xmlns="http://java.sun.com/xml/ns/persistence" xmlns:orm="http://java.sun.com/xml/ns/persistence/orm"
+<persistence version="2.1"
+             xmlns="http://xmlns.jcp.org/xml/ns/persistence"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd
-                      http://java.sun.com/xml/ns/persistence/orm http://java.sun.com/xml/ns/persistence/orm_2_0.xsd">
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
 
   <persistence-unit name="org.jbpm.domain" transaction-type="JTA">
-    <provider>org.hibernate.ejb.HibernatePersistence</provider>
+    <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
     <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
     <mapping-file>META-INF/Taskorm.xml</mapping-file>
     <mapping-file>META-INF/JBPMorm.xml</mapping-file>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/resources/META-INF/persistence.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/resources/META-INF/persistence.xml
@@ -8,14 +8,13 @@
   License for the specific language governing permissions and ~ limitations 
   under the License. -->
 
-<persistence version="2.0"
-             xmlns="http://java.sun.com/xml/ns/persistence" xmlns:orm="http://java.sun.com/xml/ns/persistence/orm"
+<persistence version="2.1"
+             xmlns="http://xmlns.jcp.org/xml/ns/persistence"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd
-                      http://java.sun.com/xml/ns/persistence/orm http://java.sun.com/xml/ns/persistence/orm_2_0.xsd">
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
 
   <persistence-unit name="org.jbpm.domain" transaction-type="JTA">
-    <provider>org.hibernate.ejb.HibernatePersistence</provider>
+    <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
     <jta-data-source>jdbc/jbpm-ds</jta-data-source>
     <mapping-file>META-INF/Taskorm.xml</mapping-file>
     <mapping-file>META-INF/JBPMorm.xml</mapping-file>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/resources/META-INF/persistence.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/resources/META-INF/persistence.xml
@@ -15,7 +15,7 @@
                       http://java.sun.com/xml/ns/persistence/orm http://java.sun.com/xml/ns/persistence/orm_2_0.xsd">
 
   <persistence-unit name="org.jbpm.domain" transaction-type="JTA">
-    <provider>org.hibernate.ejb.HibernatePersistence</provider>
+    <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
     <jta-data-source>jdbc/jbpm-ds</jta-data-source>
     <mapping-file>META-INF/Taskorm.xml</mapping-file>
     <mapping-file>META-INF/JBPMorm.xml</mapping-file>

--- a/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-ee6-container.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-ee6-container.xml
@@ -58,7 +58,7 @@
         <exclude>javax.validation:validation-api</exclude>
         <exclude>stax:stax-api</exclude>
         <exclude>javax.activation:activation</exclude>
-        <exclude>org.hibernate.javax.persistence:hibernate-jpa-2.0-api</exclude>
+        <exclude>org.hibernate.javax.persistence:hibernate-jpa-2.1-api</exclude>
         <exclude>xml-apis:xml-apis</exclude>
         <exclude>org.javassist:javassist</exclude>
         <exclude>javax.mail:mail</exclude>

--- a/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-ee7-container.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-ee7-container.xml
@@ -87,7 +87,7 @@
         <exclude>javax.validation:validation-api</exclude>
         <exclude>stax:stax-api</exclude>
         <exclude>javax.activation:activation</exclude>
-        <exclude>org.hibernate.javax.persistence:hibernate-jpa-2.0-api</exclude>
+        <exclude>org.hibernate.javax.persistence:hibernate-jpa-2.1-api</exclude>
         <exclude>xml-apis:xml-apis</exclude>
         <exclude>javax.mail:mail</exclude>
       </excludes>

--- a/kie-spring/pom.xml
+++ b/kie-spring/pom.xml
@@ -130,7 +130,7 @@
     </dependency>
     <dependency>
       <groupId>org.hibernate.javax.persistence</groupId>
-      <artifactId>hibernate-jpa-2.0-api</artifactId>
+      <artifactId>hibernate-jpa-2.1-api</artifactId>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -237,6 +237,15 @@
       </testResource>
     </testResources>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <kie.maven.settings.custom>${project.build.testOutputDirectory}/kie-custom-settings.xml</kie.maven.settings.custom>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>

--- a/kie-spring/src/test/filtered-resources/kie-custom-settings.xml
+++ b/kie-spring/src/test/filtered-resources/kie-custom-settings.xml
@@ -1,0 +1,15 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <localRepository>${settings.localRepository}</localRepository>
+  <interactiveMode/>
+  <usePluginRegistry/>
+  <offline/>
+  <pluginGroups/>
+  <servers/>
+  <mirrors/>
+  <proxies/>
+  <profiles/>
+  <activeProfiles/>
+</settings>

--- a/kie-spring/src/test/resources/META-INF/persistence.xml
+++ b/kie-spring/src/test/resources/META-INF/persistence.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<persistence
-    version="2.0"
-    xmlns="http://java.sun.com/xml/ns/persistence"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
+<persistence version="2.1"
+             xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
 
   <persistence-unit name="org.drools.persistence.jpa.local" transaction-type="RESOURCE_LOCAL">
-    <provider>org.hibernate.ejb.HibernatePersistence</provider>
-    <mapping-file>META-INF/ProcessInstanceInfo.hbm.xml</mapping-file>
+    <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
     <!--
     <jta-data-source>jdbc/testDS1</jta-data-source>
     -->

--- a/kie-spring/src/test/resources/jbpm/persistence-jta.xml
+++ b/kie-spring/src/test/resources/jbpm/persistence-jta.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<persistence
-    version="2.0"
-    xmlns="http://java.sun.com/xml/ns/persistence"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
+<persistence version="2.1"
+             xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
 
   <!-- spring with jta -->
   <persistence-unit name="org.jbpm.persistence.spring.jta" transaction-type="JTA">
-    <provider>org.hibernate.ejb.HibernatePersistence</provider>
+    <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
     <jta-data-source>jdbc/jbpm-ds</jta-data-source>
 
     <!--<mapping-file>META-INF/JBPMorm.xml</mapping-file>-->

--- a/kie-spring/src/test/resources/jbpm/persistence-local.xml
+++ b/kie-spring/src/test/resources/jbpm/persistence-local.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<persistence
-    version="2.0"
-    xmlns="http://java.sun.com/xml/ns/persistence"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
+<persistence version="2.1"
+             xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
 
   <!-- spring with local transactions -->
   <persistence-unit name="org.jbpm.persistence.spring.local" transaction-type="RESOURCE_LOCAL">
-    <provider>org.hibernate.ejb.HibernatePersistence</provider>
+    <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
     <non-jta-data-source>jdbc/jbpm-ds</non-jta-data-source>
 
     <!--<mapping-file>META-INF/JBPMorm.xml</mapping-file>-->


### PR DESCRIPTION
 * custom settings.xml needed for builds
   that use "-Dmaven.repo.local", as otherwise
   KIE Maven support looks into the default ~./m2
   repo where the artifacts are not present

 * the mapping-file "META-INF/ProcessInstanceInfo.hbm.xml"
   is not needed (likely just copy&paste error). Hibernate
   was complaining it can not find the file and would refuse
   to initialize

Please don't merge yet. All the IP BOM 7.0.0.CR5 PRs need to be merged together.