### PR TITLE
[6.5.x] kie-server-tests: Reset class loader before failing maven build

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerDeployer.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerDeployer.java
@@ -72,11 +72,13 @@ public class KieServerDeployer {
             mvnArgs.add(kjarsBuildSettingsXml);
         }
         int mvnRunResult = cli.doMain(mvnArgs.toArray(new String[mvnArgs.size()]), basedir, System.out, System.err);
+
+        Thread.currentThread().setContextClassLoader(classLoaderBak);
+
         if (mvnRunResult != 0) {
             throw new RuntimeException("Error while building Maven project from basedir " + basedir +
                     ". Return code=" + mvnRunResult);
         }
-        Thread.currentThread().setContextClassLoader(classLoaderBak);
         logger.debug("Maven project successfully built and deployed!");
     }
 


### PR DESCRIPTION
Cherrypick of https://github.com/droolsjbpm/droolsjbpm-integration/pull/772
Affects just tests.