### PR TITLE
kie-server-tests: Avoid NPE when closing JAX-RS response

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/rest/RestMalformedRequestIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/rest/RestMalformedRequestIntegrationTest.java
@@ -46,7 +46,9 @@ public class RestMalformedRequestIntegrationTest extends RestOnlyBaseIntegration
                     "Unexpected exception creating container: " + resource.getContainerId() + " with release-id " + resource.getReleaseId(),
                     e);
         } finally {
-            response.close();
+            if(response != null) {
+                response.close();
+            }
         }
     }
 
@@ -61,7 +63,9 @@ public class RestMalformedRequestIntegrationTest extends RestOnlyBaseIntegration
         } catch (Exception e) {
             throw new RuntimeException("Unexpected exception on empty body", e);
         } finally {
-            response.close();
+            if(response != null) {
+                response.close();
+            }
         }
     }
     

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/rest/RestMalformedRequestIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/rest/RestMalformedRequestIntegrationTest.java
@@ -71,7 +71,9 @@ public class RestMalformedRequestIntegrationTest extends RestOnlyBaseIntegration
         } catch (Exception e) {
             throw new RuntimeException("Unexpected exception on empty body", e);
         } finally {
-            response.close();
+            if(response != null) {
+                response.close();
+            }
         }
     }
 
@@ -101,7 +103,9 @@ public class RestMalformedRequestIntegrationTest extends RestOnlyBaseIntegration
         } catch (Exception e) {
             throw new RuntimeException("Unexpected exception on invalid body", e);
         } finally {
-            response.close();
+            if(response != null) {
+                response.close();
+            }
         }
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/rest/JbpmRestIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/rest/JbpmRestIntegrationTest.java
@@ -128,7 +128,9 @@ public class JbpmRestIntegrationTest extends RestOnlyBaseIntegrationTest {
                     response.getStatus() == noContentStatusCode || response.getStatus() == okStatusCode);
 
         } finally {
-            response.close();
+            if(response != null) {
+                response.close();
+            }
         }
 
     }
@@ -172,7 +174,9 @@ public class JbpmRestIntegrationTest extends RestOnlyBaseIntegrationTest {
                     response.getStatus() == noContentStatusCode || response.getStatus() == okStatusCode);
 
         } finally {
-            response.close();
+            if(response != null) {
+                response.close();
+            }
         }
 
     }
@@ -205,7 +209,9 @@ public class JbpmRestIntegrationTest extends RestOnlyBaseIntegrationTest {
                     response.getStatus() == noContentStatusCode || response.getStatus() == okStatusCode);
 
         } finally {
-            response.close();
+            if(response != null) {
+                response.close();
+            }
         }
 
     }
@@ -278,7 +284,9 @@ public class JbpmRestIntegrationTest extends RestOnlyBaseIntegrationTest {
                     response.getStatus() == noContentStatusCode || response.getStatus() == okStatusCode);
 
         } finally {
-            response.close();
+            if(response != null) {
+                response.close();
+            }
         }
 
     }


### PR DESCRIPTION
To reveal real issue thrown when sending request.