### PR TITLE
Exclude geronimo-jta_1.1_spec artifact from Kie server

### DIFF
--- a/kie-server-parent/kie-server-wars/kie-server/pom.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/pom.xml
@@ -181,6 +181,10 @@
           <groupId>dom4j</groupId>
           <artifactId>dom4j</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.geronimo.specs</groupId>
+          <artifactId>geronimo-jta_1.1_spec</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -190,6 +194,10 @@
         <exclusion>
           <groupId>org.jboss.spec.javax.transaction</groupId>
           <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.geronimo.specs</groupId>
+          <artifactId>geronimo-jta_1.1_spec</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
This artifact is brought by Hibernate 5. Cause issues with Tomcat.
Kie server should use jboss-transaction-api artifact.
@psiroky FYI