### PR TITLE
kie-server-tests: Add user for remote deployment of Kie server

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/config/TestConfig.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/config/TestConfig.java
@@ -70,6 +70,8 @@ public class TestConfig {
 
     private static final StringTestParameter CONTAINER_ID = new StringTestParameter("cargo.container.id");
     private static final StringTestParameter CONTAINER_PORT = new StringTestParameter("cargo.servlet.port");
+    private static final StringTestParameter CARGO_REMOTE_USERNAME = new StringTestParameter("cargo.remote.username");
+    private static final StringTestParameter CARGO_REMOTE_PASSWORD = new StringTestParameter("cargo.remote.password");
     private static final StringTestParameter KIE_SERVER_WAR_PATH = new StringTestParameter("kie.server.war.path");
 
     private static final StringTestParameter WEBLOGIC_HOME = new StringTestParameter("weblogic.home");
@@ -364,6 +366,34 @@ public class TestConfig {
      */
     public static boolean isWebLogicHomeProvided() {
         return TestConfig.WEBLOGIC_HOME.isParameterConfigured();
+    }
+
+    /**
+     * @return Username for Cargo remote deployment.
+     */
+    public static String getCargoRemoteUsername() {
+        return TestConfig.CARGO_REMOTE_USERNAME.getParameterValue();
+    }
+
+    /**
+     * @return True if username for Cargo remote deployment defined.
+     */
+    public static boolean isCargoRemoteUsernameProvided() {
+        return TestConfig.CARGO_REMOTE_USERNAME.isParameterConfigured();
+    }
+
+    /**
+     * @return Password for Cargo remote deployment.
+     */
+    public static String getCargoRemotePassword() {
+        return TestConfig.CARGO_REMOTE_PASSWORD.getParameterValue();
+    }
+
+    /**
+     * @return True if password for Cargo remote deployment defined.
+     */
+    public static boolean isCargoRemotePasswordProvided() {
+        return TestConfig.CARGO_REMOTE_PASSWORD.isParameterConfigured();
     }
 
     /**

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/controller/ContainerRemoteController.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/controller/ContainerRemoteController.java
@@ -23,6 +23,7 @@ import org.codehaus.cargo.container.configuration.ConfigurationType;
 import org.codehaus.cargo.container.deployable.DeployableType;
 import org.codehaus.cargo.container.deployable.WAR;
 import org.codehaus.cargo.container.deployer.Deployer;
+import org.codehaus.cargo.container.property.RemotePropertySet;
 import org.codehaus.cargo.container.property.ServletPropertySet;
 import org.codehaus.cargo.container.weblogic.WebLogicPropertySet;
 import org.codehaus.cargo.generic.DefaultContainerFactory;
@@ -45,6 +46,14 @@ public class ContainerRemoteController {
         deployer = new DefaultDeployerFactory().createDeployer(container);
 
         configuration.setProperty(ServletPropertySet.PORT, containerPort);
+
+        if(TestConfig.isCargoRemoteUsernameProvided()) {
+            configuration.setProperty(RemotePropertySet.USERNAME, TestConfig.getCargoRemoteUsername());
+        }
+        if(TestConfig.isCargoRemotePasswordProvided()) {
+            configuration.setProperty(RemotePropertySet.PASSWORD, TestConfig.getCargoRemotePassword());
+        }
+
         // WLS remote configuration
         if (TestConfig.isWebLogicHomeProvided()) {
             String wlserverHome = TestConfig.getWebLogicHome().matches(".*/wlserver") ?

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -392,6 +392,17 @@
                 </configuration>
               </configuration>
             </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-failsafe-plugin</artifactId>
+              <configuration>
+                <systemPropertyVariables>
+                  <!-- Reuse yoda user for deploying and undeploying Kie server from within the test -->
+                  <cargo.remote.username>yoda</cargo.remote.username>
+                  <cargo.remote.password>usetheforce123@</cargo.remote.password>
+                </systemPropertyVariables>
+              </configuration>
+            </plugin>
           </plugins>
         </pluginManagement>
       </build>
@@ -531,6 +542,17 @@
                     <cargo.jvmargs>-Xmx1024m</cargo.jvmargs>
                   </properties>
                 </configuration>
+              </configuration>
+            </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-failsafe-plugin</artifactId>
+              <configuration>
+                <systemPropertyVariables>
+                  <!-- Reuse yoda user for deploying and undeploying Kie server from within the test -->
+                  <cargo.remote.username>yoda</cargo.remote.username>
+                  <cargo.remote.password>usetheforce123@</cargo.remote.password>
+                </systemPropertyVariables>
               </configuration>
             </plugin>
           </plugins>


### PR DESCRIPTION
To make Kie server tests compatible with new Cargo version, see https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/pull/349 .
