### PR TITLE
kie-server-tests: Specify directory for test remote repo

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/config/TestConfig.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/config/TestConfig.java
@@ -67,6 +67,7 @@ public class TestConfig {
 
     private static final StringTestParameter KJARS_BUILD_SETTINGS_XML = new StringTestParameter("kie.server.testing.kjars.build.settings.xml");
     private static final StringTestParameter KIE_CLIENT_DEPLOYMENT_SETTINGS = new StringTestParameter("kie.server.client.deployment.settings.xml");
+    private static final StringTestParameter REMOTE_REPO_DIR = new StringTestParameter("kie.server.testing.remote.repo.dir");
 
     private static final StringTestParameter CONTAINER_ID = new StringTestParameter("cargo.container.id");
     private static final StringTestParameter CONTAINER_PORT = new StringTestParameter("cargo.servlet.port");
@@ -401,6 +402,20 @@ public class TestConfig {
      */
     public static String getKieClientDeploymentSettings() {
         return TestConfig.KIE_CLIENT_DEPLOYMENT_SETTINGS.getParameterValue();
+    }
+
+    /**
+     * @return True if remote repo directory is provided.
+     */
+    public static boolean isRemoteRepoDirProvided() {
+        return TestConfig.REMOTE_REPO_DIR.isParameterConfigured();
+    }
+
+    /**
+     * @return Location of remote repo directory.
+     */
+    public static String getRemoteRepoDir() {
+        return TestConfig.REMOTE_REPO_DIR.getParameterValue();
     }
 
     // Used for printing all configuration values at the beginning of first test run.

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerDeployer.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerDeployer.java
@@ -67,6 +67,12 @@ public class KieServerDeployer {
             mvnArgs = new ArrayList<String>(Arrays.asList("-B", "-e", "clean", "deploy"));
         }
 
+        // Maven CLI installs project dependencies to default repo if it is not overridden here.
+        // localRepository element from settings.xml brought by kjarsBuildSettingsXml seems to be ignored for project dependencies.
+        if (TestConfig.isRemoteRepoDirProvided()) {
+            System.setProperty("maven.repo.local", TestConfig.getRemoteRepoDir());
+        }
+
         // use custom settings.xml file, if one specified
         String kjarsBuildSettingsXml = TestConfig.getKjarsBuildSettingsXml();
         if (kjarsBuildSettingsXml != null && !kjarsBuildSettingsXml.isEmpty()) {

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -481,6 +481,9 @@
                   <!-- Reuse yoda user for deploying and undeploying Kie server from within the test -->
                   <cargo.remote.username>yoda</cargo.remote.username>
                   <cargo.remote.password>usetheforce123@</cargo.remote.password>
+                  <!-- Remote repo dir is passed to tests as it is needed by Maven CLI to run properly.
+                       Maven CLI needs specific definition of local repository to download all dependencies there. -->
+                  <kie.server.testing.remote.repo.dir>${kie.server.testing.remote.repo.dir}</kie.server.testing.remote.repo.dir>
                 </systemPropertyVariables>
               </configuration>
             </plugin>


### PR DESCRIPTION
Currently Maven CLI downloads dependencies for built test kjars into default repo (i.e. /home/"user"/.m2/repository). That happens even when settings.xml provided for kjar builds contains defined localRepository element - not sure why is it so.

This behaviour cause troubles for example when we want to use mirror server in settings.xml. As default repository can contain artifacts from different Nexus servers it can lead to classloader issues like:

"ERROR org.apache.maven.cli.MavenCli - Failed to execute goal org.kie:kie-maven-plugin:7.0.0-SNAPSHOT:build (default-build) on project stateless-session-kjar: Execution default-build of goal org.kie:kie-maven-plugin:7.0.0-SNAPSHOT:build failed: A required class was missing while executing org.kie:kie-maven-plugin:7.0.0-SNAPSHOT:build: org/drools/compiler/kproject/xml/PomModelGenerator"

@mswiderski @psiroky What do you think about this?