### PR TITLE
JBPM-5454: Add support for external URL configuration

### DIFF
--- a/kie-server-parent/kie-server-router/kie-server-router-proxy/src/main/java/org/kie/server/router/KieServerRouter.java
+++ b/kie-server-parent/kie-server-router/kie-server-router-proxy/src/main/java/org/kie/server/router/KieServerRouter.java
@@ -35,8 +35,8 @@ import io.undertow.server.handlers.proxy.ProxyHandler;
 import org.kie.server.router.repository.FileRepository;
 
 public class KieServerRouter {
-    private static final String HOST = System.getProperty("org.kie.server.router.host", "localhost");
-    private static final String PORT = System.getProperty("org.kie.server.router.port", "9000");
+    private static final String HOST = System.getProperty(KieServerRouterConstants.ROUTER_HOST, "localhost");
+    private static final String PORT = System.getProperty(KieServerRouterConstants.ROUTER_PORT, "9000");
     
     private static final Logger log = Logger.getLogger(KieServerRouter.class);
     
@@ -49,8 +49,8 @@ public class KieServerRouter {
     }
     
     public void start(String host, Integer port) {
-        System.setProperty("org.kie.server.router.host", host);
-        System.setProperty("org.kie.server.router.port", port.toString());
+        System.setProperty(KieServerRouterConstants.ROUTER_HOST, host);
+        System.setProperty(KieServerRouterConstants.ROUTER_PORT, port.toString());
         final KieServerProxyClient proxyClient = new KieServerProxyClient();
         
         HttpHandler notFoundHandler = ResponseCodeHandler.HANDLE_404;        
@@ -83,7 +83,7 @@ public class KieServerRouter {
             if (clean) {
                 repository.clean();
             }
-            log.infof("KieServerRouter stopped on %s:%s at %s", System.getProperty("org.kie.server.router.host"), System.getProperty("org.kie.server.router.port"), new Date());
+            log.infof("KieServerRouter stopped on %s:%s at %s", System.getProperty(KieServerRouterConstants.ROUTER_HOST), System.getProperty(KieServerRouterConstants.ROUTER_PORT), new Date());
         } else {
             log.error("KieServerRouter was not started");
         }

--- a/kie-server-parent/kie-server-router/kie-server-router-proxy/src/main/java/org/kie/server/router/KieServerRouterConstants.java
+++ b/kie-server-parent/kie-server-router/kie-server-router-proxy/src/main/java/org/kie/server/router/KieServerRouterConstants.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.router;
+
+public class KieServerRouterConstants {
+    public static final String ROUTER_HOST = "org.kie.server.router.host";
+    public static final String ROUTER_PORT = "org.kie.server.router.port";
+    public static final String ROUTER_EXTERNAL_URL = "org.kie.server.router.url.external";
+
+    public static final String ROUTER_REPOSITORY_DIR = "org.kie.server.router.repo";
+}

--- a/kie-server-parent/kie-server-router/kie-server-router-proxy/src/main/java/org/kie/server/router/handlers/KieServerInfoHandler.java
+++ b/kie-server-parent/kie-server-router/kie-server-router-proxy/src/main/java/org/kie/server/router/handlers/KieServerInfoHandler.java
@@ -21,12 +21,10 @@ import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HeaderValues;
 import io.undertow.util.Headers;
+import org.kie.server.router.KieServerRouterConstants;
 
 
 public class KieServerInfoHandler implements HttpHandler {
-    
-    private static final String HOST = System.getProperty("org.kie.server.router.host");
-    private static final String PORT = System.getProperty("org.kie.server.router.port");
 
     private static final String JAXB_RESPONSE = "<response type=\"SUCCESS\" msg=\"Kie Server info\">\n"+
             "<kie-server-info>\n"+
@@ -37,7 +35,7 @@ public class KieServerInfoHandler implements HttpHandler {
             "<capabilities>BPM-UI</capabilities>\n"+
             "<capabilities>BRP</capabilities>\n"+
             "<location>\n"+
-            "http://" + HOST +":" + PORT + "/\n"+
+            getLocationUrl() + "\n"+
             "</location>\n"+
             "<messages/>\n"+            
             "<name>KIE Server Router</name>\n"+
@@ -53,7 +51,7 @@ public class KieServerInfoHandler implements HttpHandler {
             "    \"kie-server-info\" : {\n"+
             "      \"version\" : \"LATEST\",\n"+
             "      \"name\" : \"KIE Server Router\",\n"+
-            "      \"location\" : \"" + HOST +":" + PORT + "\",\n"+
+            "      \"location\" : \"" + getLocationUrl() + "\",\n"+
             "      \"capabilities\" : [ \"KieServer\", \"BRM\", \"BPM\", \"CaseMgmt\", \"BPM-UI\", \"BRP\" ],\n"+     
             "      \"id\" : \"kie-server-router\"\n"+
             "    }\n"+
@@ -68,7 +66,7 @@ public class KieServerInfoHandler implements HttpHandler {
                            "<version>LATEST</version>\n"+
                            "<name>KIE Server Router</name>\n"+
                            "<location>\n"+
-                           "http://" + HOST +":" + PORT + "\n"+
+                           getLocationUrl() + "\n"+
                            "</location>\n"+
                            "<capabilities>\n"+
                            "<string>KieServer</string>\n"+
@@ -113,4 +111,19 @@ public class KieServerInfoHandler implements HttpHandler {
 
     }
 
+    protected static String getLocationUrl() {
+        String externalUrl = System.getProperty(KieServerRouterConstants.ROUTER_EXTERNAL_URL);
+
+        if(externalUrl == null) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("http://");
+            sb.append(System.getProperty(KieServerRouterConstants.ROUTER_HOST));
+            sb.append(":");
+            sb.append(System.getProperty(KieServerRouterConstants.ROUTER_PORT));
+            sb.append("/");
+            externalUrl = sb.toString();
+        }
+
+        return externalUrl;
+    }
 }

--- a/kie-server-parent/kie-server-router/kie-server-router-proxy/src/main/java/org/kie/server/router/repository/FileRepository.java
+++ b/kie-server-parent/kie-server-router/kie-server-router-proxy/src/main/java/org/kie/server/router/repository/FileRepository.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 
 import org.kie.server.router.Configuration;
+import org.kie.server.router.KieServerRouterConstants;
 
 public class FileRepository {
     
@@ -29,7 +30,7 @@ public class FileRepository {
     private ConfigurationMarshaller marshaller = new ConfigurationMarshaller();
     
     public FileRepository() {
-        this(new File(System.getProperty("org.kie.server.router.repo", ".")));
+        this(new File(System.getProperty(KieServerRouterConstants.ROUTER_REPOSITORY_DIR, ".")));
     }
     
     public FileRepository(File repositoryDir) {

--- a/kie-server-parent/kie-server-router/kie-server-router-proxy/src/test/java/org/kie/server/router/handlers/KieServerInfoHandlerTest.java
+++ b/kie-server-parent/kie-server-router/kie-server-router-proxy/src/test/java/org/kie/server/router/handlers/KieServerInfoHandlerTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.router.handlers;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.server.router.KieServerRouterConstants;
+
+
+public class KieServerInfoHandlerTest {
+
+    @Before
+    public void setUp() {
+        System.setProperty(KieServerRouterConstants.ROUTER_HOST, "localhost");
+        System.setProperty(KieServerRouterConstants.ROUTER_PORT, "9000");
+    }
+
+    @After
+    public void tearDown() {
+        System.clearProperty(KieServerRouterConstants.ROUTER_HOST);
+        System.clearProperty(KieServerRouterConstants.ROUTER_PORT);
+        System.clearProperty(KieServerRouterConstants.ROUTER_EXTERNAL_URL);
+    }
+
+    @Test
+    public void testGetLocationUrl() {
+        String locationUrl = KieServerInfoHandler.getLocationUrl();
+        assertEquals("http://localhost:9000/", locationUrl);
+    }
+
+    @Test
+    public void testGetLocationUrlExternalLocation() {
+        System.setProperty(KieServerRouterConstants.ROUTER_EXTERNAL_URL, "https://my-domain:8900/");
+        String locationUrl = KieServerInfoHandler.getLocationUrl();
+        assertEquals("https://my-domain:8900/", locationUrl);
+    }
+}


### PR DESCRIPTION
Sometimes Kie server router needs to return different URL
in its kie-server-info response than he actually listens to locally.
This can happen in case Kie server router is placed behind
another router, for example if it is deployed in OpenShift.

Grouped all system properties to one constant class.