### PR TITLE
[6.4.x] Workaround for dependency issues in OptaPlanner kie-server test

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/pom.xml
@@ -15,16 +15,19 @@
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-core</artifactId>
+      <version>${version.org.kie}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-persistence-xstream</artifactId>
+      <version>${version.org.kie}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.codehaus.jackson</groupId>
       <artifactId>jackson-core-asl</artifactId>
+      <version>${version.org.codehaus.jackson}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
@@ -7,24 +7,13 @@
   <packaging>pom</packaging>
 
   <properties>
-    <!-- The version is set during the Maven build (this file is a filtered resource) -->
+    <!-- These versions are set during the Maven build (this file is a filtered resource) -->
     <version.org.kie>${version.org.kie}</version.org.kie>
-    <drools.compiler.lnglevel>1.6</drools.compiler.lnglevel>
+    <version.org.codehaus.jackson>${version.org.codehaus.jackson}</version.org.codehaus.jackson>
 
+    <drools.compiler.lnglevel>1.6</drools.compiler.lnglevel>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.kie</groupId>
-        <artifactId>kie-platform-bom</artifactId>
-        <version>${version.org.kie}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <build>
     <pluginManagement>


### PR DESCRIPTION
Importing the kie-platform-bom somehow confuses the KIE Maven builder
as it is not able to find the droolsjbpm-integration.pom during the
test execution. Since this branch (6.4.x) is no longer being supported,
it does not make sense to invest more time into proper solution.

@ksuta could you please take a look? I know this is not ideal solution, but its IMO good enough considering this branch is no longer actively maintained (+ the tests are working on 6.5.x and master).