### PR TITLE
Fix POMs after IP BOM 7.0.0.CR6 upgrade

### DIFF
--- a/droolsjbpm-integration-examples/pom.xml
+++ b/droolsjbpm-integration-examples/pom.xml
@@ -13,20 +13,6 @@
   <name>Drools and jBPM examples</name>
   <description>Examples for Drools Expert, Fusion and/or jBPM.</description>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-eclipse-plugin</artifactId>
-        <configuration>
-          <additionalBuildcommands>
-            <buildcommand>org.kie.eclipse.droolsbuilder</buildcommand>
-          </additionalBuildcommands>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
   <dependencies>
     <!-- Internal dependencies -->
     <dependency>

--- a/kie-eap-integration/kie-eap-tests/pom.xml
+++ b/kie-eap-integration/kie-eap-tests/pom.xml
@@ -13,7 +13,6 @@
 
   <properties>
     <version.org.wildfly>10.0.0.Final</version.org.wildfly>
-    <version.org.wildfly.arquillian.container>1.0.0.Final</version.org.wildfly.arquillian.container>
   </properties>
 
   <build>
@@ -81,16 +80,6 @@
       </plugin>
     </plugins>
   </build>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.wildfly.arquillian</groupId>
-        <artifactId>wildfly-arquillian-container-managed</artifactId>
-        <version>${version.org.wildfly.arquillian.container}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>

--- a/kie-server-parent/kie-server-api/pom.xml
+++ b/kie-server-parent/kie-server-api/pom.xml
@@ -109,42 +109,6 @@
     </resources>
 
     <plugins>
-      <!-- Eclipse does not read the pom.xml by default, so it does not know it should process the filtered-resources.
-           The config below is needed and makes sure the resources are properly processed, e.g. when running the tests
-           directly from the Eclipse. Without the config tests that depend on those filtered resources will fail. -->
-      <plugin>
-        <artifactId>maven-eclipse-plugin</artifactId>
-        <configuration>
-          <additionalBuildcommands>
-            <buildCommand>
-              <name>org.eclipse.ui.externaltools.ExternalToolBuilder</name>
-              <triggers>auto,full,incremental,</triggers>
-              <arguments>
-                <LaunchConfigHandle>&lt;project&gt;/.externalToolBuilders/mvn-resources.launch</LaunchConfigHandle>
-              </arguments>
-            </buildCommand>
-          </additionalBuildcommands>
-          <additionalConfig>
-            <file>
-              <name>.externalToolBuilders/mvn-resources.launch</name>
-              <content>
-                <![CDATA[<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<launchConfiguration type="org.eclipse.ui.externaltools.ProgramBuilderLaunchConfigurationType">
-<booleanAttribute key="org.eclipse.debug.ui.ATTR_LAUNCH_IN_BACKGROUND" value="true"/>
-<booleanAttribute key="org.eclipse.ui.externaltools.ATTR_BUILDER_ENABLED" value="true"/>
-<stringAttribute key="org.eclipse.ui.externaltools.ATTR_BUILD_SCOPE" value="&#36;{working_set:&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&#13;&#10;&lt;launchConfigurationWorkingSet editPageId=&quot;org.eclipse.ui.resourceWorkingSetPage&quot; factoryID=&quot;org.eclipse.ui.internal.WorkingSetFactory&quot; label=&quot;workingSet&quot; name=&quot;workingSet&quot;&gt;&#13;&#10;&lt;item factoryID=&quot;org.eclipse.ui.internal.model.ResourceFactory&quot; path=&quot;/${project.artifactId}/src/main/resources&quot; type=&quot;2&quot;/&gt;&#13;&#10;&lt;/launchConfigurationWorkingSet&gt;}"/>
-<stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${env_var:MAVEN_HOME}/bin/mvn"/>
-<stringAttribute key="org.eclipse.ui.externaltools.ATTR_RUN_BUILD_KINDS" value="full,incremental,auto,"/>
-<stringAttribute key="org.eclipse.ui.externaltools.ATTR_TOOL_ARGUMENTS" value="resources:resources"/>
-<booleanAttribute key="org.eclipse.ui.externaltools.ATTR_TRIGGERS_CONFIGURED" value="true"/>
-<stringAttribute key="org.eclipse.ui.externaltools.ATTR_WORKING_DIRECTORY" value="&#36;{workspace_loc:/${project.artifactId}}"/>
-</launchConfiguration>]]>
-              </content>
-            </file>
-          </additionalConfig>
-        </configuration>
-      </plugin>
-
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>


### PR DESCRIPTION
As per http://maven.apache.org/plugins/maven-eclipse-plugin/:
"Plugin is retired. Users are advised to use m2e, the Eclipse Maven
Integration instead of this plugin, as it can more closely resemble the
actual build and runtime classpaths as described in the project pom.xml
- among other advantages."

Also Eclipse comes win m2e by default nowadays, so there is no need
for this plugin anymore.