### PR TITLE
JBPM-5708 MapDB implementation of persistence for Drools and jBPM

### DIFF
--- a/kie-infinispan/drools-infinispan-persistence/pom.xml
+++ b/kie-infinispan/drools-infinispan-persistence/pom.xml
@@ -60,7 +60,10 @@
       <groupId>org.drools</groupId>
       <artifactId>drools-persistence-jpa</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-persistence-api</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-api</artifactId>

--- a/kie-infinispan/drools-infinispan-persistence/src/main/java/org/drools/persistence/infinispan/InfinispanPersistenceContext.java
+++ b/kie-infinispan/drools-infinispan-persistence/src/main/java/org/drools/persistence/infinispan/InfinispanPersistenceContext.java
@@ -16,9 +16,9 @@
 package org.drools.persistence.infinispan;
 
 import org.drools.persistence.PersistenceContext;
+import org.drools.persistence.PersistentSession;
+import org.drools.persistence.PersistentWorkItem;
 import org.drools.persistence.info.EntityHolder;
-import org.drools.persistence.info.SessionInfo;
-import org.drools.persistence.info.WorkItemInfo;
 import org.infinispan.Cache;
 
 public class InfinispanPersistenceContext implements PersistenceContext {
@@ -39,7 +39,7 @@ public class InfinispanPersistenceContext implements PersistenceContext {
         this.isJTA = isJTA;
     }
 
-    public SessionInfo persist(SessionInfo entity) {
+    public PersistentSession persist(PersistentSession entity) {
     	if (entity.getId() == null) {
     		entity.setId(generateSessionInfoId());
     	}
@@ -79,7 +79,7 @@ public class InfinispanPersistenceContext implements PersistenceContext {
 		return String.valueOf(id); //TODO
 	}
 
-    public SessionInfo findSessionInfo(Long id) {
+    public PersistentSession findSession(Long id) {
     	EntityHolder holder = (EntityHolder) this.cache.get( createSessionKey(id) );
     	if (holder == null) {
     		return null;
@@ -88,7 +88,7 @@ public class InfinispanPersistenceContext implements PersistenceContext {
     }
 
     @Override
-    public void remove(SessionInfo sessionInfo) {
+    public void remove(PersistentSession sessionInfo) {
         cache.remove( createSessionKey(sessionInfo.getId()) );
         cache.evict( createSessionKey(sessionInfo.getId()) );
     }
@@ -108,7 +108,7 @@ public class InfinispanPersistenceContext implements PersistenceContext {
         //cache doesn't close
     }
 
-    public WorkItemInfo persist(WorkItemInfo workItemInfo) {
+    public PersistentWorkItem persist(PersistentWorkItem workItemInfo) {
     	if (workItemInfo.getId() == null) {
     		workItemInfo.setId(generateWorkItemInfoId());
     	}
@@ -118,7 +118,7 @@ public class InfinispanPersistenceContext implements PersistenceContext {
     	return workItemInfo;
     }
 
-    public WorkItemInfo findWorkItemInfo(Long id) {
+    public PersistentWorkItem findWorkItem(Long id) {
     	EntityHolder holder = (EntityHolder) cache.get(createWorkItemKey(id));
     	if (holder == null) {
     		return null;
@@ -126,12 +126,12 @@ public class InfinispanPersistenceContext implements PersistenceContext {
     	return holder.getWorkItemInfo();
     }
 
-    public void remove(WorkItemInfo workItemInfo) {
+    public void remove(PersistentWorkItem workItemInfo) {
         cache.remove( createWorkItemKey(workItemInfo.getId()) );
         cache.evict( createWorkItemKey(workItemInfo.getId()) );
     }
 
-    public WorkItemInfo merge(WorkItemInfo workItemInfo) {
+    public PersistentWorkItem merge(PersistentWorkItem workItemInfo) {
     	String key = createWorkItemKey(workItemInfo.getId());
     	workItemInfo.transform();
     	EntityHolder entityHolder = new EntityHolder(key, workItemInfo);
@@ -143,7 +143,7 @@ public class InfinispanPersistenceContext implements PersistenceContext {
 		return cache;
 	}
 
-    public void lock(WorkItemInfo workItemInfo) {
+    public void lock(PersistentWorkItem workItemInfo) {
         // no-op: no locking implemented here
     }
 }

--- a/kie-infinispan/drools-infinispan-persistence/src/main/java/org/drools/persistence/infinispan/processinstance/InfinispanWorkItemManager.java
+++ b/kie-infinispan/drools-infinispan-persistence/src/main/java/org/drools/persistence/infinispan/processinstance/InfinispanWorkItemManager.java
@@ -15,6 +15,11 @@
 
 package org.drools.persistence.infinispan.processinstance;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
 import org.drools.core.WorkItemHandlerNotFoundException;
 import org.drools.core.common.InternalKnowledgeRuntime;
 import org.drools.core.impl.InternalKnowledgeBase;
@@ -23,17 +28,13 @@ import org.drools.core.process.instance.WorkItemManager;
 import org.drools.core.process.instance.impl.WorkItemImpl;
 import org.drools.persistence.PersistenceContext;
 import org.drools.persistence.PersistenceContextManager;
+import org.drools.persistence.PersistentWorkItem;
 import org.drools.persistence.info.WorkItemInfo;
 import org.drools.persistence.jpa.processinstance.JPAWorkItemManager;
 import org.kie.api.runtime.Environment;
 import org.kie.api.runtime.EnvironmentName;
 import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.runtime.process.WorkItemHandler;
-
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 
 public class InfinispanWorkItemManager extends JPAWorkItemManager implements WorkItemManager {
 
@@ -116,7 +117,7 @@ public class InfinispanWorkItemManager extends JPAWorkItemManager implements Wor
         PersistenceContext context = ((PersistenceContextManager) env.get( EnvironmentName.PERSISTENCE_CONTEXT_MANAGER )).getCommandScopedPersistenceContext();
 
         
-        WorkItemInfo workItemInfo = context.findWorkItemInfo( id );
+        PersistentWorkItem workItemInfo = context.findWorkItem( id );
         // work item may have been aborted
         if (workItemInfo != null) {
             WorkItemImpl workItem = (WorkItemImpl) internalGetWorkItem(workItemInfo);
@@ -141,7 +142,7 @@ public class InfinispanWorkItemManager extends JPAWorkItemManager implements Wor
         PersistenceContext context = ((PersistenceContextManager) env.get( EnvironmentName.PERSISTENCE_CONTEXT_MANAGER )).getCommandScopedPersistenceContext();
 
         
-        WorkItemInfo workItemInfo = context.findWorkItemInfo( id );
+        PersistentWorkItem workItemInfo = context.findWorkItem( id );
         
         // work item may have been aborted
         if (workItemInfo != null) {
@@ -163,7 +164,7 @@ public class InfinispanWorkItemManager extends JPAWorkItemManager implements Wor
 //        EntityManager em = (EntityManager) env.get(EnvironmentName.CMD_SCOPED_ENTITY_MANAGER);
         PersistenceContext context = ((PersistenceContextManager) env.get( EnvironmentName.PERSISTENCE_CONTEXT_MANAGER )).getCommandScopedPersistenceContext();
 
-        WorkItemInfo workItemInfo = context.findWorkItemInfo( id );
+        PersistentWorkItem workItemInfo = context.findWorkItem( id );
         
         // work item may have been aborted
         if (workItemInfo != null) {
@@ -184,10 +185,10 @@ public class InfinispanWorkItemManager extends JPAWorkItemManager implements Wor
 //        EntityManager em = (EntityManager) env.get(EnvironmentName.CMD_SCOPED_ENTITY_MANAGER);
         PersistenceContext context = ((PersistenceContextManager) env.get( EnvironmentName.PERSISTENCE_CONTEXT_MANAGER )).getCommandScopedPersistenceContext();
         
-        WorkItemInfo workItemInfo = null;
+        PersistentWorkItem workItemInfo = null;
         
         if (context != null) {
-            workItemInfo = context.findWorkItemInfo( id );
+            workItemInfo = context.findWorkItem( id );
         }
 
         if (workItemInfo == null) {
@@ -196,10 +197,10 @@ public class InfinispanWorkItemManager extends JPAWorkItemManager implements Wor
         return internalGetWorkItem(workItemInfo);
     }
 
-    private WorkItem internalGetWorkItem(WorkItemInfo workItemInfo) { 
+    private WorkItem internalGetWorkItem(PersistentWorkItem workItemInfo) { 
         Environment env = kruntime.getEnvironment();
         InternalKnowledgeBase ruleBase = (InternalKnowledgeBase) kruntime.getKieBase();
-        WorkItem workItem = workItemInfo.getWorkItem(env, ruleBase); 
+        WorkItem workItem = ((WorkItemInfo) workItemInfo).getWorkItem(env, ruleBase); 
         ((WorkItemImpl) workItem).setId(workItemInfo.getId());
         return workItem;
     }

--- a/kie-infinispan/drools-infinispan-persistence/src/main/java/org/drools/persistence/info/EntityHolder.java
+++ b/kie-infinispan/drools-infinispan-persistence/src/main/java/org/drools/persistence/info/EntityHolder.java
@@ -21,6 +21,8 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 
 import org.drools.core.process.instance.impl.WorkItemImpl;
+import org.drools.persistence.PersistentSession;
+import org.drools.persistence.PersistentWorkItem;
 import org.drools.persistence.util.Base64;
 import org.hibernate.search.annotations.DocumentId;
 import org.hibernate.search.annotations.Field;
@@ -59,22 +61,24 @@ public class EntityHolder {
 	@Field
 	private String workItemInfoByteArray;
 
-	public EntityHolder(String key, SessionInfo sessionInfo) {
+	public EntityHolder(String key, PersistentSession session) {
 		this.key = key;
 		this.type = "sessionInfo";
-		this.sessionInfoId = sessionInfo.getId();
+		this.sessionInfoId = session.getId();
+		SessionInfo sessionInfo = (SessionInfo) session;
 		this.sessionInfoVersion = sessionInfo.getVersion();
-		sessionInfo.transform();
+		session.transform();
 		this.sessionInfoData = Base64.encodeBase64String(sessionInfo.getData());
 		this.sessionInfoLastModificationDate = sessionInfo.getLastModificationDate();
 		this.sessionInfoStartDate = sessionInfo.getStartDate();
 	}
 
-	public EntityHolder(String key, WorkItemInfo workItemInfo) {
+	public EntityHolder(String key, PersistentWorkItem workItem) {
 		this.key = key;
 		this.type = "workItemInfo";
-		workItemInfo.transform();
-		this.workItemInfoId = workItemInfo.getId();
+		workItem.transform();
+		this.workItemInfoId = workItem.getId();
+		WorkItemInfo workItemInfo = (WorkItemInfo) workItem;
 		this.workItemInfoName = workItemInfo.getName();
 		this.workItemInfoVersion = workItemInfo.getVersion();
 		this.workItemInfoProcessInstanceId = workItemInfo.getProcessInstanceId();

--- a/kie-infinispan/jbpm-infinispan-persistence/pom.xml
+++ b/kie-infinispan/jbpm-infinispan-persistence/pom.xml
@@ -40,7 +40,10 @@
       <groupId>org.drools</groupId>
       <artifactId>drools-persistence-jpa</artifactId>
     </dependency>
-    
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-persistence-api</artifactId>
+    </dependency>
     <!-- jbpm -->
     <dependency>
       <groupId>org.jbpm</groupId>
@@ -49,6 +52,10 @@
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-flow</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jbpm</groupId>
+      <artifactId>jbpm-persistence-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jbpm</groupId>
@@ -101,6 +108,12 @@
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-persistence-jpa</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jbpm</groupId>
+      <artifactId>jbpm-persistence-api</artifactId>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/kie-infinispan/jbpm-infinispan-persistence/src/main/java/org/jbpm/persistence/InfinispanProcessPersistenceContext.java
+++ b/kie-infinispan/jbpm-infinispan-persistence/src/main/java/org/jbpm/persistence/InfinispanProcessPersistenceContext.java
@@ -18,6 +18,8 @@ package org.jbpm.persistence;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jbpm.persistence.PersistentCorrelationKey;
+import org.jbpm.persistence.PersistentProcessInstance;
 import org.drools.persistence.infinispan.InfinispanPersistenceContext;
 import org.infinispan.Cache;
 import org.jbpm.persistence.correlation.CorrelationKeyInfo;
@@ -41,7 +43,8 @@ public class InfinispanProcessPersistenceContext extends InfinispanPersistenceCo
         super( cache );
     }
 
-    public ProcessInstanceInfo persist(ProcessInstanceInfo processInstanceInfo) {
+    public PersistentProcessInstance persist(PersistentProcessInstance processInstance) {
+        ProcessInstanceInfo processInstanceInfo = (ProcessInstanceInfo) processInstance;
     	String id = generateProcessInstanceInfoId(processInstanceInfo);
         getCache().put( id, new ProcessEntityHolder(id, processInstanceInfo) );
         return processInstanceInfo;
@@ -56,7 +59,8 @@ public class InfinispanProcessPersistenceContext extends InfinispanPersistenceCo
 		return holder.getProcessInstanceInfo();
     }
 
-	public void remove(ProcessInstanceInfo processInstanceInfo) {
+	public void remove(PersistentProcessInstance processInstance) {
+        ProcessInstanceInfo processInstanceInfo = (ProcessInstanceInfo) processInstance;
         getCache().remove( generateProcessInstanceInfoId(processInstanceInfo) );
         getCache().evict( generateProcessInstanceInfoId(processInstanceInfo) );
         List<CorrelationKeyInfo> correlations = getCorrelationKeysByProcessInstanceId(processInstanceInfo.getId());
@@ -136,7 +140,8 @@ public class InfinispanProcessPersistenceContext extends InfinispanPersistenceCo
 		return retval;
     }
 
-    public CorrelationKeyInfo persist(CorrelationKeyInfo correlationKeyInfo) {
+    public CorrelationKeyInfo persist(PersistentCorrelationKey correlationKey) {
+        CorrelationKeyInfo correlationKeyInfo = (CorrelationKeyInfo) correlationKey;
         Long processInstanceId = getProcessInstanceByCorrelationKey(correlationKeyInfo);
         if (processInstanceId != null) {
             throw new RuntimeException(correlationKeyInfo + " already exists");

--- a/kie-infinispan/jbpm-infinispan-persistence/src/main/java/org/jbpm/persistence/processinstance/InfinispanProcessInstanceManager.java
+++ b/kie-infinispan/jbpm-infinispan-persistence/src/main/java/org/jbpm/persistence/processinstance/InfinispanProcessInstanceManager.java
@@ -124,7 +124,7 @@ public class InfinispanProcessInstanceManager
         }
 
     	// Make sure that the cmd scoped entity manager has started
-        ProcessInstanceInfo processInstanceInfo = context.findProcessInstanceInfo( id );
+        ProcessInstanceInfo processInstanceInfo = (ProcessInstanceInfo) context.findProcessInstanceInfo( id );
         if ( processInstanceInfo == null ) {
             return null;
         }
@@ -160,7 +160,7 @@ public class InfinispanProcessInstanceManager
     @Override
     public void removeProcessInstance(ProcessInstance processInstance) {
         ProcessPersistenceContext context = ((ProcessPersistenceContextManager) this.kruntime.getEnvironment().get( EnvironmentName.PERSISTENCE_CONTEXT_MANAGER )).getProcessPersistenceContext();
-        ProcessInstanceInfo processInstanceInfo = context.findProcessInstanceInfo( processInstance.getId() );
+        ProcessInstanceInfo processInstanceInfo = (ProcessInstanceInfo) context.findProcessInstanceInfo( processInstance.getId() );
         
         if ( processInstanceInfo != null ) {
             context.remove( processInstanceInfo );

--- a/kie-spring/pom.xml
+++ b/kie-spring/pom.xml
@@ -67,7 +67,19 @@
 
     <dependency>
       <groupId>org.drools</groupId>
+      <artifactId>drools-persistence-api</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.drools</groupId>
       <artifactId>drools-persistence-jpa</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jbpm</groupId>
+      <artifactId>jbpm-persistence-api</artifactId>
       <optional>true</optional>
     </dependency>
 


### PR DESCRIPTION
Implementation of MapDB persistence layer for Drools and jBPM persistence. This requires a set of modifications:
 - Creating drools-persistence-api and jbpm-persistence-api
 - SingleSessionCommandService refactors
 - PersistenceContext and ProcessPersistenceContext refactors:
 - TaskPersistenceContext refactors
 - Changes in the current persistence model interfaces
 - TimerJobFactoryManager / TimerService refactors