### PR TITLE
Re instantiate pom comment explaining artificial dependency motivation

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/pom.xml
@@ -171,6 +171,9 @@
       <type>war</type>
       <scope>test</scope>
     </dependency>
+
+    <!-- This is an artificial dependency to make sure the kie-server-tests modules are executed one at a time during
+         parallel build (otherwise the tests fail because of conflicting port binding) -->
     <dependency>
       <groupId>org.kie.server</groupId>
       <artifactId>kie-server-integ-tests-jbpm</artifactId>
@@ -182,6 +185,7 @@
         </exclusion>
       </exclusions>
     </dependency>
+    
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>


### PR DESCRIPTION
.. this comment may have been accidentaly removed by commit 22f0dc0 [here](https://github.com/droolsjbpm/droolsjbpm-integration/commit/22f0dc0c8db1848cb79a60568effb58244ade87e#diff-e19734e25078062ec3c61cea48fb1eecL164).