### PR TITLE
RHBPMS-4557 - NPE when searching nonexistent task using the method Us…

### DIFF
--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm/src/main/java/org/kie/server/remote/rest/jbpm/RuntimeDataResource.java
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm/src/main/java/org/kie/server/remote/rest/jbpm/RuntimeDataResource.java
@@ -30,6 +30,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Variant;
 
 import org.jbpm.services.api.ProcessInstanceNotFoundException;
+import org.jbpm.services.api.TaskNotFoundException;
 import org.kie.server.api.model.definition.ProcessDefinitionList;
 import org.kie.server.api.model.instance.NodeInstance;
 import org.kie.server.api.model.instance.NodeInstanceList;
@@ -317,12 +318,17 @@ public class RuntimeDataResource {
         Variant v = getVariant(headers);
         // no container id available so only used to transfer conversation id if given by client
         Header conversationIdHeader = buildConversationIdHeader("", context, headers);
-        TaskInstance userTaskDesc = runtimeDataServiceBase.getTaskByWorkItemId(workItemId);
-        if (userTaskDesc == null) {
+        TaskInstance userTaskDesc = null;
+        try {
+            userTaskDesc = runtimeDataServiceBase.getTaskByWorkItemId(workItemId);
+            return createCorrectVariant(userTaskDesc, headers, Response.Status.OK, conversationIdHeader);
 
+        } catch (TaskNotFoundException e) {
             return notFound(MessageFormat.format(TASK_INSTANCE_NOT_FOUND_FOR_WORKITEM, workItemId), v, conversationIdHeader);
+        } catch (Exception e) {
+            logger.error("Unexpected error during processing {}", e.getMessage(), e);
+            return internalServerError(MessageFormat.format(UNEXPECTED_ERROR, e.getMessage()), v, conversationIdHeader);
         }
-        return createCorrectVariant(userTaskDesc, headers, Response.Status.OK, conversationIdHeader);
     }
 
     @GET
@@ -333,12 +339,17 @@ public class RuntimeDataResource {
         // no container id available so only used to transfer conversation id if given by client
         Header conversationIdHeader = buildConversationIdHeader("", context, headers);
 
-        TaskInstance userTaskDesc = runtimeDataServiceBase.getTaskById(taskId);
-        if (userTaskDesc == null) {
+        TaskInstance userTaskDesc = null;
+        try {
+            userTaskDesc = runtimeDataServiceBase.getTaskById(taskId);
+            return createCorrectVariant(userTaskDesc, headers, Response.Status.OK, conversationIdHeader);
 
+        } catch (TaskNotFoundException e) {
             return notFound(MessageFormat.format(TASK_INSTANCE_NOT_FOUND, taskId), v, conversationIdHeader);
+        } catch (Exception e) {
+            logger.error("Unexpected error during processing {}", e.getMessage(), e);
+            return internalServerError(MessageFormat.format(UNEXPECTED_ERROR, e.getMessage()), v, conversationIdHeader);
         }
-        return createCorrectVariant(userTaskDesc, headers, Response.Status.OK, conversationIdHeader);
     }
 
 

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/RuntimeDataServiceBase.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/RuntimeDataServiceBase.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import org.jbpm.services.api.ProcessInstanceNotFoundException;
 import org.jbpm.services.api.RuntimeDataService;
+import org.jbpm.services.api.TaskNotFoundException;
 import org.jbpm.services.api.model.NodeInstanceDesc;
 import org.jbpm.services.api.model.ProcessDefinition;
 import org.jbpm.services.api.model.ProcessInstanceDesc;
@@ -347,12 +348,20 @@ public class RuntimeDataServiceBase {
 
         UserTaskInstanceDesc userTaskDesc = runtimeDataService.getTaskByWorkItemId(workItemId);
 
+        if (userTaskDesc == null) {
+            throw new TaskNotFoundException("No task found with work item id " + workItemId);
+        }
+
         return convertToTask(userTaskDesc);
     }
 
     public TaskInstance getTaskById(long taskId) {
 
         UserTaskInstanceDesc userTaskDesc = runtimeDataService.getTaskById(taskId);
+
+        if (userTaskDesc == null) {
+            throw new TaskNotFoundException("No task found with id " + taskId);
+        }
 
         return convertToTask(userTaskDesc);
     }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/RuntimeDataServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/RuntimeDataServiceIntegrationTest.java
@@ -1301,6 +1301,17 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
 
     }
 
+    @Test (expected = KieServicesException.class)
+    public void testNotExistingUserTaskFindByWorkItemId() throws Exception {
+        taskClient.findTaskByWorkItemId(-9999l);
+    }
+
+    @Test (expected = KieServicesException.class)
+    public void testNotExistingUserTaskFindById() throws Exception {
+        taskClient.findTaskById(-9999l);
+    }
+
+
     @Test
     public void testFindTasks() throws Exception {
         Map<String, Object> parameters = new HashMap<String, Object>();


### PR DESCRIPTION
…erTaskServicesClient.findTaskById

Hi,

I have created a new PR as a replacement for #776. Now it handles non-existing tasks this way: In case of REST config, a KieServerHttpException is thrown which has a 404 code in the message. In case of JMS config, a KieServerException is thrown with the message that no such task was found while on the server side TaskNotFoundException is logged as a cause of InvocationTargetException. BTW I have also updated findTaskByWorkItemId method to behave the same way.

Thanks.