### PR TITLE
[6.5.x] RHBPMS-4445: add reproducer of found regression

### DIFF
--- a/kie-remote/kie-remote-services/src/test/java/org/kie/remote/services/rest/query/QueryResourceQueryHelperTest.java
+++ b/kie-remote/kie-remote-services/src/test/java/org/kie/remote/services/rest/query/QueryResourceQueryHelperTest.java
@@ -255,4 +255,35 @@ public class QueryResourceQueryHelperTest extends AbstractQueryResourceTest {
 
     }
 
+    @Test
+    public void testAllUsingVariableValue() {
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("myobject", "first");
+        ProcessInstance p1 = ksession.startProcess(OBJECT_VARIABLE_PROCESS_ID, params); // completed
+        ((WorkflowProcessInstance) p1).setVariable("myobject", "second");
+
+        params = new HashMap<String, Object>();
+        params.put("myobject", "first");
+        ProcessInstance p2 = ksession.startProcess(OBJECT_VARIABLE_PROCESS_ID, params); // completed
+
+        Map<String, String[]> queryParams = new HashMap<String, String[]>();
+        addParams(queryParams, "varvalue", "first");
+
+        int [] pageInfo = { 0, 0 };
+        JaxbQueryProcessInstanceResult result1 = queryProcInstHelper.queryTasksOrProcInstsAndVariables(queryParams, pageInfo);
+
+        assertNotNull(result1);
+        assertFalse(result1.getProcessInstanceInfoList().isEmpty());
+        List<JaxbQueryProcessInstanceInfo> processInfoList1 = result1.getProcessInstanceInfoList();
+        assertEquals(1, processInfoList1.size());
+
+        addParams(queryParams, "all", "true");
+        JaxbQueryProcessInstanceResult result2 = queryProcInstHelper.queryTasksOrProcInstsAndVariables(queryParams, pageInfo);
+
+        assertNotNull(result2);
+        assertFalse(result2.getProcessInstanceInfoList().isEmpty());
+        List<JaxbQueryProcessInstanceInfo> processInfoList2 = result2.getProcessInstanceInfoList();
+        assertEquals(2, processInfoList2.size());
+    }
+
 }


### PR DESCRIPTION
I have added a reproducer of regression found after the fix for [RHBPMS-4445](https://issues.jboss.org/browse/RHBPMS-4445) was merged.

The problem is that the filtering of results does not work correctly now. Yes, it does not return older variable values (unless `all` parameter is given) but it returns processes in which the queried variable value is not the latest value (just a history record).