### PR TITLE
Split revapi configuration into filter and ignores

### DIFF
--- a/kie-server-parent/kie-server-api/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-api/src/build/revapi-config.json
@@ -1,126 +1,133 @@
 {
-  "revapi": {
-    "java": {
-      "filter": {
-        "_comment": "We don't want to check transitive classes, e.g. from OptaPlanner, since we already check them in their own module.",
-        "packages": {
-          "regex": true,
-          "include": [
-            "org\\.kie\\.server\\.api.*"
-          ]
+  "filters": {
+    "revapi": {
+      "java": {
+        "filter": {
+          "_comment": "We don't want to check transitive classes, e.g. from OptaPlanner, since we already check them in their own module.",
+          "packages": {
+            "regex": true,
+            "include": [
+              "org\\.kie\\.server\\.api.*"
+            ]
+          }
         }
       }
-    },
-    "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
-    "ignore": [
-      {
-        "code": "java.method.returnTypeChanged",
-        "old": "method org.optaplanner.core.api.domain.solution.Solution org.kie.server.api.model.instance.SolverInstance::getBestSolution()",
-        "new": "method java.lang.Object org.kie.server.api.model.instance.SolverInstance::getBestSolution()",
-        "justification": "Removed deprecated interface usage."
-      },
-      {
-        "code": "java.method.returnTypeChanged",
-        "old": "method org.optaplanner.core.api.domain.solution.Solution org.kie.server.api.model.instance.SolverInstance::getPlanningProblem()",
-        "new": "method java.lang.Object org.kie.server.api.model.instance.SolverInstance::getPlanningProblem()",
-        "justification": "Removed deprecated interface usage."
-      },
-      {
-        "code": "java.method.removed",
-        "old": "method org.optaplanner.core.api.score.Score org.kie.server.api.model.instance.SolverInstance::getScore()",
-        "justification": "Moved to org.kie.server.api.model.instance.ScoreWrapper.toScore()."
-      },
-      {
-        "code": "java.method.parameterTypeChanged",
-        "old": "parameter void org.kie.server.api.model.instance.SolverInstance::setBestSolution(===org.optaplanner.core.api.domain.solution.Solution===)",
-        "new": "parameter void org.kie.server.api.model.instance.SolverInstance::setBestSolution(===java.lang.Object===)",
-        "justification": "Removed deprecated interface usage in method parameter."
-      },
-      {
-        "code": "java.method.parameterTypeChanged",
-        "old": "parameter void org.kie.server.api.model.instance.SolverInstance::setPlanningProblem(===org.optaplanner.core.api.domain.solution.Solution===)",
-        "new": "parameter void org.kie.server.api.model.instance.SolverInstance::setPlanningProblem(===java.lang.Object===)",
-        "justification": "Removed deprecated interface usage in method parameter."
-      },
-      {
-        "code": "java.method.removed",
-        "old": "method void org.kie.server.api.model.instance.SolverInstance::setScore(org.optaplanner.core.api.score.Score)",
-        "justification": "Moved to org.kie.server.api.model.instance.SolverInstance.setScoreWrapper(org.kie.server.api.model.instance.ScoreWrapper)"
-      },
-      {
-        "code": "java.annotation.attributeValueChanged",
-        "old": "field org.kie.server.api.commands.CommandScript.commands",
-        "new": "field org.kie.server.api.commands.CommandScript.commands",
-        "justification": "Because of getReleaseId method in KieServicesClient"
-      },
-      {
-       "code": "java.annotation.added",
-       "old": "field org.kie.server.api.commands.CommandScript.commands",
-       "new": "field org.kie.server.api.commands.CommandScript.commands",
-       "annotationType": "com.fasterxml.jackson.annotation.JsonTypeInfo",
-       "elementKind": "annotation",
-       "justification": "Upgrade Jackson library to version 2"
-       },
-       {
-       "code": "java.annotation.removed",
-       "old": "field org.kie.server.api.commands.CommandScript.commands",
-       "new": "field org.kie.server.api.commands.CommandScript.commands",
-       "annotationType": "org.codehaus.jackson.annotate.JsonTypeInfo",
-       "elementKind": "annotation",
-       "justification": "Upgrade Jackson library to version 2"
-       },
-       {
-       "code": "java.field.typeChanged",
-       "old": "field org.kie.server.api.marshalling.json.JSONMarshaller.deserializeObjectMapper",
-       "new": "field org.kie.server.api.marshalling.json.JSONMarshaller.deserializeObjectMapper",
-       "oldType": "org.codehaus.jackson.map.ObjectMapper",
-       "newType": "com.fasterxml.jackson.databind.ObjectMapper",
-       "package": "org.kie.server.api.marshalling.json",
-       "classSimpleName": "JSONMarshaller",
-       "fieldName": "deserializeObjectMapper",
-       "elementKind": "field",
-       "justification": "Upgrade Jackson library to version 2"
-       },
-       {
-       "code": "java.field.typeChanged",
-       "old": "field org.kie.server.api.marshalling.json.JSONMarshaller.objectMapper",
-       "new": "field org.kie.server.api.marshalling.json.JSONMarshaller.objectMapper",
-       "oldType": "org.codehaus.jackson.map.ObjectMapper",
-       "newType": "com.fasterxml.jackson.databind.ObjectMapper",
-       "package": "org.kie.server.api.marshalling.json",
-       "classSimpleName": "JSONMarshaller",
-       "fieldName": "objectMapper",
-       "elementKind": "field",
-       "justification": "Upgrade Jackson library to version 2"
-       },
-       {
-       "code": "java.method.returnTypeTypeParametersChanged",
-       "old": "method java.util.List<org.codehaus.jackson.map.jsontype.NamedType> org.kie.server.api.marshalling.json.JSONMarshaller::prepareCustomClasses(java.util.Set<java.lang.Class<?>>)",
-       "new": "method java.util.List<com.fasterxml.jackson.databind.jsontype.NamedType> org.kie.server.api.marshalling.json.JSONMarshaller::prepareCustomClasses(java.util.Set<java.lang.Class<?>>)",
-       "oldType": "java.util.List<org.codehaus.jackson.map.jsontype.NamedType>",
-       "newType": "java.util.List<com.fasterxml.jackson.databind.jsontype.NamedType>",
-       "package": "org.kie.server.api.marshalling.json",
-       "classSimpleName": "JSONMarshaller",
-       "methodName": "prepareCustomClasses",
-       "elementKind": "method",
-       "justification": "Upgrade Jackson library to version 2"
-       },
-       {
-       "code": "java.annotation.added",
-       "old": "class org.kie.server.api.model.ReleaseId",
-       "new": "class org.kie.server.api.model.ReleaseId",
-       "annotationType": "com.fasterxml.jackson.annotation.JsonIgnoreProperties",
-       "elementKind": "annotation",
-       "justification": "Upgrade Jackson library to version 2"
-       },
-       {
-       "code": "java.annotation.removed",
-       "old": "class org.kie.server.api.model.ReleaseId",
-       "new": "class org.kie.server.api.model.ReleaseId",
-       "annotationType": "org.codehaus.jackson.annotate.JsonIgnoreProperties",
-       "elementKind": "annotation",
-       "justification": "Upgrade Jackson library to version 2"
-       }
-    ]
+    }
+  },
+
+  "ignores": {
+    "revapi": {
+      "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
+      "ignore": [
+        {
+          "code": "java.method.returnTypeChanged",
+          "old": "method org.optaplanner.core.api.domain.solution.Solution org.kie.server.api.model.instance.SolverInstance::getBestSolution()",
+          "new": "method java.lang.Object org.kie.server.api.model.instance.SolverInstance::getBestSolution()",
+          "justification": "Removed deprecated interface usage."
+        },
+        {
+          "code": "java.method.returnTypeChanged",
+          "old": "method org.optaplanner.core.api.domain.solution.Solution org.kie.server.api.model.instance.SolverInstance::getPlanningProblem()",
+          "new": "method java.lang.Object org.kie.server.api.model.instance.SolverInstance::getPlanningProblem()",
+          "justification": "Removed deprecated interface usage."
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method org.optaplanner.core.api.score.Score org.kie.server.api.model.instance.SolverInstance::getScore()",
+          "justification": "Moved to org.kie.server.api.model.instance.ScoreWrapper.toScore()."
+        },
+        {
+          "code": "java.method.parameterTypeChanged",
+          "old": "parameter void org.kie.server.api.model.instance.SolverInstance::setBestSolution(===org.optaplanner.core.api.domain.solution.Solution===)",
+          "new": "parameter void org.kie.server.api.model.instance.SolverInstance::setBestSolution(===java.lang.Object===)",
+          "justification": "Removed deprecated interface usage in method parameter."
+        },
+        {
+          "code": "java.method.parameterTypeChanged",
+          "old": "parameter void org.kie.server.api.model.instance.SolverInstance::setPlanningProblem(===org.optaplanner.core.api.domain.solution.Solution===)",
+          "new": "parameter void org.kie.server.api.model.instance.SolverInstance::setPlanningProblem(===java.lang.Object===)",
+          "justification": "Removed deprecated interface usage in method parameter."
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method void org.kie.server.api.model.instance.SolverInstance::setScore(org.optaplanner.core.api.score.Score)",
+          "justification": "Moved to org.kie.server.api.model.instance.SolverInstance.setScoreWrapper(org.kie.server.api.model.instance.ScoreWrapper)"
+        },
+        {
+          "code": "java.annotation.attributeValueChanged",
+          "old": "field org.kie.server.api.commands.CommandScript.commands",
+          "new": "field org.kie.server.api.commands.CommandScript.commands",
+          "justification": "Because of getReleaseId method in KieServicesClient"
+        },
+        {
+          "code": "java.annotation.added",
+          "old": "field org.kie.server.api.commands.CommandScript.commands",
+          "new": "field org.kie.server.api.commands.CommandScript.commands",
+          "annotationType": "com.fasterxml.jackson.annotation.JsonTypeInfo",
+          "elementKind": "annotation",
+          "justification": "Upgrade Jackson library to version 2"
+        },
+        {
+          "code": "java.annotation.removed",
+          "old": "field org.kie.server.api.commands.CommandScript.commands",
+          "new": "field org.kie.server.api.commands.CommandScript.commands",
+          "annotationType": "org.codehaus.jackson.annotate.JsonTypeInfo",
+          "elementKind": "annotation",
+          "justification": "Upgrade Jackson library to version 2"
+        },
+        {
+          "code": "java.field.typeChanged",
+          "old": "field org.kie.server.api.marshalling.json.JSONMarshaller.deserializeObjectMapper",
+          "new": "field org.kie.server.api.marshalling.json.JSONMarshaller.deserializeObjectMapper",
+          "oldType": "org.codehaus.jackson.map.ObjectMapper",
+          "newType": "com.fasterxml.jackson.databind.ObjectMapper",
+          "package": "org.kie.server.api.marshalling.json",
+          "classSimpleName": "JSONMarshaller",
+          "fieldName": "deserializeObjectMapper",
+          "elementKind": "field",
+          "justification": "Upgrade Jackson library to version 2"
+        },
+        {
+          "code": "java.field.typeChanged",
+          "old": "field org.kie.server.api.marshalling.json.JSONMarshaller.objectMapper",
+          "new": "field org.kie.server.api.marshalling.json.JSONMarshaller.objectMapper",
+          "oldType": "org.codehaus.jackson.map.ObjectMapper",
+          "newType": "com.fasterxml.jackson.databind.ObjectMapper",
+          "package": "org.kie.server.api.marshalling.json",
+          "classSimpleName": "JSONMarshaller",
+          "fieldName": "objectMapper",
+          "elementKind": "field",
+          "justification": "Upgrade Jackson library to version 2"
+        },
+        {
+          "code": "java.method.returnTypeTypeParametersChanged",
+          "old": "method java.util.List<org.codehaus.jackson.map.jsontype.NamedType> org.kie.server.api.marshalling.json.JSONMarshaller::prepareCustomClasses(java.util.Set<java.lang.Class<?>>)",
+          "new": "method java.util.List<com.fasterxml.jackson.databind.jsontype.NamedType> org.kie.server.api.marshalling.json.JSONMarshaller::prepareCustomClasses(java.util.Set<java.lang.Class<?>>)",
+          "oldType": "java.util.List<org.codehaus.jackson.map.jsontype.NamedType>",
+          "newType": "java.util.List<com.fasterxml.jackson.databind.jsontype.NamedType>",
+          "package": "org.kie.server.api.marshalling.json",
+          "classSimpleName": "JSONMarshaller",
+          "methodName": "prepareCustomClasses",
+          "elementKind": "method",
+          "justification": "Upgrade Jackson library to version 2"
+        },
+        {
+          "code": "java.annotation.added",
+          "old": "class org.kie.server.api.model.ReleaseId",
+          "new": "class org.kie.server.api.model.ReleaseId",
+          "annotationType": "com.fasterxml.jackson.annotation.JsonIgnoreProperties",
+          "elementKind": "annotation",
+          "justification": "Upgrade Jackson library to version 2"
+        },
+        {
+          "code": "java.annotation.removed",
+          "old": "class org.kie.server.api.model.ReleaseId",
+          "new": "class org.kie.server.api.model.ReleaseId",
+          "annotationType": "org.codehaus.jackson.annotate.JsonIgnoreProperties",
+          "elementKind": "annotation",
+          "justification": "Upgrade Jackson library to version 2"
+        }
+      ]
+    }
   }
 }

--- a/kie-server-parent/kie-server-controller/kie-server-controller-api/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-api/src/build/revapi-config.json
@@ -1,38 +1,45 @@
 {
-  "revapi": {
-    "java": {
-      "filter": {
-        "_comment": "We don't want to check transitive classes, e.g. from kie-server-api, since we already check them in their own module.",
-        "packages": {
-          "regex": true,
-          "include": [
-            "org\\.kie\\.server\\.controller\\.api.*"
-          ]
+  "filters": {
+    "revapi": {
+      "java": {
+        "filter": {
+          "_comment": "We don't want to check transitive classes, e.g. from kie-server-api, since we already check them in their own module.",
+          "packages": {
+            "regex": true,
+            "include": [
+              "org\\.kie\\.server\\.controller\\.api.*"
+            ]
+          }
         }
       }
-    },
-    "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
-    "ignore": [
-      {
-        "code": "java.class.removed",
-        "old": "interface org.kie.server.controller.api.KieServerControllerAdmin",
-        "justification": "Removed deprecated class"
-      },
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method void org.kie.server.controller.api.service.NotificationService::notify(org.kie.server.controller.api.model.events.ServerInstanceConnected)",
-        "justification": "Allow fine grained notification"
-      },
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method void org.kie.server.controller.api.service.NotificationService::notify(org.kie.server.controller.api.model.events.ServerInstanceDisconnected)",
-        "justification": "Allow fine grained notification"
-      },
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method void org.kie.server.controller.api.service.SpecManagementService::updateContainerSpec(java.lang.String, org.kie.server.controller.api.model.spec.ContainerSpec)",
-        "justification": "Allow to update existing container specification"
-      }
-    ]
+    }
+  },
+
+  "ignores": {
+    "revapi": {
+      "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
+      "ignore": [
+        {
+          "code": "java.class.removed",
+          "old": "interface org.kie.server.controller.api.KieServerControllerAdmin",
+          "justification": "Removed deprecated class"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method void org.kie.server.controller.api.service.NotificationService::notify(org.kie.server.controller.api.model.events.ServerInstanceConnected)",
+          "justification": "Allow fine grained notification"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method void org.kie.server.controller.api.service.NotificationService::notify(org.kie.server.controller.api.model.events.ServerInstanceDisconnected)",
+          "justification": "Allow fine grained notification"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method void org.kie.server.controller.api.service.SpecManagementService::updateContainerSpec(java.lang.String, org.kie.server.controller.api.model.spec.ContainerSpec)",
+          "justification": "Allow to update existing container specification"
+        }
+      ]
+    }
   }
 }

--- a/kie-server-parent/kie-server-controller/kie-server-controller-rest/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-rest/src/build/revapi-config.json
@@ -1,30 +1,37 @@
 {
-  "revapi": {
-    "java": {
-      "_comment": "Only classes with javax.ws.rs annotations are included since we want to check only REST API.",
-      "filter": {
-        "_comment": "We don't want to check transitive classes, e.g. from package org.kie.server.controller.api, since we already check them in their own module.",
-        "packages": {
-          "regex": false,
-          "include": [
-            "org.kie.server.controller.rest"
-          ]
-        },
-        "classes": {
-          "regex": false,
-          "exclude": [
-            "org.kie.server.controller.rest.ControllerUtils"
-          ]
+  "filters": {
+    "revapi": {
+      "java": {
+        "_comment": "Only classes with javax.ws.rs annotations are included since we want to check only REST API.",
+        "filter": {
+          "_comment": "We don't want to check transitive classes, e.g. from package org.kie.server.controller.api, since we already check them in their own module.",
+          "packages": {
+            "regex": false,
+            "include": [
+              "org.kie.server.controller.rest"
+            ]
+          },
+          "classes": {
+            "regex": false,
+            "exclude": [
+              "org.kie.server.controller.rest.ControllerUtils"
+            ]
+          }
         }
       }
-    },
-    "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
-    "ignore": [
-      {
-        "code": "java.class.removed",
-        "old": "class org.kie.server.controller.rest.RestKieServerControllerAdminImpl",
-        "justification": "Removed deprecated class"
-      }
-    ]
+    }
+  },
+
+  "ignores": {
+    "revapi": {
+      "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
+      "ignore": [
+        {
+          "code": "java.class.removed",
+          "old": "class org.kie.server.controller.rest.RestKieServerControllerAdminImpl",
+          "justification": "Removed deprecated class"
+        }
+      ]
+    }
   }
 }

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/build/revapi-config.json
@@ -1,228 +1,234 @@
 {
-  "revapi": {
-    "java": {
-      "_comment": "We don't want to check classes, just interfaces. Every class is therefore excluded so new interfaces and classes in future are discovered by revapi.",
-      "filter": {
-        "packages": {
-          "_comment": [
-            "We don't want to check transitive classes, e.g. from kie-server-api, since we already check them in their own module.",
-            "Therefore, only module's packages are included. Excluded packages contain only classes."
-          ],
-          "regex": true,
-          "include": [
-            "org\\.kie\\.server\\.client.*"
-          ],
-          "exclude": [
-            "org\\.kie\\.server\\.client\\.admin\\.impl",
-            "org\\.kie\\.server\\.client\\.balancer\\.impl",
-            "org\\.kie\\.server\\.client\\.credentials",
-            "org\\.kie\\.server\\.client\\.impl"
-          ]
-        },
-        "classes": {
-          "_comment": "In the remaining packages which are mixed (both interfaces and classes), we just exclude classes.",
-          "regex": false,
-          "exclude": [
-            "org.kie.server.client.balancer.LoadBalancer",
-            "org.kie.server.client.helper.CaseServicesClientBuilder",
-            "org.kie.server.client.helper.DroolsServicesClientBuilder",
-            "org.kie.server.client.helper.JBPMServicesClientBuilder",
-            "org.kie.server.client.helper.JBPMUIServicesClientBuilder",
-            "org.kie.server.client.helper.OptaplannerServicesClientBuilder",
-            "org.kie.server.client.KieServicesException",
-            "org.kie.server.client.KieServicesFactory"
-          ]
+  "filters": {
+    "revapi": {
+      "java": {
+        "_comment": "We don't want to check classes, just interfaces. Every class is therefore excluded so new interfaces and classes in future are discovered by revapi.",
+        "filter": {
+          "packages": {
+            "_comment": [
+              "We don't want to check transitive classes, e.g. from kie-server-api, since we already check them in their own module.",
+              "Therefore, only module's packages are included. Excluded packages contain only classes."
+            ],
+            "regex": true,
+            "include": [
+              "org\\.kie\\.server\\.client.*"
+            ],
+            "exclude": [
+              "org\\.kie\\.server\\.client\\.admin\\.impl",
+              "org\\.kie\\.server\\.client\\.balancer\\.impl",
+              "org\\.kie\\.server\\.client\\.credentials",
+              "org\\.kie\\.server\\.client\\.impl"
+            ]
+          },
+          "classes": {
+            "_comment": "In the remaining packages which are mixed (both interfaces and classes), we just exclude classes.",
+            "regex": false,
+            "exclude": [
+              "org.kie.server.client.balancer.LoadBalancer",
+              "org.kie.server.client.helper.CaseServicesClientBuilder",
+              "org.kie.server.client.helper.DroolsServicesClientBuilder",
+              "org.kie.server.client.helper.JBPMServicesClientBuilder",
+              "org.kie.server.client.helper.JBPMUIServicesClientBuilder",
+              "org.kie.server.client.helper.OptaplannerServicesClientBuilder",
+              "org.kie.server.client.KieServicesException",
+              "org.kie.server.client.KieServicesFactory"
+            ]
+          }
         }
       }
-    },
-    "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
-    "ignore": [
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method org.kie.server.client.balancer.LoadBalancer org.kie.server.client.KieServicesConfiguration::getLoadBalancer()",
-        "justification": "Added to support Kie Server Client load balancing"
-      },
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method void org.kie.server.client.KieServicesConfiguration::setLoadBalancer(org.kie.server.client.balancer.LoadBalancer)",
-        "justification": "Added to support Kie Server Client load balancing"
-      },
+    }
+  },
 
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method java.lang.String org.kie.server.client.UIServicesClient::getProcessFormByType(java.lang.String, java.lang.String, java.lang.String)",
-        "justification": "Support multiple formats of forms"
-      },
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method java.lang.String org.kie.server.client.UIServicesClient::getProcessFormByType(java.lang.String, java.lang.String, java.lang.String, java.lang.String)",
-        "justification": "Support multiple formats of forms"
-      },
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method java.lang.String org.kie.server.client.UIServicesClient::getProcessRawForm(java.lang.String, java.lang.String)",
-        "justification": "Support multiple formats of forms"
-      },
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method java.lang.String org.kie.server.client.UIServicesClient::getTaskFormByType(java.lang.String, java.lang.Long, java.lang.String)",
-        "justification": "Support multiple formats of forms"
-      },
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method java.lang.String org.kie.server.client.UIServicesClient::getTaskFormByType(java.lang.String, java.lang.Long, java.lang.String, java.lang.String)",
-        "justification": "Support multiple formats of forms"
-      },
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method java.lang.String org.kie.server.client.UIServicesClient::getTaskRawForm(java.lang.String, java.lang.Long)",
-        "justification": "Support multiple formats of forms"
-      },
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method org.kie.server.api.model.ServiceResponse<org.kie.server.api.model.ReleaseId> org.kie.server.client.KieServicesClient::getReleaseId(java.lang.String)",
-        "justification": "JBPM-5504: Missing getReleaseId method in KieServicesClient"
-      },
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method java.util.List<org.kie.server.api.model.instance.TaskSummary> org.kie.server.client.UserTaskServicesClient::findTasksAssignedAsPotentialOwner(java.lang.String, java.lang.String, java.util.List<java.lang.String>, java.lang.Integer, java.lang.Integer)",
-        "justification": "JBPM-4646 - Case management - filter by task name"
-      },
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method java.util.List<org.kie.server.api.model.instance.TaskSummary> org.kie.server.client.UserTaskServicesClient::findTasksAssignedAsPotentialOwner(java.lang.String, java.lang.String, java.util.List<java.lang.String>, java.lang.Integer, java.lang.Integer, java.lang.String, boolean)",
-        "justification": "JBPM-4646 - Case management - filter by task name"
-      },
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method void org.kie.server.client.admin.ProcessAdminServicesClient::cancelNodeInstance(java.lang.String, java.lang.Long, java.lang.Long)",
-        "justification": "JBPM-5370 - Administration service for processes and tasks - services api and kie server"
-      },
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method java.util.List<org.kie.server.api.model.instance.NodeInstance> org.kie.server.client.admin.ProcessAdminServicesClient::getActiveNodeInstances(java.lang.String, java.lang.Long)",
-        "justification": "JBPM-5370 - Administration service for processes and tasks - services api and kie server"
-      },
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method java.util.List<org.kie.server.api.model.admin.ProcessNode> org.kie.server.client.admin.ProcessAdminServicesClient::getProcessNodes(java.lang.String, java.lang.Long)",
-        "justification": "JBPM-5370 - Administration service for processes and tasks - services api and kie server"
-      },
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method java.util.List<org.kie.server.api.model.admin.TimerInstance> org.kie.server.client.admin.ProcessAdminServicesClient::getTimerInstances(java.lang.String, java.lang.Long)",
-        "justification": "JBPM-5370 - Administration service for processes and tasks - services api and kie server"
-      },
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method void org.kie.server.client.admin.ProcessAdminServicesClient::retriggerNodeInstance(java.lang.String, java.lang.Long, java.lang.Long)",
-        "justification": "JBPM-5370 - Administration service for processes and tasks - services api and kie server"
-      },
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method void org.kie.server.client.admin.ProcessAdminServicesClient::triggerNode(java.lang.String, java.lang.Long, java.lang.Long)",
-        "justification": "JBPM-5370 - Administration service for processes and tasks - services api and kie server"
-      },
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method void org.kie.server.client.admin.ProcessAdminServicesClient::updateTimer(java.lang.String, java.lang.Long, long, long, long, int)",
-        "justification": "JBPM-5370 - Administration service for processes and tasks - services api and kie server"
-      },
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method void org.kie.server.client.admin.ProcessAdminServicesClient::updateTimerRelative(java.lang.String, java.lang.Long, long, long, long, int)",
-        "justification": "JBPM-5370 - Administration service for processes and tasks - services api and kie server"
-      },
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method java.util.List<org.kie.server.api.model.instance.NodeInstance> org.kie.server.client.ProcessServicesClient::findActiveNodeInstances(java.lang.String, java.lang.Long, java.lang.Integer, java.lang.Integer)",
-        "package": "org.kie.server.client",
-        "classSimpleName": "ProcessServicesClient",
-        "methodName": "findActiveNodeInstances",
-        "elementKind": "method",
-        "justification": "Allow to find active nodes of a process via container id"
-      },
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method java.util.List<org.kie.server.api.model.instance.NodeInstance> org.kie.server.client.ProcessServicesClient::findCompletedNodeInstances(java.lang.String, java.lang.Long, java.lang.Integer, java.lang.Integer)",
-        "package": "org.kie.server.client",
-        "classSimpleName": "ProcessServicesClient",
-        "methodName": "findCompletedNodeInstances",
-        "elementKind": "method",
-        "justification": "Allow to find completed nodes of a process via container id"
-      },
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method java.util.List<org.kie.server.api.model.instance.NodeInstance> org.kie.server.client.ProcessServicesClient::findNodeInstances(java.lang.String, java.lang.Long, java.lang.Integer, java.lang.Integer)",
-        "package": "org.kie.server.client",
-        "classSimpleName": "ProcessServicesClient",
-        "methodName": "findNodeInstances",
-        "elementKind": "method",
-        "justification": "Allow to find nodes of a process via container id"
-      },
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method java.util.List<org.kie.server.api.model.instance.VariableInstance> org.kie.server.client.ProcessServicesClient::findVariableHistory(java.lang.String, java.lang.Long, java.lang.String, java.lang.Integer, java.lang.Integer)",
-        "package": "org.kie.server.client",
-        "classSimpleName": "ProcessServicesClient",
-        "methodName": "findVariableHistory",
-        "elementKind": "method",
-        "justification": "Allow to find process variable history via container id"
-      },
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method java.util.List<org.kie.server.api.model.instance.VariableInstance> org.kie.server.client.ProcessServicesClient::findVariablesCurrentState(java.lang.String, java.lang.Long)",
-        "package": "org.kie.server.client",
-        "classSimpleName": "ProcessServicesClient",
-        "methodName": "findVariablesCurrentState",
-        "elementKind": "method",
-        "justification": "Allow to find process variable current state via container id"
-      },
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method java.util.List<org.kie.server.api.model.instance.TaskEventInstance> org.kie.server.client.UserTaskServicesClient::findTaskEvents(java.lang.String, java.lang.Long, java.lang.Integer, java.lang.Integer)",
-        "package": "org.kie.server.client",
-        "classSimpleName": "UserTaskServicesClient",
-        "methodName": "findTaskEvents",
-        "elementKind": "method",
-        "justification": "Allow to find tasks events via container id"
-      },
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method java.util.List<org.kie.server.api.model.instance.TaskEventInstance> org.kie.server.client.UserTaskServicesClient::findTaskEvents(java.lang.String, java.lang.Long, java.lang.Integer, java.lang.Integer, java.lang.String, boolean)",
-        "package": "org.kie.server.client",
-        "classSimpleName": "UserTaskServicesClient",
-        "methodName": "findTaskEvents",
-        "elementKind": "method",
-        "justification": "Allow to find tasks events via container id with sorting"
-      },
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method java.util.List<org.kie.server.api.model.instance.ProcessInstance> org.kie.server.client.ProcessServicesClient::findProcessInstancesByParent(java.lang.String, java.lang.Long, java.lang.Integer, java.lang.Integer)",
-        "package": "org.kie.server.client",
-        "classSimpleName": "ProcessServicesClient",
-        "methodName": "findProcessInstancesByParent",
-        "elementKind": "method",
-        "justification": "support for finding process instance by their parent process instance"
-      },
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method java.util.List<org.kie.server.api.model.instance.ProcessInstance> org.kie.server.client.ProcessServicesClient::findProcessInstancesByParent(java.lang.String, java.lang.Long, java.util.List<java.lang.Integer>, java.lang.Integer, java.lang.Integer)",
-        "package": "org.kie.server.client",
-        "classSimpleName": "ProcessServicesClient",
-        "methodName": "findProcessInstancesByParent",
-        "elementKind": "method",
-        "justification": "support for finding process instance by their parent process instance"
-      },
-      {
-        "code": "java.method.addedToInterface",
-        "new": "method java.util.List<org.kie.server.api.model.instance.ProcessInstance> org.kie.server.client.ProcessServicesClient::findProcessInstancesByParent(java.lang.String, java.lang.Long, java.util.List<java.lang.Integer>, java.lang.Integer, java.lang.Integer, java.lang.String, boolean)",
-        "package": "org.kie.server.client",
-        "classSimpleName": "ProcessServicesClient",
-        "methodName": "findProcessInstancesByParent",
-        "elementKind": "method",
-        "justification": "support for finding process instance by their parent process instance"
-      }
-    ]
+  "ignores": {
+    "revapi": {
+      "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
+      "ignore": [
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method org.kie.server.client.balancer.LoadBalancer org.kie.server.client.KieServicesConfiguration::getLoadBalancer()",
+          "justification": "Added to support Kie Server Client load balancing"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method void org.kie.server.client.KieServicesConfiguration::setLoadBalancer(org.kie.server.client.balancer.LoadBalancer)",
+          "justification": "Added to support Kie Server Client load balancing"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method java.lang.String org.kie.server.client.UIServicesClient::getProcessFormByType(java.lang.String, java.lang.String, java.lang.String)",
+          "justification": "Support multiple formats of forms"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method java.lang.String org.kie.server.client.UIServicesClient::getProcessFormByType(java.lang.String, java.lang.String, java.lang.String, java.lang.String)",
+          "justification": "Support multiple formats of forms"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method java.lang.String org.kie.server.client.UIServicesClient::getProcessRawForm(java.lang.String, java.lang.String)",
+          "justification": "Support multiple formats of forms"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method java.lang.String org.kie.server.client.UIServicesClient::getTaskFormByType(java.lang.String, java.lang.Long, java.lang.String)",
+          "justification": "Support multiple formats of forms"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method java.lang.String org.kie.server.client.UIServicesClient::getTaskFormByType(java.lang.String, java.lang.Long, java.lang.String, java.lang.String)",
+          "justification": "Support multiple formats of forms"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method java.lang.String org.kie.server.client.UIServicesClient::getTaskRawForm(java.lang.String, java.lang.Long)",
+          "justification": "Support multiple formats of forms"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method org.kie.server.api.model.ServiceResponse<org.kie.server.api.model.ReleaseId> org.kie.server.client.KieServicesClient::getReleaseId(java.lang.String)",
+          "justification": "JBPM-5504: Missing getReleaseId method in KieServicesClient"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method java.util.List<org.kie.server.api.model.instance.TaskSummary> org.kie.server.client.UserTaskServicesClient::findTasksAssignedAsPotentialOwner(java.lang.String, java.lang.String, java.util.List<java.lang.String>, java.lang.Integer, java.lang.Integer)",
+          "justification": "JBPM-4646 - Case management - filter by task name"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method java.util.List<org.kie.server.api.model.instance.TaskSummary> org.kie.server.client.UserTaskServicesClient::findTasksAssignedAsPotentialOwner(java.lang.String, java.lang.String, java.util.List<java.lang.String>, java.lang.Integer, java.lang.Integer, java.lang.String, boolean)",
+          "justification": "JBPM-4646 - Case management - filter by task name"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method void org.kie.server.client.admin.ProcessAdminServicesClient::cancelNodeInstance(java.lang.String, java.lang.Long, java.lang.Long)",
+          "justification": "JBPM-5370 - Administration service for processes and tasks - services api and kie server"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method java.util.List<org.kie.server.api.model.instance.NodeInstance> org.kie.server.client.admin.ProcessAdminServicesClient::getActiveNodeInstances(java.lang.String, java.lang.Long)",
+          "justification": "JBPM-5370 - Administration service for processes and tasks - services api and kie server"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method java.util.List<org.kie.server.api.model.admin.ProcessNode> org.kie.server.client.admin.ProcessAdminServicesClient::getProcessNodes(java.lang.String, java.lang.Long)",
+          "justification": "JBPM-5370 - Administration service for processes and tasks - services api and kie server"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method java.util.List<org.kie.server.api.model.admin.TimerInstance> org.kie.server.client.admin.ProcessAdminServicesClient::getTimerInstances(java.lang.String, java.lang.Long)",
+          "justification": "JBPM-5370 - Administration service for processes and tasks - services api and kie server"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method void org.kie.server.client.admin.ProcessAdminServicesClient::retriggerNodeInstance(java.lang.String, java.lang.Long, java.lang.Long)",
+          "justification": "JBPM-5370 - Administration service for processes and tasks - services api and kie server"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method void org.kie.server.client.admin.ProcessAdminServicesClient::triggerNode(java.lang.String, java.lang.Long, java.lang.Long)",
+          "justification": "JBPM-5370 - Administration service for processes and tasks - services api and kie server"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method void org.kie.server.client.admin.ProcessAdminServicesClient::updateTimer(java.lang.String, java.lang.Long, long, long, long, int)",
+          "justification": "JBPM-5370 - Administration service for processes and tasks - services api and kie server"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method void org.kie.server.client.admin.ProcessAdminServicesClient::updateTimerRelative(java.lang.String, java.lang.Long, long, long, long, int)",
+          "justification": "JBPM-5370 - Administration service for processes and tasks - services api and kie server"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method java.util.List<org.kie.server.api.model.instance.NodeInstance> org.kie.server.client.ProcessServicesClient::findActiveNodeInstances(java.lang.String, java.lang.Long, java.lang.Integer, java.lang.Integer)",
+          "package": "org.kie.server.client",
+          "classSimpleName": "ProcessServicesClient",
+          "methodName": "findActiveNodeInstances",
+          "elementKind": "method",
+          "justification": "Allow to find active nodes of a process via container id"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method java.util.List<org.kie.server.api.model.instance.NodeInstance> org.kie.server.client.ProcessServicesClient::findCompletedNodeInstances(java.lang.String, java.lang.Long, java.lang.Integer, java.lang.Integer)",
+          "package": "org.kie.server.client",
+          "classSimpleName": "ProcessServicesClient",
+          "methodName": "findCompletedNodeInstances",
+          "elementKind": "method",
+          "justification": "Allow to find completed nodes of a process via container id"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method java.util.List<org.kie.server.api.model.instance.NodeInstance> org.kie.server.client.ProcessServicesClient::findNodeInstances(java.lang.String, java.lang.Long, java.lang.Integer, java.lang.Integer)",
+          "package": "org.kie.server.client",
+          "classSimpleName": "ProcessServicesClient",
+          "methodName": "findNodeInstances",
+          "elementKind": "method",
+          "justification": "Allow to find nodes of a process via container id"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method java.util.List<org.kie.server.api.model.instance.VariableInstance> org.kie.server.client.ProcessServicesClient::findVariableHistory(java.lang.String, java.lang.Long, java.lang.String, java.lang.Integer, java.lang.Integer)",
+          "package": "org.kie.server.client",
+          "classSimpleName": "ProcessServicesClient",
+          "methodName": "findVariableHistory",
+          "elementKind": "method",
+          "justification": "Allow to find process variable history via container id"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method java.util.List<org.kie.server.api.model.instance.VariableInstance> org.kie.server.client.ProcessServicesClient::findVariablesCurrentState(java.lang.String, java.lang.Long)",
+          "package": "org.kie.server.client",
+          "classSimpleName": "ProcessServicesClient",
+          "methodName": "findVariablesCurrentState",
+          "elementKind": "method",
+          "justification": "Allow to find process variable current state via container id"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method java.util.List<org.kie.server.api.model.instance.TaskEventInstance> org.kie.server.client.UserTaskServicesClient::findTaskEvents(java.lang.String, java.lang.Long, java.lang.Integer, java.lang.Integer)",
+          "package": "org.kie.server.client",
+          "classSimpleName": "UserTaskServicesClient",
+          "methodName": "findTaskEvents",
+          "elementKind": "method",
+          "justification": "Allow to find tasks events via container id"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method java.util.List<org.kie.server.api.model.instance.TaskEventInstance> org.kie.server.client.UserTaskServicesClient::findTaskEvents(java.lang.String, java.lang.Long, java.lang.Integer, java.lang.Integer, java.lang.String, boolean)",
+          "package": "org.kie.server.client",
+          "classSimpleName": "UserTaskServicesClient",
+          "methodName": "findTaskEvents",
+          "elementKind": "method",
+          "justification": "Allow to find tasks events via container id with sorting"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method java.util.List<org.kie.server.api.model.instance.ProcessInstance> org.kie.server.client.ProcessServicesClient::findProcessInstancesByParent(java.lang.String, java.lang.Long, java.lang.Integer, java.lang.Integer)",
+          "package": "org.kie.server.client",
+          "classSimpleName": "ProcessServicesClient",
+          "methodName": "findProcessInstancesByParent",
+          "elementKind": "method",
+          "justification": "support for finding process instance by their parent process instance"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method java.util.List<org.kie.server.api.model.instance.ProcessInstance> org.kie.server.client.ProcessServicesClient::findProcessInstancesByParent(java.lang.String, java.lang.Long, java.util.List<java.lang.Integer>, java.lang.Integer, java.lang.Integer)",
+          "package": "org.kie.server.client",
+          "classSimpleName": "ProcessServicesClient",
+          "methodName": "findProcessInstancesByParent",
+          "elementKind": "method",
+          "justification": "support for finding process instance by their parent process instance"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method java.util.List<org.kie.server.api.model.instance.ProcessInstance> org.kie.server.client.ProcessServicesClient::findProcessInstancesByParent(java.lang.String, java.lang.Long, java.util.List<java.lang.Integer>, java.lang.Integer, java.lang.Integer, java.lang.String, boolean)",
+          "package": "org.kie.server.client",
+          "classSimpleName": "ProcessServicesClient",
+          "methodName": "findProcessInstancesByParent",
+          "elementKind": "method",
+          "justification": "support for finding process instance by their parent process instance"
+        }
+      ]
+    }
   }
 }

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-case-mgmt/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-case-mgmt/src/build/revapi-config.json
@@ -1,21 +1,28 @@
 {
-  "revapi": {
-    "java": {
-      "_comment": "Only classes with javax.ws.rs annotations are included since we want to check only REST API.",
-      "filter": {
-        "_comment": "Classes are excluded, not included, so new classes in future are discovered by revapi.",
-        "classes": {
-          "regex": false,
-          "exclude": [
-            "org.kie.server.remote.rest.casemgmt.AbstractCaseResource",
-            "org.kie.server.remote.rest.casemgmt.CaseOperation",
-            "org.kie.server.remote.rest.casemgmt.CaseRestApplicationComponentsService",
-            "org.kie.server.remote.rest.casemgmt.Messages"
-          ]
+  "filters": {
+    "revapi": {
+      "java": {
+        "_comment": "Only classes with javax.ws.rs annotations are included since we want to check only REST API.",
+        "filter": {
+          "_comment": "Classes are excluded, not included, so new classes in future are discovered by revapi.",
+          "classes": {
+            "regex": false,
+            "exclude": [
+              "org.kie.server.remote.rest.casemgmt.AbstractCaseResource",
+              "org.kie.server.remote.rest.casemgmt.CaseOperation",
+              "org.kie.server.remote.rest.casemgmt.CaseRestApplicationComponentsService",
+              "org.kie.server.remote.rest.casemgmt.Messages"
+            ]
+          }
         }
       }
-    },
-    "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
-    "ignore": []
+    }
+  },
+
+  "ignores": {
+    "revapi": {
+      "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
+      "ignore": []
+    }
   }
 }

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/build/revapi-config.json
@@ -1,30 +1,37 @@
 {
-  "revapi": {
-    "java": {
-      "_comment": "Only classes with javax.ws.rs annotations are included since we want to check only REST API.",
-      "filter": {
-        "packages": {
-          "regex": true,
-          "comment": "We don't want to check transitive classes, e.g. from kie-server-api, since we already check them in their own module.",
-          "include": [
-            "org\\.kie\\.server\\.remote\\.rest\\.common.*"
-          ],
-          "exclude": [
-            "org\\.kie\\.server\\.remote\\.rest\\.common\\.util"
-          ]
-        },
-        "_comment": "Classes are excluded, not included, so new classes in future are discovered by revapi.",
-        "classes": {
-          "regex": false,
-          "exclude": [
-            "org.kie.server.remote.rest.common.Header",
-            "org.kie.server.remote.rest.common.KieServerApplication",
-            "org.kie.server.remote.rest.common.KieServerRestApplicationComponentService"
-          ]
+  "filters": {
+    "revapi": {
+      "java": {
+        "_comment": "Only classes with javax.ws.rs annotations are included since we want to check only REST API.",
+        "filter": {
+          "packages": {
+            "regex": true,
+            "comment": "We don't want to check transitive classes, e.g. from kie-server-api, since we already check them in their own module.",
+            "include": [
+              "org\\.kie\\.server\\.remote\\.rest\\.common.*"
+            ],
+            "exclude": [
+              "org\\.kie\\.server\\.remote\\.rest\\.common\\.util"
+            ]
+          },
+          "_comment": "Classes are excluded, not included, so new classes in future are discovered by revapi.",
+          "classes": {
+            "regex": false,
+            "exclude": [
+              "org.kie.server.remote.rest.common.Header",
+              "org.kie.server.remote.rest.common.KieServerApplication",
+              "org.kie.server.remote.rest.common.KieServerRestApplicationComponentService"
+            ]
+          }
         }
       }
-    },
-    "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
-    "ignore": []
+    }
+  },
+
+  "ignores": {
+    "revapi": {
+      "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
+      "ignore": []
+    }
   }
 }

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-drools/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-drools/src/build/revapi-config.json
@@ -1,25 +1,32 @@
 {
-  "revapi": {
-    "java": {
-      "_comment": "Only classes with javax.ws.rs annotations are included since we want to check only REST API.",
-      "filter": {
-        "packages": {
-          "comment": "We don't want to check transitive classes, e.g. from kie-server-api, since we already check them in their own module.",
-          "regex": true,
-          "include": [
-            "org\\.kie\\.server\\.remote\\.rest\\.drools.*"
-          ]
-        },
-        "classes": {
-          "_comment": "Classes are excluded, not included, so new classes in future are discovered by revapi.",
-          "regex": false,
-          "exclude": [
-            "org.kie.server.remote.rest.drools.DroolsRestApplicationComponentsService"
-          ]
+  "filters": {
+    "revapi": {
+      "java": {
+        "_comment": "Only classes with javax.ws.rs annotations are included since we want to check only REST API.",
+        "filter": {
+          "packages": {
+            "comment": "We don't want to check transitive classes, e.g. from kie-server-api, since we already check them in their own module.",
+            "regex": true,
+            "include": [
+              "org\\.kie\\.server\\.remote\\.rest\\.drools.*"
+            ]
+          },
+          "classes": {
+            "_comment": "Classes are excluded, not included, so new classes in future are discovered by revapi.",
+            "regex": false,
+            "exclude": [
+              "org.kie.server.remote.rest.drools.DroolsRestApplicationComponentsService"
+            ]
+          }
         }
       }
-    },
-    "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
-    "ignore": []
+    }
+  },
+
+  "ignores": {
+    "revapi": {
+      "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
+      "ignore": []
+    }
   }
 }

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm-ui/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm-ui/src/build/revapi-config.json
@@ -1,38 +1,45 @@
 {
-  "revapi": {
-    "java": {
-      "_comment": "Only classes with javax.ws.rs annotations are included since we want to check only REST API.",
-      "filter": {
-        "packages": {
-          "comment": "We don't want to check transitive classes, e.g. from kie-server-api, since we already check them in their own module.",
-          "regex": true,
-          "include": [
-            "org\\.kie\\.server\\.remote\\.rest\\.jbpm\\.ui.*"
-          ]
-        },
-        "_comment": "Classes are excluded, not included, so new classes in future are discovered by revapi.",
-        "classes": {
-          "regex": false,
-          "exclude": [
-            "org.kie.server.remote.rest.jbpm.ui.JbpmUIRestApplicationComponentsService"
-          ]
+  "filters": {
+    "revapi": {
+      "java": {
+        "_comment": "Only classes with javax.ws.rs annotations are included since we want to check only REST API.",
+        "filter": {
+          "packages": {
+            "comment": "We don't want to check transitive classes, e.g. from kie-server-api, since we already check them in their own module.",
+            "regex": true,
+            "include": [
+              "org\\.kie\\.server\\.remote\\.rest\\.jbpm\\.ui.*"
+            ]
+          },
+          "_comment": "Classes are excluded, not included, so new classes in future are discovered by revapi.",
+          "classes": {
+            "regex": false,
+            "exclude": [
+              "org.kie.server.remote.rest.jbpm.ui.JbpmUIRestApplicationComponentsService"
+            ]
+          }
         }
       }
-    },
-    "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
-    "ignore": [
-      {
-        "code": "java.method.numberOfParametersChanged",
-        "old": "method javax.ws.rs.core.Response org.kie.server.remote.rest.jbpm.ui.FormResource::getProcessForm(javax.ws.rs.core.HttpHeaders, java.lang.String, java.lang.String, java.lang.String, boolean)",
-        "new": "method javax.ws.rs.core.Response org.kie.server.remote.rest.jbpm.ui.FormResource::getProcessForm(javax.ws.rs.core.HttpHeaders, java.lang.String, java.lang.String, java.lang.String, boolean, java.lang.String, boolean)",
-        "justification": "Support multiple formats of forms"
-      },
-      {
-        "code": "java.method.numberOfParametersChanged",
-        "old": "method javax.ws.rs.core.Response org.kie.server.remote.rest.jbpm.ui.FormResource::getTaskForm(javax.ws.rs.core.HttpHeaders, java.lang.String, java.lang.Long, java.lang.String, boolean)",
-        "new": "method javax.ws.rs.core.Response org.kie.server.remote.rest.jbpm.ui.FormResource::getTaskForm(javax.ws.rs.core.HttpHeaders, java.lang.String, java.lang.Long, java.lang.String, boolean, java.lang.String, boolean)",
-        "justification": "Support multiple formats of forms"
-      }
-    ]
+    }
+  },
+
+  "ignores": {
+    "revapi": {
+      "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
+      "ignore": [
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method javax.ws.rs.core.Response org.kie.server.remote.rest.jbpm.ui.FormResource::getProcessForm(javax.ws.rs.core.HttpHeaders, java.lang.String, java.lang.String, java.lang.String, boolean)",
+          "new": "method javax.ws.rs.core.Response org.kie.server.remote.rest.jbpm.ui.FormResource::getProcessForm(javax.ws.rs.core.HttpHeaders, java.lang.String, java.lang.String, java.lang.String, boolean, java.lang.String, boolean)",
+          "justification": "Support multiple formats of forms"
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method javax.ws.rs.core.Response org.kie.server.remote.rest.jbpm.ui.FormResource::getTaskForm(javax.ws.rs.core.HttpHeaders, java.lang.String, java.lang.Long, java.lang.String, boolean)",
+          "new": "method javax.ws.rs.core.Response org.kie.server.remote.rest.jbpm.ui.FormResource::getTaskForm(javax.ws.rs.core.HttpHeaders, java.lang.String, java.lang.Long, java.lang.String, boolean, java.lang.String, boolean)",
+          "justification": "Support multiple formats of forms"
+        }
+      ]
+    }
   }
 }

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm/src/build/revapi-config.json
@@ -1,63 +1,70 @@
 {
-  "revapi": {
-    "java": {
-      "_comment": "Only classes with javax.ws.rs annotations are included since we want to check only REST API.",
-      "filter": {
-        "packages": {
-          "comment": "We don't want to check transitive classes, e.g. from kie-server-api, since we already check them in their own module.",
-          "regex": true,
-          "include": [
-            "org\\.kie\\.server\\.remote\\.rest\\.jbpm.*"
-          ],
-          "exclude": [
-            "org\\.kie\\.server\\.remote\\.rest\\.jbpm\\.resources"
-          ]
-        },
-        "classes": {
-          "_comment": "Classes are excluded, not included, so new classes in future are discovered by revapi.",
-          "regex": false,
-          "exclude": [
-            "org.kie.server.remote.rest.jbpm.JbpmRestApplicationComponentsService"
-          ]
+  "filters": {
+    "revapi": {
+      "java": {
+        "_comment": "Only classes with javax.ws.rs annotations are included since we want to check only REST API.",
+        "filter": {
+          "packages": {
+            "comment": "We don't want to check transitive classes, e.g. from kie-server-api, since we already check them in their own module.",
+            "regex": true,
+            "include": [
+              "org\\.kie\\.server\\.remote\\.rest\\.jbpm.*"
+            ],
+            "exclude": [
+              "org\\.kie\\.server\\.remote\\.rest\\.jbpm\\.resources"
+            ]
+          },
+          "classes": {
+            "_comment": "Classes are excluded, not included, so new classes in future are discovered by revapi.",
+            "regex": false,
+            "exclude": [
+              "org.kie.server.remote.rest.jbpm.JbpmRestApplicationComponentsService"
+            ]
+          }
         }
       }
-    },
-    "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
-    "ignore": [
-      {
-        "code": "java.field.visibilityReduced",
-        "old": "field org.kie.server.remote.rest.jbpm.admin.ProcessAdminResource.logger",
-        "new": "field org.kie.server.remote.rest.jbpm.admin.ProcessAdminResource.logger",
-        "oldVisibility": "public",
-        "newVisibility": "private",
-        "justification": "This is logger, which should definitely be hidden from public API"
-      },
-      {
-        "code": "java.method.numberOfParametersChanged",
-        "old": "method javax.ws.rs.core.Response org.kie.server.remote.rest.jbpm.RuntimeDataResource::getTasksAssignedAsPotentialOwner(javax.ws.rs.core.HttpHeaders, java.util.List<java.lang.String>, java.util.List<java.lang.String>, java.lang.String, java.lang.Integer, java.lang.Integer, java.lang.String, boolean)",
-        "new": "method javax.ws.rs.core.Response org.kie.server.remote.rest.jbpm.RuntimeDataResource::getTasksAssignedAsPotentialOwner(javax.ws.rs.core.HttpHeaders, java.util.List<java.lang.String>, java.util.List<java.lang.String>, java.lang.String, java.lang.Integer, java.lang.Integer, java.lang.String, boolean, java.lang.String)",
-        "justification": "Add filter by task name"
-      },
-      {
-       "code": "java.method.numberOfParametersChanged",
-       "old": "method void org.kie.server.remote.rest.jbpm.UserTaskResource::<init>(org.kie.server.services.jbpm.UserTaskServiceBase, org.kie.server.services.api.KieServerRegistry)",
-       "new": "method void org.kie.server.remote.rest.jbpm.UserTaskResource::<init>(org.kie.server.services.jbpm.UserTaskServiceBase, org.kie.server.services.jbpm.RuntimeDataServiceBase, org.kie.server.services.api.KieServerRegistry)",
-       "package": "org.kie.server.remote.rest.jbpm",
-       "classSimpleName": "UserTaskResource",
-       "methodName": "<init>",
-       "elementKind": "constructor",
-       "justification": "Required to be able to use runtime data service from within UserTaskServiceResource"
-       },
-       {
-        "code": "java.method.numberOfParametersChanged",
-        "old": "method void org.kie.server.remote.rest.jbpm.ProcessResource::<init>(org.kie.server.services.jbpm.ProcessServiceBase, org.kie.server.services.jbpm.DefinitionServiceBase, org.kie.server.services.jbpm.RuntimeDataServiceBase, org.kie.server.services.api.KieServerRegistry)",
-        "new": "method void org.kie.server.remote.rest.jbpm.ProcessResource::<init>(org.kie.server.services.jbpm.ProcessServiceBase, org.kie.server.services.jbpm.RuntimeDataServiceBase, org.kie.server.services.api.KieServerRegistry)",
-        "package": "org.kie.server.remote.rest.jbpm",
-        "classSimpleName": "ProcessResource",
-        "methodName": "<init>",
-        "elementKind": "constructor",
-        "justification": "Removed unused parameters. Change in this constructor does not break backward compatibility of REST API"
+    }
+  },
+
+  "ignores": {
+    "revapi": {
+      "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
+      "ignore": [
+        {
+          "code": "java.field.visibilityReduced",
+          "old": "field org.kie.server.remote.rest.jbpm.admin.ProcessAdminResource.logger",
+          "new": "field org.kie.server.remote.rest.jbpm.admin.ProcessAdminResource.logger",
+          "oldVisibility": "public",
+          "newVisibility": "private",
+          "justification": "This is logger, which should definitely be hidden from public API"
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method javax.ws.rs.core.Response org.kie.server.remote.rest.jbpm.RuntimeDataResource::getTasksAssignedAsPotentialOwner(javax.ws.rs.core.HttpHeaders, java.util.List<java.lang.String>, java.util.List<java.lang.String>, java.lang.String, java.lang.Integer, java.lang.Integer, java.lang.String, boolean)",
+          "new": "method javax.ws.rs.core.Response org.kie.server.remote.rest.jbpm.RuntimeDataResource::getTasksAssignedAsPotentialOwner(javax.ws.rs.core.HttpHeaders, java.util.List<java.lang.String>, java.util.List<java.lang.String>, java.lang.String, java.lang.Integer, java.lang.Integer, java.lang.String, boolean, java.lang.String)",
+          "justification": "Add filter by task name"
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method void org.kie.server.remote.rest.jbpm.UserTaskResource::<init>(org.kie.server.services.jbpm.UserTaskServiceBase, org.kie.server.services.api.KieServerRegistry)",
+          "new": "method void org.kie.server.remote.rest.jbpm.UserTaskResource::<init>(org.kie.server.services.jbpm.UserTaskServiceBase, org.kie.server.services.jbpm.RuntimeDataServiceBase, org.kie.server.services.api.KieServerRegistry)",
+          "package": "org.kie.server.remote.rest.jbpm",
+          "classSimpleName": "UserTaskResource",
+          "methodName": "<init>",
+          "elementKind": "constructor",
+          "justification": "Required to be able to use runtime data service from within UserTaskServiceResource"
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method void org.kie.server.remote.rest.jbpm.ProcessResource::<init>(org.kie.server.services.jbpm.ProcessServiceBase, org.kie.server.services.jbpm.DefinitionServiceBase, org.kie.server.services.jbpm.RuntimeDataServiceBase, org.kie.server.services.api.KieServerRegistry)",
+          "new": "method void org.kie.server.remote.rest.jbpm.ProcessResource::<init>(org.kie.server.services.jbpm.ProcessServiceBase, org.kie.server.services.jbpm.RuntimeDataServiceBase, org.kie.server.services.api.KieServerRegistry)",
+          "package": "org.kie.server.remote.rest.jbpm",
+          "classSimpleName": "ProcessResource",
+          "methodName": "<init>",
+          "elementKind": "constructor",
+          "justification": "Removed unused parameters. Change in this constructor does not break backward compatibility of REST API"
         }
-    ]
+      ]
+    }
   }
 }

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-optaplanner/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-optaplanner/src/build/revapi-config.json
@@ -1,28 +1,35 @@
 {
-  "revapi": {
-    "java": {
-      "_comment": "Only classes with javax.ws.rs annotations are included since we want to check only REST API.",
-      "filter": {
-        "packages": {
-          "comment": "We don't want to check transitive classes, e.g. from kie-server-api, since we already check them in their own module.",
-          "regex": true,
-          "include": [
-            "org\\.kie\\.server\\.remote\\.rest\\.optaplanner.*"
-          ],
-          "exclude": [
-            "org\\.kie\\.server\\.remote\\.rest\\.optaplanner\\.resources"
-          ]
-        },
-        "classes": {
-          "_comment": "Classes are excluded, not included, so new classes in future are discovered by revapi.",
-          "regex": false,
-          "exclude": [
-            "org.kie.server.remote.rest.optaplanner.OptaplannerRestApplicationComponentsService"
-          ]
+  "filters": {
+    "revapi": {
+      "java": {
+        "_comment": "Only classes with javax.ws.rs annotations are included since we want to check only REST API.",
+        "filter": {
+          "packages": {
+            "comment": "We don't want to check transitive classes, e.g. from kie-server-api, since we already check them in their own module.",
+            "regex": true,
+            "include": [
+              "org\\.kie\\.server\\.remote\\.rest\\.optaplanner.*"
+            ],
+            "exclude": [
+              "org\\.kie\\.server\\.remote\\.rest\\.optaplanner\\.resources"
+            ]
+          },
+          "classes": {
+            "_comment": "Classes are excluded, not included, so new classes in future are discovered by revapi.",
+            "regex": false,
+            "exclude": [
+              "org.kie.server.remote.rest.optaplanner.OptaplannerRestApplicationComponentsService"
+            ]
+          }
         }
       }
-    },
-    "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
-    "ignore": []
+    }
+  },
+
+  "ignores": {
+    "revapi": {
+      "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
+      "ignore": []
+    }
   }
 }


### PR DESCRIPTION
Hi,

this PR is related to droolsjbpm/droolsjbpm-build-bootstrap#393. Revapi config JSON files were divided into filter and ignores parts.

Marian
