### PR TITLE
[DROOLS-1445] fix the kie-eap-modules smoke test

### DIFF
--- a/kie-eap-integration/kie-eap-tests/pom.xml
+++ b/kie-eap-integration/kie-eap-tests/pom.xml
@@ -11,10 +11,6 @@
   <artifactId>kie-eap-tests</artifactId>
   <name>KIE EAP :: Integration Tests</name>
 
-  <properties>
-    <version.org.wildfly>10.0.0.Final</version.org.wildfly>
-  </properties>
-
   <build>
     <testResources>
       <testResource>

--- a/kie-eap-integration/kie-eap-tests/src/test/resources/arquillian.xml
+++ b/kie-eap-integration/kie-eap-tests/src/test/resources/arquillian.xml
@@ -7,7 +7,7 @@
     <configuration>
       <property name="jbossHome">target/wildfly-${version.org.wildfly}</property>
       <!-- Port offset allows running the tests while a WildFly server is already running -->
-      <property name="javaVmArguments">-Djboss.socket.binding.port-offset=10000 -Xms512m -Xmx1024m -XX:MaxPermSize=512m</property>
+      <property name="javaVmArguments">-Djboss.socket.binding.port-offset=10000 -Xms512m -Xmx1024m</property>
       <property name="managementPort">19990</property>
     </configuration>
   </container>


### PR DESCRIPTION
Since the rule contains "String()", the resulting knowledge
base also contains a KiePackage "java.lang" with the property
reactive info there.

@tarilabs this is the test we talked about, could you please quickly review?