### PR TITLE
Fix KIE Server output for not registered extensions

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-case-mgmt/src/main/java/org/kie/server/services/casemgmt/CaseKieServerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-case-mgmt/src/main/java/org/kie/server/services/casemgmt/CaseKieServerExtension.java
@@ -69,6 +69,11 @@ public class CaseKieServerExtension implements KieServerExtension {
     private KieContainerCommandService kieContainerCommandService;
 
     @Override
+    public boolean isInitialized() {
+        return initialized;
+    }
+
+    @Override
     public boolean isActive() {
         return disabled == false && jbpmDisabled == false;
     }

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/api/KieServerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/api/KieServerExtension.java
@@ -22,6 +22,8 @@ import org.kie.server.services.impl.KieServerImpl;
 
 public interface KieServerExtension {
 
+    boolean isInitialized();
+
     boolean isActive();
 
     void init(KieServerImpl kieServer, KieServerRegistry registry);

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerContainerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerContainerExtension.java
@@ -33,6 +33,12 @@ public class KieServerContainerExtension implements KieServerExtension {
     private KieContainerCommandService batchCommandService;
 
     private List<Object> services = new ArrayList<Object>();
+    private boolean initialized = false;
+
+    @Override
+    public boolean isInitialized() {
+        return initialized;
+    }
 
     @Override
     public boolean isActive() {
@@ -44,6 +50,8 @@ public class KieServerContainerExtension implements KieServerExtension {
         this.batchCommandService = new KieContainerCommandServiceImpl(kieServer, registry);
 
         services.add(batchCommandService);
+
+        initialized = true;
     }
 
     @Override

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
@@ -121,7 +121,11 @@ public class KieServerImpl implements KieServer {
 
                 this.context.registerServerExtension(extension);
 
-                logger.info("{} has been successfully registered as server extension", extension);
+                if(extension.isInitialized()) {
+                    logger.info("{} has been successfully registered as server extension", extension);
+                } else {
+                    logger.warn("{} has not been registered as server extension", extension);
+                }
             } catch (Exception e) {
                 serverMessages.add(new Message(Severity.ERROR, "Error when initializing server extension of type " + extension + " due to " + e.getMessage()));
                 logger.error("Error when initializing server extension of type {}", extension, e);

--- a/kie-server-parent/kie-server-services/kie-server-services-drools/src/main/java/org/kie/server/services/drools/DroolsKieServerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-drools/src/main/java/org/kie/server/services/drools/DroolsKieServerExtension.java
@@ -53,6 +53,12 @@ public class DroolsKieServerExtension implements KieServerExtension {
     private KieServerRegistry registry;
 
     private List<Object> services = new ArrayList<Object>();
+    private boolean initialized = false;
+
+    @Override
+    public boolean isInitialized() {
+        return initialized;
+    }
 
     @Override
     public boolean isActive() {
@@ -69,6 +75,8 @@ public class DroolsKieServerExtension implements KieServerExtension {
         }
         services.add(batchCommandService);
         services.add(rulesExecutionService);
+
+        initialized = true;
     }
 
     @Override

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/JBPMUIKieServerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/JBPMUIKieServerExtension.java
@@ -65,6 +65,11 @@ public class JBPMUIKieServerExtension implements KieServerExtension {
     private KieContainerCommandService kieContainerCommandService;
 
     @Override
+    public boolean isInitialized() {
+        return initialized;
+    }
+
+    @Override
     public boolean isActive() {
         return disabled == false && jbpmDisabled == false;
     }

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/JbpmKieServerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/JbpmKieServerExtension.java
@@ -148,9 +148,15 @@ public class JbpmKieServerExtension implements KieServerExtension {
     private DeploymentDescriptorMerger merger = new DeploymentDescriptorMerger();
 
     private List<Object> services = new ArrayList<Object>();
+    private boolean initialized = false;
 
     private Map<String, List<String>> containerMappers = new ConcurrentHashMap<String, List<String>>();
     private Map<String, List<String>> containerQueries = new ConcurrentHashMap<String, List<String>>();
+
+    @Override
+    public boolean isInitialized() {
+        return initialized;
+    }
 
     @Override
     public boolean isActive() {
@@ -284,6 +290,8 @@ public class JbpmKieServerExtension implements KieServerExtension {
         services.add(processInstanceMigrationService);
         services.add(processInstanceAdminService);
         services.add(userTaskAdminService);
+
+        initialized = true;
     }
 
     @Override

--- a/kie-server-parent/kie-server-services/kie-server-services-optaplanner/src/main/java/org/kie/server/services/optaplanner/OptaplannerKieServerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-optaplanner/src/main/java/org/kie/server/services/optaplanner/OptaplannerKieServerExtension.java
@@ -50,7 +50,13 @@ public class OptaplannerKieServerExtension
     private ExecutorService threadPool = null;
 
     private List<Object> services = new ArrayList<Object>();
+    private boolean initialized = false;
     private OptaplannerCommandServiceImpl optaplannerCommandService;
+
+    @Override
+    public boolean isInitialized() {
+        return initialized;
+    }
 
     @Override
     public boolean isActive() {
@@ -83,6 +89,8 @@ public class OptaplannerKieServerExtension
         this.optaplannerCommandService = new OptaplannerCommandServiceImpl(registry, solverServiceBase);
 
         this.services.add( solverServiceBase );
+
+        initialized = true;
     }
 
     @Override


### PR DESCRIPTION
Case-Mgmt KIE Server extension and jBPM-UI KIE Server extension can't be registered without a jBPM extension.
Actual state of the server output make no sense:
...
WARN  [org.kie.server.services.casemgmt.CaseKieServerExtension] (ServerService Thread Pool -- 97) jBPM extension not found, Case Management cannot work without jBPM extension, disabling itself
INFO  [org.kie.server.services.impl.KieServerImpl] (ServerService Thread Pool -- 97) Case-Mgmt KIE Server extension has been successfully registered as server extension
...