### PR TITLE
kie-server-tests: move user info properties config to jbpm tests

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
@@ -291,6 +291,9 @@
               <org.optaplanner.server.ext.disabled>true</org.optaplanner.server.ext.disabled>
               <org.jbpm.case.server.ext.disabled>true</org.jbpm.case.server.ext.disabled>
               <org.drools.server.ext.disabled>true</org.drools.server.ext.disabled>
+              <!-- UserInfo properties for UserTaskEscalationIntegrationTest-->
+              <org.jbpm.ht.userinfo>props</org.jbpm.ht.userinfo>
+              <jbpm.user.info.properties>file://${project.build.testOutputDirectory}/userinfo.properties</jbpm.user.info.properties>
             </systemProperties>
           </container>
         </configuration>

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -411,9 +411,6 @@
                     <!-- disable JMS support for executor to use same tests for all containers for jbpm executor -->
                     <org.kie.executor.jms>false</org.kie.executor.jms>
                     <org.kie.server.sync.deploy>true</org.kie.server.sync.deploy>
-                    <!-- UserInfo properties for UserTaskEscalationIntegrationTest-->
-                    <org.jbpm.ht.userinfo>props</org.jbpm.ht.userinfo>
-                    <jbpm.user.info.properties>file://${project.build.testOutputDirectory}/userinfo.properties</jbpm.user.info.properties>
                     <org.kie.mail.session>java:/mail/Session</org.kie.mail.session>
                   </systemProperties>
                 </container>
@@ -564,12 +561,9 @@
                     <url>${eap7.download.url}</url>
                   </zipUrlInstaller>
                   <systemProperties>
-                    <!-- disable JMS support for executor touse same tests for all containers for jbpm executor -->
+                    <!-- disable JMS support for executor to use same tests for all containers for jbpm executor -->
                     <org.kie.executor.jms>false</org.kie.executor.jms>
                     <org.kie.server.sync.deploy>true</org.kie.server.sync.deploy>
-                    <!-- UserInfo properties for UserTaskEscalationIntegrationTest-->
-                    <org.jbpm.ht.userinfo>props</org.jbpm.ht.userinfo>
-                    <jbpm.user.info.properties>file://${project.build.testOutputDirectory}/userinfo.properties</jbpm.user.info.properties>
                     <org.kie.mail.session>java:/mail/Session</org.kie.mail.session>
                   </systemProperties>
                 </container>


### PR DESCRIPTION
User info properties file is available just in jbpm test module.