### PR TITLE
kie-server-tests: Delete document storage before tests

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerUtil.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerUtil.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2016 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.server.integrationtests.shared;
+
+import java.io.File;
+
+import org.kie.server.api.KieServerConstants;
+
+public class KieServerUtil {
+
+    public static void deleteDocumentStorageFolder() {
+        File storagePath = new File(System.getProperty(KieServerConstants.CFG_DOCUMENT_STORAGE_PATH, "target/docs"));
+        deleteFolder(storagePath);
+    }
+
+    private static void deleteFolder(File path) {
+        File[] directories = path.listFiles();
+        if (directories != null) {
+            for (File file : directories) {
+                if (file.isDirectory()) {
+                    deleteFolder(file);
+                }
+                file.delete();
+            }
+        }
+    }
+}

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/DocumentServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/DocumentServiceIntegrationTest.java
@@ -15,7 +15,6 @@
 
 package org.kie.server.integrationtests.jbpm;
 
-import java.io.File;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -28,7 +27,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.api.KieServices;
-import org.kie.server.api.KieServerConstants;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.instance.DocumentInstance;
 import org.kie.server.api.model.instance.TaskSummary;
@@ -37,6 +35,7 @@ import org.kie.server.integrationtests.category.Smoke;
 
 import static org.junit.Assert.*;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
+import org.kie.server.integrationtests.shared.KieServerUtil;
 
 public class DocumentServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest {
 
@@ -63,8 +62,7 @@ public class DocumentServiceIntegrationTest extends JbpmKieServerBaseIntegration
     @Before
     public void createData() {
 
-        File storagePath = new File(System.getProperty(KieServerConstants.CFG_DOCUMENT_STORAGE_PATH, "target/docs"));
-        deleteFolder(storagePath);
+        KieServerUtil.deleteDocumentStorageFolder();
 
         content = "just text content";
         contentBytes = content.getBytes();
@@ -76,19 +74,6 @@ public class DocumentServiceIntegrationTest extends JbpmKieServerBaseIntegration
                 .content(contentBytes)
                 .build();
     }
-
-    protected void deleteFolder(File path) {
-        File[] directories = path.listFiles();
-        if (directories != null) {
-            for (File file : directories) {
-                if (file.isDirectory()) {
-                    deleteFolder(file);
-                }
-                file.delete();
-            }
-        }
-    }
-
 
     @Override
     protected void addExtraCustomClasses(Map<String, Class<?>> extraClasses) throws Exception {

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/rest/JbpmRestIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/rest/JbpmRestIntegrationTest.java
@@ -43,6 +43,7 @@ import org.kie.server.api.model.type.JaxbLong;
 import org.kie.server.api.model.type.JaxbString;
 import org.kie.server.integrationtests.config.TestConfig;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
+import org.kie.server.integrationtests.shared.KieServerUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -204,6 +205,8 @@ public class JbpmRestIntegrationTest extends RestJbpmBaseIntegrationTest {
 
     @Test
     public void testUploadListDownloadDocument() throws Exception {
+        KieServerUtil.deleteDocumentStorageFolder();
+
         Marshaller marshaller = MarshallerFactory.getMarshaller(new HashSet<Class<?>>(extraClasses.values()), marshallingFormat, client.getClassLoader());
 
         DocumentInstance documentInstance = DocumentInstance.builder().name("test file.txt").size(50).content("test content".getBytes()).lastModified(new Date()).build();
@@ -274,6 +277,5 @@ public class JbpmRestIntegrationTest extends RestJbpmBaseIntegrationTest {
                 response.close();
             }
         }
-
     }
 }


### PR DESCRIPTION
Test testUploadListDownloadDocument() was affected by documents left by DocumentServiceIntegrationTest.