### PR TITLE
JBPM-5750: Cannot disable registration of process event listeners

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/JbpmKieServerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/JbpmKieServerExtension.java
@@ -370,17 +370,17 @@ public class JbpmKieServerExtension implements KieServerExtension {
 
             addAsyncHandler(unit, kieContainer);
 
-            if (config.getConfigItemValue(KieServerConstants.CFG_JBPM_TASK_CLEANUP_LISTENER, "true").equalsIgnoreCase("true")) {
+            if (System.getProperty(KieServerConstants.CFG_JBPM_TASK_CLEANUP_LISTENER, "true").equalsIgnoreCase("true")) {
                 logger.debug("Registering TaskCleanUpProcessEventListener");
                 addTaskCleanUpProcessListener(unit, kieContainer);
             }
 
-            if (config.getConfigItemValue(KieServerConstants.CFG_JBPM_TASK_BAM_LISTENER, "true").equalsIgnoreCase("true")) {
+            if (System.getProperty(KieServerConstants.CFG_JBPM_TASK_BAM_LISTENER, "true").equalsIgnoreCase("true")) {
                 logger.debug("Registering BAMTaskEventListener");
                 addTaskBAMEventListener(unit, kieContainer);
             }
 
-            if (config.getConfigItemValue(KieServerConstants.CFG_JBPM_PROCESS_IDENTITY_LISTENER, "true").equalsIgnoreCase("true")) {
+            if (System.getProperty(KieServerConstants.CFG_JBPM_PROCESS_IDENTITY_LISTENER, "true").equalsIgnoreCase("true")) {
                 logger.debug("Registering IdentityProviderAwareProcessListener");
                 addProcessIdentityProcessListener(unit, kieContainer);
             }


### PR DESCRIPTION
I think the listeners registration should be configurable only globally and so they should be retrieved directly from the system properties. Correct me if I am wrong.