### PR TITLE
JBPM-5504: Missing getReleaseId method in KieServicesClient

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/CommandScript.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/CommandScript.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2010 - 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,6 +49,7 @@ public class CommandScript implements Serializable {
             @XmlElement(name = "dispose-container", type = DisposeContainerCommand.class),
             @XmlElement(name = "get-scanner-info", type = GetScannerInfoCommand.class),
             @XmlElement(name = "update-scanner", type = UpdateScannerCommand.class),
+            @XmlElement(name = "get-release-id", type = GetReleaseIdCommand.class),
             @XmlElement(name = "update-release-id", type = UpdateReleaseIdCommand.class),
             @XmlElement(name = "call-container", type = CallContainerCommand.class),
             @XmlElement(name = "descriptor-command", type = DescriptorCommand.class),

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/GetReleaseIdCommand.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/GetReleaseIdCommand.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.api.commands;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import org.kie.server.api.model.KieServerCommand;
+
+@XmlRootElement(name = "get-release-id")
+@XStreamAlias("get-release-id")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class GetReleaseIdCommand implements KieServerCommand {
+
+    private static final long serialVersionUID = -1803374525440238478L;
+
+    @XmlAttribute(name = "container-id")
+    @XStreamAlias("container-id")
+    private String containerId;
+
+    public GetReleaseIdCommand() {
+    }
+
+    public GetReleaseIdCommand(String containerId) {
+        this.containerId = containerId;
+    }
+
+    public String getContainerId() {
+        return containerId;
+    }
+
+    public void setContainerId(String containerId) {
+        this.containerId = containerId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        GetReleaseIdCommand that = (GetReleaseIdCommand) o;
+
+        return containerId != null ? containerId.equals(that.containerId) : that.containerId == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return containerId != null ? containerId.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return "GetReleaseIdCommand{" + "containerId='" + containerId + '\'' + '}';
+    }
+}

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/jaxb/JaxbMarshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/jaxb/JaxbMarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2015 - 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,7 @@ import org.kie.server.api.commands.CreateContainerCommand;
 import org.kie.server.api.commands.DescriptorCommand;
 import org.kie.server.api.commands.DisposeContainerCommand;
 import org.kie.server.api.commands.GetContainerInfoCommand;
+import org.kie.server.api.commands.GetReleaseIdCommand;
 import org.kie.server.api.commands.GetScannerInfoCommand;
 import org.kie.server.api.commands.GetServerInfoCommand;
 import org.kie.server.api.commands.GetServerStateCommand;
@@ -135,6 +136,7 @@ public class JaxbMarshaller implements Marshaller {
                 GetScannerInfoCommand.class,
                 GetServerInfoCommand.class,
                 UpdateScannerCommand.class,
+                GetReleaseIdCommand.class,
                 UpdateReleaseIdCommand.class,
                 DescriptorCommand.class,
                 GetServerStateCommand.class,

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/xstream/XStreamMarshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/xstream/XStreamMarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2015 - 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.kie.server.api.commands.CommandScript;
 import org.kie.server.api.commands.CreateContainerCommand;
 import org.kie.server.api.commands.DisposeContainerCommand;
 import org.kie.server.api.commands.GetContainerInfoCommand;
+import org.kie.server.api.commands.GetReleaseIdCommand;
 import org.kie.server.api.commands.GetScannerInfoCommand;
 import org.kie.server.api.commands.GetServerInfoCommand;
 import org.kie.server.api.commands.ListContainersCommand;
@@ -120,6 +121,7 @@ public class XStreamMarshaller
         this.xstream.processAnnotations( GetContainerInfoCommand.class );
         this.xstream.processAnnotations( GetScannerInfoCommand.class );
         this.xstream.processAnnotations( UpdateScannerCommand.class );
+        this.xstream.processAnnotations( GetReleaseIdCommand.class );
         this.xstream.processAnnotations( UpdateReleaseIdCommand.class );
         this.xstream.processAnnotations( GetServerInfoCommand.class );
         this.xstream.processAnnotations( ListContainersCommand.class );

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/KieServicesClient.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/KieServicesClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2015 - 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,9 @@
 package org.kie.server.client;
 
 import org.kie.api.command.Command;
-import org.kie.server.api.model.KieContainerResourceFilter;
-import org.kie.server.api.model.ReleaseIdFilter;
 import org.kie.server.api.commands.CommandScript;
 import org.kie.server.api.model.KieContainerResource;
+import org.kie.server.api.model.KieContainerResourceFilter;
 import org.kie.server.api.model.KieContainerResourceList;
 import org.kie.server.api.model.KieScannerResource;
 import org.kie.server.api.model.KieServerInfo;
@@ -51,10 +50,11 @@ public interface KieServicesClient {
 
     ServiceResponse<KieScannerResource> updateScanner(String id, KieScannerResource resource);
 
+    ServiceResponse<ReleaseId> getReleaseId(String containerId);
+
     ServiceResponse<ReleaseId> updateReleaseId(String id, ReleaseId releaseId);
 
     ServiceResponse<KieServerStateInfo> getServerState();
-
 
     // for backward compatibility reason
 

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/KieServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/KieServicesClientImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2015 - 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.kie.server.client.impl;
 
 import org.kie.api.command.Command;
+import org.kie.server.api.commands.GetReleaseIdCommand;
 import org.kie.server.api.model.KieContainerResourceFilter;
 import org.kie.server.api.commands.CallContainerCommand;
 import org.kie.server.api.commands.CommandScript;
@@ -245,6 +246,17 @@ public class KieServicesClientImpl extends AbstractKieServicesClientImpl impleme
         } else {
             CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new UpdateScannerCommand(id, resource)));
             ServiceResponse<KieScannerResource> response = (ServiceResponse<KieScannerResource>) executeJmsCommand(script, null, null, id).getResponses().get(0);
+            return getResponseOrNullIfNoResponse(response);
+        }
+    }
+
+    @Override
+    public ServiceResponse<ReleaseId> getReleaseId(String containerId) {
+        if (config.isRest()) {
+            return makeHttpGetRequestAndCreateServiceResponse(loadBalancer.getUrl() + "/containers/" + containerId + "/release-id", ReleaseId.class);
+        } else {
+            CommandScript script = new CommandScript(Collections.singletonList(new GetReleaseIdCommand(containerId)));
+            ServiceResponse<ReleaseId> response = (ServiceResponse<ReleaseId>) executeJmsCommand(script).getResponses().get(0);
             return getResponseOrNullIfNoResponse(response);
         }
     }

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/test/java/org/kie/server/client/BaseKieServicesClientTest.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/test/java/org/kie/server/client/BaseKieServicesClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2015 - 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.util.Collections;
 
 public abstract class BaseKieServicesClientTest {
     private static Logger logger = LoggerFactory.getLogger(BaseKieServicesClientTest.class);
@@ -33,6 +34,8 @@ public abstract class BaseKieServicesClientTest {
     public BaseKieServicesClientTest() {
         try {
             config = KieServicesFactory.newRestConfiguration( mockServerBaseUri, null, null );
+            // set capabilities so the client will not to try to get them from the server
+            config.setCapabilities(Collections.emptyList());
         } catch ( Exception e ) {
             // nothing to do.
             throw new RuntimeException( "Error instantiating configuration", e );

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/test/java/org/kie/server/client/KieServicesClientTest.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/test/java/org/kie/server/client/KieServicesClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2015 - 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package org.kie.server.client;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 import org.junit.Test;
 import org.kie.server.api.marshalling.MarshallingFormat;
@@ -35,19 +34,24 @@ import static org.junit.Assert.*;
 
 public class KieServicesClientTest extends BaseKieServicesClientTest {
 
+    private static final String CONTAINER_ID = "mycontainer";
+
+    private static final String ARTIFACT_ID = "myproject";
+    private static final String GROUP_ID = "org.kie";
+    private static final String VERSION = "1.2.3";
+
     @Test
     public void testGetServerInfo() {
         stubFor(get(urlEqualTo("/"))
                 .withHeader("Accept", equalTo("application/xml"))
                 .willReturn(aResponse()
-                                .withStatus(200)
-                                .withHeader("Content-Type", "application/xml")
-                                .withBody("<response type=\"SUCCESS\" msg=\"Kie Server info\">\n" +
-                                        "  <kie-server-info>\n" +
-                                        "    <version>1.2.3</version>\n" +
-                                        "  </kie-server-info>\n" +
-                                        "</response>")));
-
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/xml")
+                        .withBody("<response type=\"SUCCESS\" msg=\"Kie Server info\">\n" +
+                                "  <kie-server-info>\n" +
+                                "    <version>1.2.3</version>\n" +
+                                "  </kie-server-info>\n" +
+                                "</response>")));
 
         KieServicesClient client = KieServicesFactory.newKieServicesClient(config);
         ServiceResponse<KieServerInfo> response = client.getServerInfo();
@@ -70,14 +74,14 @@ public class KieServicesClientTest extends BaseKieServicesClientTest {
         stubFor(get(urlEqualTo("/containers"))
                 .withHeader("Accept", equalTo("application/xml"))
                 .willReturn(aResponse()
-                                .withStatus(200)
-                                .withHeader("Content-Type", "application/xml")
-                                .withBody("<response type=\"SUCCESS\" msg=\"List of created containers\">\n" +
-                                        "  <kie-containers>\n" +
-                                        "    <kie-container container-id=\"kjar1\" status=\"FAILED\"/>\n" +
-                                        "    <kie-container container-id=\"kjar2\" status=\"FAILED\"/>" +
-                                        "  </kie-containers>" +
-                                        "</response>")));
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/xml")
+                        .withBody("<response type=\"SUCCESS\" msg=\"List of created containers\">\n" +
+                                "  <kie-containers>\n" +
+                                "    <kie-container container-id=\"kjar1\" status=\"FAILED\"/>\n" +
+                                "    <kie-container container-id=\"kjar2\" status=\"FAILED\"/>" +
+                                "  </kie-containers>" +
+                                "</response>")));
 
         KieServicesClient client = KieServicesFactory.newKieServicesClient(config);
         ServiceResponse<KieContainerResourceList> response = client.listContainers();
@@ -136,15 +140,14 @@ public class KieServicesClientTest extends BaseKieServicesClientTest {
                         .withStatus(200)
                         .withHeader("Content-Type", "application/json")
                         .withBody("{\n" +
-                                    "  \"type\" : \"SUCCESS\",\n" +
-                                    "  \"msg\" : \"Kie Server info\",\n" +
-                                    "  \"result\" : {\n" +
-                                    "    \"kie-server-info\" : {\n" +
-                                    "      \"version\" : \"1.2.3\"\n" +
-                                    "    }\n" +
-                                    "  }\n" +
-                                    "}")));
-
+                                "  \"type\" : \"SUCCESS\",\n" +
+                                "  \"msg\" : \"Kie Server info\",\n" +
+                                "  \"result\" : {\n" +
+                                "    \"kie-server-info\" : {\n" +
+                                "      \"version\" : \"1.2.3\"\n" +
+                                "    }\n" +
+                                "  }\n" +
+                                "}")));
 
         config.setMarshallingFormat(MarshallingFormat.JSON);
         config.setExtraClasses(Collections.singleton(KieContainerStatus.class));
@@ -167,13 +170,12 @@ public class KieServicesClientTest extends BaseKieServicesClientTest {
                                 "  </kie-server-info>\n" +
                                 "</response>")));
 
-
         KieServicesClient client = KieServicesFactory.newKieServicesClient(config);
         ServiceResponse<KieServerInfo> response = client.getServerInfo();
         assertSuccess(response);
         assertEquals("Server version", "1.2.3", response.getResult().getVersion());
 
-        verify(2, getRequestedFor(urlEqualTo("/")).withHeader("Authorization", equalTo("Basic bnVsbDpudWxs")));
+        verify(1, getRequestedFor(urlEqualTo("/")).withHeader("Authorization", equalTo("Basic bnVsbDpudWxs")));
         verify(0, getRequestedFor(urlEqualTo("/")).withHeader("Authorization", equalTo("Bearer abcdefghijk")));
     }
 
@@ -196,7 +198,7 @@ public class KieServicesClientTest extends BaseKieServicesClientTest {
         assertSuccess(response);
         assertEquals("Server version", "1.2.3", response.getResult().getVersion());
 
-        verify(2, getRequestedFor(urlEqualTo("/")).withHeader("Authorization", equalTo("Bearer abcdefghijk")));
+        verify(1, getRequestedFor(urlEqualTo("/")).withHeader("Authorization", equalTo("Bearer abcdefghijk")));
         verify(0, getRequestedFor(urlEqualTo("/")).withHeader("Authorization", equalTo("Basic bnVsbDpudWxs")));
     }
 
@@ -222,8 +224,34 @@ public class KieServicesClientTest extends BaseKieServicesClientTest {
         assertSuccess(response);
         assertEquals("Server version", "1.2.3", response.getResult().getVersion());
 
-        verify(2, getRequestedFor(urlEqualTo("/")).withHeader("X-KIE-First-Header", equalTo("first-value")));
-        verify(2, getRequestedFor(urlEqualTo("/")).withHeader("X-KIE-Second-Header", equalTo("second value")));
+        verify(1, getRequestedFor(urlEqualTo("/")).withHeader("X-KIE-First-Header", equalTo("first-value")));
+        verify(1, getRequestedFor(urlEqualTo("/")).withHeader("X-KIE-Second-Header", equalTo("second value")));
+    }
+
+    @Test
+    public void testGetReleaseId() {
+        stubFor(get(urlEqualTo("/containers/" + CONTAINER_ID + "/release-id"))
+                .withHeader("Accept", equalTo("application/xml"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/xml")
+                        .withBody("<response type=\"SUCCESS\" msg=\"Release ID for " + CONTAINER_ID + "\">\n" +
+                                "  <release-id>\n" +
+                                "    <artifact-id>" + ARTIFACT_ID + "</artifact-id>\n" +
+                                "    <group-id>" + GROUP_ID + "</group-id>\n" +
+                                "    <version>" + VERSION + "</version>\n" +
+                                "  </release-id>\n" +
+                                "</response>")));
+
+        KieServicesClient client = KieServicesFactory.newKieServicesClient(config);
+        ServiceResponse<ReleaseId> response = client.getReleaseId(CONTAINER_ID);
+        assertSuccess(response);
+
+        ReleaseId releaseId = response.getResult();
+        assertNotNull(releaseId);
+        assertEquals("Artifact ID", ARTIFACT_ID, releaseId.getArtifactId());
+        assertEquals("Group ID", GROUP_ID, releaseId.getGroupId());
+        assertEquals("Version", VERSION, releaseId.getVersion());
     }
 
     // TODO create more tests for other operations

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieContainerCommandServiceImpl.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieContainerCommandServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2015 - 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.kie.server.api.commands.CommandScript;
 import org.kie.server.api.commands.CreateContainerCommand;
 import org.kie.server.api.commands.DisposeContainerCommand;
 import org.kie.server.api.commands.GetContainerInfoCommand;
+import org.kie.server.api.commands.GetReleaseIdCommand;
 import org.kie.server.api.commands.GetScannerInfoCommand;
 import org.kie.server.api.commands.GetServerInfoCommand;
 import org.kie.server.api.commands.GetServerStateCommand;
@@ -151,6 +152,8 @@ public class KieContainerCommandServiceImpl implements KieContainerCommandServic
                     responses.add(this.kieServer.getScannerInfo(((GetScannerInfoCommand) command).getContainerId()));
                 } else if (command instanceof UpdateScannerCommand) {
                     responses.add(this.kieServer.updateScanner(((UpdateScannerCommand) command).getContainerId(), ((UpdateScannerCommand) command).getScanner()));
+                } else if (command instanceof GetReleaseIdCommand) {
+                    responses.add(this.kieServer.getContainerReleaseId(((GetReleaseIdCommand) command).getContainerId()));
                 } else if (command instanceof UpdateReleaseIdCommand) {
                     responses.add(this.kieServer.updateContainerReleaseId(((UpdateReleaseIdCommand) command).getContainerId(), ((UpdateReleaseIdCommand) command).getReleaseId()));
                 } else if (command instanceof GetServerStateCommand) {

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/KieServerContainerCRUDIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/KieServerContainerCRUDIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2015 - 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,6 +114,19 @@ public class KieServerContainerCRUDIntegrationTest extends RestJmsSharedBaseInte
         Assert.assertEquals("Number of listed containers!", 2, containers.size());
         assertContainsContainer(containers, "list-containers-c1");
         assertContainsContainer(containers, "list-containers-c2");
+    }
+
+    @Test
+    public void testGetReleaseId() throws Exception {
+        String containerId = "get-releaseId";
+        client.createContainer(containerId, new KieContainerResource(containerId, releaseId1));
+
+        ServiceResponse<ReleaseId> reply = client.getReleaseId(containerId);
+        KieServerAssert.assertSuccess(reply);
+        Assert.assertEquals(releaseId1, reply.getResult());
+
+        ServiceResponse<Void> disposeReply = client.disposeContainer(containerId);
+        KieServerAssert.assertSuccess(disposeReply);
     }
 
     @Test


### PR DESCRIPTION
I have added missing `getReleaseId` method to `KieServicesClient`.