### PR TITLE
[DROOLS-936] clean-up dependencies to fix duplicated classes issue

### DIFF
--- a/drools-android/pom.xml
+++ b/drools-android/pom.xml
@@ -53,6 +53,14 @@
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>xpp3</groupId>
+          <artifactId>xpp3</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>xerces</groupId>
+          <artifactId>xmlParserAPIs</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -72,6 +80,12 @@
     <dependency>
       <groupId>javax.enterprise</groupId>
       <artifactId>cdi-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.inject</groupId>
+          <artifactId>javax.inject</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.roboguice</groupId>
@@ -101,9 +115,13 @@
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-ant-tasks</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
+  <dependency>
       <groupId>org.robolectric</groupId>
       <artifactId>robolectric-annotations</artifactId>
       <optional>true</optional>

--- a/droolsjbpm-bpms-distribution/pom.xml
+++ b/droolsjbpm-bpms-distribution/pom.xml
@@ -151,10 +151,28 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-decisiontables</artifactId>
+      <exclusions>
+        <exclusion>
+          <!-- Collides with 'xml-apis:xml-apis'. -->
+          <groupId>javax.xml.stream</groupId>
+          <artifactId>stax-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-jsr94</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-ci</artifactId>
+      <exclusions>
+        <exclusion>
+          <!-- Collides with 'org.springframework:spring-aop'. -->
+          <groupId>aopalliance</groupId>
+          <artifactId>aopalliance</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.kie</groupId>
@@ -175,14 +193,6 @@
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-aries-blueprint</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.kie</groupId>
-      <artifactId>kie-maven-plugin</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.kie</groupId>
-      <artifactId>kie-ci-osgi</artifactId>
     </dependency>
 
     <!-- The old assembly also included this optional dependency -->
@@ -209,10 +219,22 @@
     <dependency>
       <groupId>javax.enterprise</groupId>
       <artifactId>cdi-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.el</groupId>
+          <artifactId>javax.el-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.quartz-scheduler</groupId>
       <artifactId>quartz</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.transaction</groupId>
+          <artifactId>jta</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.quartz-scheduler</groupId>
@@ -227,21 +249,5 @@
       <artifactId>jboss-jacc-api_1.5_spec</artifactId>
     </dependency>
 
-    <!-- Javadocs and documentation -->
-    <dependency><!-- Workaround for http://jira.codehaus.org/browse/MJAVADOC-340 -->
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency><!-- Workaround for http://jira.codehaus.org/browse/MJAVADOC-340 -->
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.compendium</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency><!-- Workaround, maybe for http://jira.codehaus.org/browse/MJAVADOC-340 -->
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>provided</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/droolsjbpm-bpms-distribution/src/main/assembly/pre-bin.xml
+++ b/droolsjbpm-bpms-distribution/src/main/assembly/pre-bin.xml
@@ -38,9 +38,7 @@
         <include>org.kie:kie-api</include>
         <include>org.kie:kie-aries-blueprint</include>
         <include>org.kie:kie-internal</include>
-        <include>org.kie:kie-maven-plugin</include>
         <include>org.kie:kie-ci</include>
-        <include>org.kie:kie-ci-osgi</include>
         <include>org.kie:kie-spring</include>
         <include>org.kie.server:kie-server-common</include>
         <include>org.kie.server:kie-server-api</include>
@@ -92,9 +90,7 @@
         <exclude>org.kie:kie-api</exclude>
         <exclude>org.kie:kie-aries-blueprint</exclude>
         <exclude>org.kie:kie-internal</exclude>
-        <exclude>org.kie:kie-maven-plugin</exclude>
         <exclude>org.kie:kie-ci</exclude>
-        <exclude>org.kie:kie-ci-osgi</exclude>
         <exclude>org.kie:kie-spring</exclude>
         <exclude>org.kie.server:kie-server-common</exclude>
         <exclude>org.kie.server:kie-server-api</exclude>

--- a/droolsjbpm-brms-distribution/pom.xml
+++ b/droolsjbpm-brms-distribution/pom.xml
@@ -65,10 +65,6 @@
       <artifactId>kie-spring</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.kie</groupId>
-      <artifactId>kie-maven-plugin</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.kie.server</groupId>
       <artifactId>kie-server-client</artifactId>
     </dependency>
@@ -99,10 +95,13 @@
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-ci</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.kie</groupId>
-      <artifactId>kie-ci-osgi</artifactId>
+      <exclusions>
+        <exclusion>
+          <!-- Collides with 'org.springframework:spring-aop'. -->
+          <groupId>aopalliance</groupId>
+          <artifactId>aopalliance</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.codehaus.btm</groupId>
@@ -127,21 +126,5 @@
       <artifactId>xstream</artifactId>
     </dependency>
 
-    <!-- Javadocs and documentation -->
-    <dependency><!-- Workaround for http://jira.codehaus.org/browse/MJAVADOC-340 -->
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency><!-- Workaround for http://jira.codehaus.org/browse/MJAVADOC-340 -->
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.compendium</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency><!-- Workaround, maybe for http://jira.codehaus.org/browse/MJAVADOC-340 -->
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>provided</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/droolsjbpm-brms-distribution/src/main/assembly/pre-bin.xml
+++ b/droolsjbpm-brms-distribution/src/main/assembly/pre-bin.xml
@@ -15,9 +15,7 @@
         <include>org.kie:kie-api</include>
         <include>org.kie:kie-aries-blueprint</include>
         <include>org.kie:kie-internal</include>
-        <include>org.kie:kie-maven-plugin</include>
         <include>org.kie:kie-ci</include>
-        <include>org.kie:kie-ci-osgi</include>
         <include>org.kie:kie-spring</include>
         <include>org.kie.server:kie-server-common</include>
         <include>org.kie.server:kie-server-api</include>
@@ -46,9 +44,7 @@
         <exclude>org.kie:kie-api</exclude>
         <exclude>org.kie:kie-aries-blueprint</exclude>
         <exclude>org.kie:kie-internal</exclude>
-        <exclude>org.kie:kie-maven-plugin</exclude>
         <exclude>org.kie:kie-ci</exclude>
-        <exclude>org.kie:kie-ci-osgi</exclude>
         <exclude>org.kie:kie-spring</exclude>
         <exclude>org.kie.server:kie-server-common</exclude>
         <exclude>org.kie.server:kie-server-api</exclude>

--- a/kie-aries-blueprint/pom.xml
+++ b/kie-aries-blueprint/pom.xml
@@ -92,6 +92,12 @@
       <groupId>javax.enterprise</groupId>
       <artifactId>cdi-api</artifactId>
       <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.annotation</groupId>
+          <artifactId>jsr250-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -168,6 +174,35 @@
         <directory>src/test/filtered-resources</directory>
       </testResource>
     </testResources>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>ban-duplicated-classes</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <banDuplicateClasses>
+                    <ignoreClasses combine.children="append">
+                      <!-- Duplicated by different blueprint artifacts and the testing uberjar *noosgi -->
+                      <ignoreClass>org.osgi.service.blueprint.*</ignoreClass>
+                      <ignoreClass>org.apache.aries.blueprint.*</ignoreClass>
+                    </ignoreClasses>
+                    <findAllDuplicates>true</findAllDuplicates>
+                  </banDuplicateClasses>
+                </rules>
+                <fail>true</fail>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.felix</groupId>

--- a/kie-eap-integration/kie-eap-distribution/pom.xml
+++ b/kie-eap-integration/kie-eap-distribution/pom.xml
@@ -41,17 +41,6 @@
     </plugins>
   </build>
 
-  <dependencyManagement>
-    <dependencies>
-      <!-- TODO remove this once we use ip-bom that contains https://github.com/jboss-integration/jboss-integration-platform-bom/pull/314 -->
-      <dependency>
-        <groupId>org.sonatype.sisu.inject</groupId>
-        <artifactId>guice-servlet</artifactId>
-        <version>${version.org.sonatype.sisu.sisu-guice}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <dependency>
       <groupId>org.kie</groupId>

--- a/kie-eap-integration/pom.xml
+++ b/kie-eap-integration/pom.xml
@@ -14,6 +14,9 @@
 
   <properties>
     <version.fuse.patch>1.6.2</version.fuse.patch>
+    <!-- Disabled as this module will likely be removed in near future and it would be just a waste of time to clean it
+     up as there are hundreds of duplicated classes brought in via transitive deps. See https://issues.jboss.org/browse/DROOLS-1427 -->
+    <enforcer.failOnDuplicatedClasses>false</enforcer.failOnDuplicatedClasses>
   </properties>
 
   <modules>

--- a/kie-identity-session-provider/pom.xml
+++ b/kie-identity-session-provider/pom.xml
@@ -38,6 +38,12 @@
     <dependency>
      <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>javassist</groupId>
+          <artifactId>javassist</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
      <groupId>org.uberfire</groupId>

--- a/kie-infinispan/drools-infinispan-persistence/pom.xml
+++ b/kie-infinispan/drools-infinispan-persistence/pom.xml
@@ -74,6 +74,13 @@
     <dependency>
       <groupId>org.infinispan</groupId>
       <artifactId>infinispan-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <!-- Collides with 'org.jboss.spec.javax.transaction: jboss-transaction-api_1.1_spec'. -->
+          <groupId>org.jboss.spec.javax.transaction</groupId>
+          <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.infinispan</groupId>
@@ -144,6 +151,16 @@
       <groupId>javax.enterprise</groupId>
       <artifactId>cdi-api</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.el</groupId>
+          <artifactId>javax.el-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.interceptor</groupId>
+          <artifactId>javax.interceptor-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jboss.weld.se</groupId>

--- a/kie-infinispan/jbpm-infinispan-persistence/pom.xml
+++ b/kie-infinispan/jbpm-infinispan-persistence/pom.xml
@@ -63,12 +63,17 @@
     <dependency>
       <groupId>org.infinispan</groupId>
       <artifactId>infinispan-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.transaction</groupId>
+          <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.infinispan</groupId>
       <artifactId>infinispan-commons</artifactId>
     </dependency>
-
 
     <!-- Logging -->
     <dependency>

--- a/kie-maven-plugin/pom.xml
+++ b/kie-maven-plugin/pom.xml
@@ -45,11 +45,21 @@
           <groupId>org.eclipse.sisu</groupId>
           <artifactId>org.eclipse.sisu.inject</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.sisu</groupId>
+          <artifactId>org.eclipse.sisu.plexus</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.eclipse.sisu</groupId>
+          <artifactId>org.eclipse.sisu.plexus</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
@@ -69,12 +79,17 @@
       <artifactId>plexus-container-default</artifactId>
       <exclusions>
         <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging-api</artifactId>
         </exclusion>
+        <!-- Superseded by Guava-->
         <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
+          <groupId>com.google.collections</groupId>
+          <artifactId>google-collections</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -185,6 +200,12 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-compat</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.eclipse.sisu</groupId>
+          <artifactId>org.eclipse.sisu.plexus</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.takari.maven.plugins</groupId>
@@ -195,11 +216,6 @@
       <groupId>io.takari.maven.plugins</groupId>
       <artifactId>takari-plugin-integration-testing</artifactId>
       <type>pom</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/kie-osgi/pom.xml
+++ b/kie-osgi/pom.xml
@@ -16,6 +16,12 @@
 
   <name>KIE :: OSGi Integration Parent Project</name>
 
+  <properties>
+    <!-- The OSGi modules depend on both non-osgi and osgi jars (with different GAs. It seems there is no easy way
+         to fix this. -->
+    <enforcer.failOnDuplicatedClasses>false</enforcer.failOnDuplicatedClasses>
+  </properties>
+
   <modules>
     <module>kie-karaf-itests-domain-model</module>
     <module>kie-karaf-itests-kjar</module>

--- a/kie-server-parent/kie-server-controller/kie-server-controller-test-war/pom.xml
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-test-war/pom.xml
@@ -28,6 +28,11 @@
           <groupId>javassist</groupId>
           <artifactId>javassist</artifactId>
         </exclusion>
+        <exclusion>
+          <!-- Collides with 'com.google.code.findbugs:annotations'. -->
+          <groupId>net.jcip</groupId>
+          <artifactId>jcip-annotations</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/kie-server-parent/kie-server-remote/kie-server-client/pom.xml
+++ b/kie-server-parent/kie-server-remote/kie-server-client/pom.xml
@@ -17,6 +17,16 @@
     <osgi.Bundle-SymbolicName>org.kie.server.client</osgi.Bundle-SymbolicName>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.github.tomakehurst</groupId>
+        <artifactId>wiremock</artifactId>
+        <version>${version.com.github.tomakehurst.wiremock}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -104,6 +114,10 @@
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>net.jcip</groupId>
+          <artifactId>jcip-annotations</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <!-- Replacement for the above excluded 'commons-logging:commons-logging' -->
@@ -120,8 +134,13 @@
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock</artifactId>
-      <classifier>standalone</classifier>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.mortbay.jetty</groupId>
+          <artifactId>servlet-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>

--- a/kie-server-parent/kie-server-services/kie-server-services-common/pom.xml
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/pom.xml
@@ -85,6 +85,20 @@
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jaxrs</artifactId>
       <scope>runtime</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>javassist</groupId>
+          <artifactId>javassist</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.annotation</groupId>
+          <artifactId>jsr250-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>net.jcip</groupId>
+          <artifactId>jcip-annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.ws.rs</groupId>

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/pom.xml
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/pom.xml
@@ -84,6 +84,12 @@
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-kie-services</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/pom.xml
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/pom.xml
@@ -135,6 +135,13 @@
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-entitymanager</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <!-- Collides with 'javax.xml.stream:stax-api' and is not required for the tests. -->
+          <groupId>xml-apis</groupId>
+          <artifactId>xml-apis</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.h2database</groupId>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/pom.xml
@@ -46,6 +46,12 @@
       <groupId>org.kie.server</groupId>
       <artifactId>kie-server-services-common</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.xml.stream</groupId>
+          <artifactId>stax-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.kie.server</groupId>
@@ -126,6 +132,12 @@
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>tjws</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.servlet</groupId>
+          <artifactId>servlet-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
    <!--  Stay with httpcomponents: it will save us pain (as opposed to changing from resteasy to cxf to cxf 3.0, etc. --> 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/pom.xml
@@ -75,10 +75,22 @@
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>tjws</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.servlet</groupId>
+          <artifactId>servlet-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jaxrs</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>net.jcip</groupId>
+          <artifactId>jcip-annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jboss.resteasy</groupId>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/pom.xml
@@ -67,6 +67,10 @@
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>net.jcip</groupId>
+          <artifactId>jcip-annotations</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/pom.xml
@@ -45,6 +45,13 @@
       <groupId>org.kie.server</groupId>
       <artifactId>kie-server-services-common</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <!-- Classes from this dependency already packaged in 'xml-apis:xml-apis'-->
+          <groupId>javax.xml.stream</groupId>
+          <artifactId>stax-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.kie.server</groupId>
@@ -90,6 +97,12 @@
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>tjws</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.servlet</groupId>
+          <artifactId>servlet-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
    <!--  Stay with httpcomponents: it will save us pain (as opposed to changing from resteasy to cxf to cxf 3.0, etc. --> 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
@@ -45,6 +45,13 @@
       <groupId>org.kie.server</groupId>
       <artifactId>kie-server-services-common</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <!-- Classes from this dependency already packaged in 'xml-apis:xml-apis'-->
+          <groupId>javax.xml.stream</groupId>
+          <artifactId>stax-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.kie.server</groupId>
@@ -96,6 +103,12 @@
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>tjws</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.servlet</groupId>
+          <artifactId>servlet-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
    <!--  Stay with httpcomponents: it will save us pain (as opposed to changing from resteasy to cxf to cxf 3.0, etc. --> 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/pom.xml
@@ -101,6 +101,12 @@
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>tjws</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.servlet</groupId>
+          <artifactId>servlet-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
    <!--  Stay with httpcomponents: it will save us pain (as opposed to changing from resteasy to cxf to cxf 3.0, etc. --> 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-policy/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-policy/pom.xml
@@ -46,6 +46,12 @@
       <groupId>org.kie.server</groupId>
       <artifactId>kie-server-services-common</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.xml.stream</groupId>
+          <artifactId>stax-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.kie.server</groupId>
@@ -107,6 +113,12 @@
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>tjws</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.servlet</groupId>
+          <artifactId>servlet-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
    <!--  Stay with httpcomponents: it will save us pain (as opposed to changing from resteasy to cxf to cxf 3.0, etc. --> 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-router/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-router/pom.xml
@@ -46,6 +46,12 @@
       <groupId>org.kie.server</groupId>
       <artifactId>kie-server-services-common</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.xml.stream</groupId>
+          <artifactId>stax-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.kie.server</groupId>
@@ -119,6 +125,12 @@
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>tjws</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.servlet</groupId>
+          <artifactId>servlet-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
    <!--  Stay with httpcomponents: it will save us pain (as opposed to changing from resteasy to cxf to cxf 3.0, etc. --> 

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -112,6 +112,34 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>ban-duplicated-classes</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <banDuplicateClasses>
+                    <dependencies>
+                      <!-- kie-server-router-proxy is an uberjar as it seems to be expected to work like that. -->
+                      <dependency>
+                        <groupId>org.kie.server</groupId>
+                        <artifactId>kie-server-router-proxy</artifactId>
+                        <ignoreClasses>
+                          <ignoreClass>*</ignoreClass>
+                        </ignoreClasses>
+                      </dependency>
+                    </dependencies>
+                  </banDuplicateClasses>
+                </rules>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
           <groupId>org.codehaus.cargo</groupId>
           <artifactId>cargo-maven2-plugin</artifactId>
           <configuration>

--- a/kie-server-parent/kie-server-wars/kie-server/pom.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/pom.xml
@@ -19,6 +19,11 @@
       <artifactId>kie-server-services-common</artifactId>
       <exclusions>
         <exclusion>
+          <!-- Collides with 'xml-apis:xml-apis' -->
+          <groupId>javax.xml.stream</groupId>
+          <artifactId>stax-api</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
@@ -174,10 +179,6 @@
       <artifactId>hibernate-entitymanager</artifactId>
       <exclusions>
         <exclusion>
-          <groupId>org.jboss.spec.javax.transaction</groupId>
-          <artifactId>jboss-transaction-api_1.1_spec</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>dom4j</groupId>
           <artifactId>dom4j</artifactId>
         </exclusion>
@@ -191,10 +192,6 @@
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
       <exclusions>
-        <exclusion>
-          <groupId>org.jboss.spec.javax.transaction</groupId>
-          <artifactId>jboss-transaction-api_1.1_spec</artifactId>
-        </exclusion>
         <exclusion>
           <groupId>org.apache.geronimo.specs</groupId>
           <artifactId>geronimo-jta_1.1_spec</artifactId>

--- a/kie-spring/pom.xml
+++ b/kie-spring/pom.xml
@@ -56,6 +56,13 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-decisiontables</artifactId>
+      <exclusions>
+        <exclusion>
+          <!-- Collides with 'xml-apis:xml-apis' -->
+          <groupId>javax.xml.stream</groupId>
+          <artifactId>stax-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -159,6 +166,13 @@
       <groupId>org.kie</groupId>
       <artifactId>kie-ci</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <!-- Partially collides with 'org.springframework:spring-aop'. -->
+          <groupId>aopalliance</groupId>
+          <artifactId>aopalliance</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.drools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,10 @@
     Drools and jBPM integration with seam, spring, camel, ...
   </description>
 
+  <properties>
+    <enforcer.failOnDuplicatedClasses>true</enforcer.failOnDuplicatedClasses>
+  </properties>
+
   <repositories>
     <!-- Bootstrap repository to locate the parent pom when the parent pom has not been build locally. -->
     <repository>


### PR DESCRIPTION
brms-distribution and bpms-distribution cleaned-up in the process
as well. They did contain some jars which really should not be
part of the engine distributiosn (kie-maven-plugin, kie-ci-osgi).