### PR TITLE
kie-server-tests: Abort processes after test cases

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/rest/RestJbpmBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/rest/RestJbpmBaseIntegrationTest.java
@@ -18,6 +18,7 @@ package org.kie.server.integrationtests.jbpm.rest;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.rules.ExternalResource;
@@ -46,7 +47,7 @@ public abstract class RestJbpmBaseIntegrationTest extends RestOnlyBaseIntegratio
         cleanupSingletonSessionId();
     }
 
-    @Before
+    @After
     public void abortAllProcesses() {
         List<Integer> status = new ArrayList<Integer>();
         status.add(ProcessInstance.STATE_ACTIVE);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/basetests/KieServerBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/basetests/KieServerBaseIntegrationTest.java
@@ -45,6 +45,7 @@ import org.kie.server.controller.api.model.spec.ServerTemplate;
 import org.kie.server.integrationtests.controller.client.KieServerMgmtControllerClient;
 import org.kie.server.integrationtests.config.TestConfig;
 import org.kie.server.integrationtests.shared.KieControllerExecutor;
+import org.kie.server.integrationtests.shared.KieServerAssert;
 import org.kie.server.integrationtests.shared.KieServerExecutor;
 import org.kie.server.integrationtests.shared.KieServerRouterExecutor;
 import org.slf4j.Logger;
@@ -110,7 +111,7 @@ public abstract class KieServerBaseIntegrationTest {
         List<KieContainerResource> containers = response.getResult().getContainers();
         if (containers != null) {
             for (KieContainerResource container : containers) {
-                client.disposeContainer(container.getContainerId());
+                KieServerAssert.assertSuccess(client.disposeContainer(container.getContainerId()));
             }
         }
     }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/JbpmKieServerBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/JbpmKieServerBaseIntegrationTest.java
@@ -18,6 +18,7 @@ package org.kie.server.integrationtests.jbpm;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.rules.ExternalResource;
@@ -76,7 +77,7 @@ public abstract class JbpmKieServerBaseIntegrationTest extends RestJmsSharedBase
         cleanupSingletonSessionId();
     }
 
-    @Before
+    @After
     public void abortAllProcesses() {
         List<Integer> status = new ArrayList<Integer>();
         status.add(org.kie.api.runtime.process.ProcessInstance.STATE_ACTIVE);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/rest/JbpmRestIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/rest/JbpmRestIntegrationTest.java
@@ -29,11 +29,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.rules.ExternalResource;
 import org.kie.scanner.KieModuleMetaData;
 import org.kie.server.api.marshalling.Marshaller;
 import org.kie.server.api.marshalling.MarshallerFactory;
@@ -45,14 +42,12 @@ import org.kie.server.api.model.instance.DocumentInstanceList;
 import org.kie.server.api.model.type.JaxbLong;
 import org.kie.server.api.model.type.JaxbString;
 import org.kie.server.integrationtests.config.TestConfig;
-import org.kie.server.integrationtests.jbpm.DBExternalResource;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
-import org.kie.server.integrationtests.shared.basetests.RestOnlyBaseIntegrationTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-public class JbpmRestIntegrationTest extends RestOnlyBaseIntegrationTest {
+public class JbpmRestIntegrationTest extends RestJbpmBaseIntegrationTest {
 
     private static ReleaseId releaseId = new ReleaseId("org.kie.server.testing", "rest-processes", "1.0.0.Final");
    
@@ -60,9 +55,6 @@ public class JbpmRestIntegrationTest extends RestOnlyBaseIntegrationTest {
 
     private static Map<MarshallingFormat, String> acceptHeadersByFormat = new HashMap<MarshallingFormat, String>();
 
-    @ClassRule
-    public static ExternalResource StaticResource = new DBExternalResource();
-    
     @BeforeClass
     public static void buildAndDeployArtifacts() {
         KieServerDeployer.buildAndDeployCommonMavenParent();
@@ -72,12 +64,6 @@ public class JbpmRestIntegrationTest extends RestOnlyBaseIntegrationTest {
         acceptHeadersByFormat.put(MarshallingFormat.JSON, "application/json;q=0.9,application/xml;q=0.3");// json is preferred over xml
 
         createContainer(CONTAINER, releaseId);
-    }
-
-
-    @Before
-    public void cleanup() {
-        cleanupSingletonSessionId();
     }
 
     /**

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/rest/RestJbpmBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/rest/RestJbpmBaseIntegrationTest.java
@@ -1,9 +1,10 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 JBoss by Red Hat.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ * You may obtain a copy of the License at
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -11,56 +12,30 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
-
-package org.kie.server.integrationtests.jbpm;
+ */
+package org.kie.server.integrationtests.jbpm.rest;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.rules.ExternalResource;
-import org.kie.api.KieServices;
 import org.kie.api.runtime.process.ProcessInstance;
-import org.kie.server.client.CaseServicesClient;
-import org.kie.server.client.JobServicesClient;
 import org.kie.server.client.KieServicesClient;
 import org.kie.server.client.ProcessServicesClient;
 import org.kie.server.client.QueryServicesClient;
-import org.kie.server.client.RuleServicesClient;
-import org.kie.server.client.UIServicesClient;
-import org.kie.server.client.UserTaskServicesClient;
-import org.kie.server.integrationtests.shared.basetests.RestJmsSharedBaseIntegrationTest;
+import org.kie.server.integrationtests.jbpm.DBExternalResource;
+import org.kie.server.integrationtests.shared.basetests.RestOnlyBaseIntegrationTest;
 
-public abstract class JbpmKieServerBaseIntegrationTest extends RestJmsSharedBaseIntegrationTest {
+public abstract class RestJbpmBaseIntegrationTest extends RestOnlyBaseIntegrationTest {
 
     @ClassRule
     public static ExternalResource StaticResource = new DBExternalResource();
 
-    protected static final String USER_YODA = "yoda";
-    protected static final String USER_JOHN = "john";
-    protected static final String USER_ADMINISTRATOR = "Administrator";
-    protected static final String USER_MARY = "mary";
-
-    protected static final String PROCESS_ID_USERTASK = "definition-project.usertask";
-    protected static final String PROCESS_ID_EVALUATION = "definition-project.evaluation";
-    protected static final String PROCESS_ID_GROUPTASK = "definition-project.grouptask";
-
     protected ProcessServicesClient processClient;
-    protected UserTaskServicesClient taskClient;
     protected QueryServicesClient queryClient;
-    protected JobServicesClient jobServicesClient;
-    protected RuleServicesClient ruleClient;
-    protected UIServicesClient uiServicesClient;
-    protected CaseServicesClient caseClient;
-
-    @BeforeClass
-    public static void setupFactory() throws Exception {
-        commandsFactory = KieServices.Factory.get().getCommands();
-    }
 
     @Before
     public void cleanup() {
@@ -82,11 +57,6 @@ public abstract class JbpmKieServerBaseIntegrationTest extends RestJmsSharedBase
     @Override
     protected void setupClients(KieServicesClient client) {
         processClient = client.getServicesClient(ProcessServicesClient.class);
-        taskClient = client.getServicesClient(UserTaskServicesClient.class);
         queryClient = client.getServicesClient(QueryServicesClient.class);
-        jobServicesClient = client.getServicesClient(JobServicesClient.class);
-        ruleClient = client.getServicesClient(RuleServicesClient.class);
-        uiServicesClient = client.getServicesClient(UIServicesClient.class);
-        caseClient = client.getServicesClient(CaseServicesClient.class);
     }
 }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-policy/src/test/java/org/kie/server/integrationtests/policy/KieServerPolicyBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-policy/src/test/java/org/kie/server/integrationtests/policy/KieServerPolicyBaseIntegrationTest.java
@@ -18,6 +18,7 @@ package org.kie.server.integrationtests.policy;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -72,7 +73,7 @@ public abstract class KieServerPolicyBaseIntegrationTest extends RestJmsSharedBa
         cleanupSingletonSessionId();
     }
 
-    @Before
+    @After
     public void abortAllProcesses() {
         List<Integer> status = new ArrayList<Integer>();
         status.add(org.kie.api.runtime.process.ProcessInstance.STATE_ACTIVE);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-router/src/test/java/org/kie/server/integrationtests/router/KieServerRouterBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-router/src/test/java/org/kie/server/integrationtests/router/KieServerRouterBaseIntegrationTest.java
@@ -18,6 +18,7 @@ package org.kie.server.integrationtests.router;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -93,7 +94,7 @@ public abstract class KieServerRouterBaseIntegrationTest extends RestJmsSharedBa
     }
 
 
-    @Before
+    @After
     public void abortAllProcesses() {
 
         // make sure we run via router


### PR DESCRIPTION
Lately I noticed that some Kie server tests are skipped in Jenkins PR job. It is caused by failure in container creation [1] which is caused by failing of container dispose [2] - caused by containers having active process instances.
Fix for this issue consists of aborting of all active processes instances right after every test case (for tests using jBPM extension). Also added aborting for JbpmRestIntegrationTest.


[1] https://github.com/sutaakar/droolsjbpm-integration/blob/master/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/basetests/KieServerBaseIntegrationTest.java#L128
[2] https://github.com/sutaakar/droolsjbpm-integration/blob/master/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/basetests/KieServerBaseIntegrationTest.java#L72